### PR TITLE
Typesafe gui

### DIFF
--- a/mimircore/src/main/scala/mimir/WebAPI.scala
+++ b/mimircore/src/main/scala/mimir/WebAPI.scala
@@ -178,10 +178,10 @@ class WebAPI(dbName: String = "tpch.db", backend: String = "sqlite") {
 
     val rowQuery = 
       mimir.algebra.Select(
-        Comparison(Cmp.Eq, Var("ROWID_MIMIR"), new RowIdPrimitive(row.substring(1, row.length - 1))),
+        Comparison(Cmp.Eq, Var("ROWID_MIMIR"), new RowIdPrimitive(row)),
         raw
       )
-    println("QUERY: "+rowQuery);
+    // println("QUERY: "+rowQuery);
 
     val iterator = db.queryLineage(rowQuery);
 

--- a/mimircore/src/main/scala/mimir/WebAPI.scala
+++ b/mimircore/src/main/scala/mimir/WebAPI.scala
@@ -92,7 +92,7 @@ class WebAPI(dbName: String = "tpch.db", backend: String = "sqlite") {
     val start = System.nanoTime()
     val raw = db.convert(sel)
     val rawT = System.nanoTime()
-    val results = db.query(CTPercolator.propagateRowIDs(raw, true))
+    val results = db.query(raw)
     val resultsT = System.nanoTime()
 
     println("Convert time: "+((rawT-start)/(1000*1000))+"ms")
@@ -129,13 +129,12 @@ class WebAPI(dbName: String = "tpch.db", backend: String = "sqlite") {
   }
 
   def getAllLenses: List[String] = {
-    val res = db.backend.execute(
+    val iter = db.query(
       """
         SELECT *
         FROM MIMIR_LENSES
       """)
 
-    val iter = new ResultSetIterator(res)
     val lensNames = new ListBuffer[String]()
 
     iter.open()
@@ -177,12 +176,14 @@ class WebAPI(dbName: String = "tpch.db", backend: String = "sqlite") {
         }
       }
 
-    val iterator = db.queryLineage(
+    val rowQuery = 
       mimir.algebra.Select(
         Comparison(Cmp.Eq, Var("ROWID_MIMIR"), new RowIdPrimitive(row.substring(1, row.length - 1))),
         raw
       )
-    )
+    println("QUERY: "+rowQuery);
+
+    val iterator = db.queryLineage(rowQuery);
 
     if(!iterator.getNext()){
       throw new SQLException("Invalid Source Data ROWID: '" +row+"'");

--- a/mimircore/src/main/scala/mimir/algebra/Eval.scala
+++ b/mimircore/src/main/scala/mimir/algebra/Eval.scala
@@ -4,6 +4,7 @@ import java.sql._;
 
 import mimir.algebra.Type._
 import mimir.ctables.{VGTerm, CTables}
+import mimir.optimizer.ExpressionOptimizer
 
 object Eval 
 {
@@ -83,10 +84,10 @@ object Eval
             case "CAST" => {
               val strVal = Eval.eval(params(1), bindings).toString.toLowerCase
               try {
-                strVal match {
-                  case "int" => IntPrimitive(Eval.eval(params(0), bindings).asLong)
-                  case "real" => FloatPrimitive(Eval.eval(params(0), bindings).asDouble)
-                  case "varchar" => StringPrimitive(Eval.eval(params(0), bindings).asString)
+                Type.fromString(strVal) match {
+                  case TInt => IntPrimitive(Eval.eval(params(0), bindings).asLong)
+                  case TFloat => FloatPrimitive(Eval.eval(params(0), bindings).asDouble)
+                  case TString => StringPrimitive(Eval.eval(params(0), bindings).asString)
                   case x => throw new SQLException("Unknown cast type: '"+x+"'")
                 }
               } catch {

--- a/mimircore/src/main/scala/mimir/algebra/Expression.scala
+++ b/mimircore/src/main/scala/mimir/algebra/Expression.scala
@@ -4,7 +4,7 @@ import java.sql._
 
 import mimir.ctables.CTables
 
-class TypeException(found: Type.T, expected: Type.T, 
+case class TypeException(found: Type.T, expected: Type.T, 
                     context:String) 
   extends Exception(
     "Type Mismatch ["+context+
@@ -32,17 +32,18 @@ object Type extends Enumeration {
   def toStringPrimitive(t: T) = StringPrimitive(toString(t))
 
   def fromString(t: String) = t.toLowerCase match {
-    case "int"    => Type.TInt
-    case "float"  => Type.TFloat
-    case "decimal"=> Type.TFloat
-    case "real"   => Type.TFloat
-    case "date"   => Type.TDate
-    case "varchar"=> Type.TString
-    case "char"   => Type.TString
-    case "string" => Type.TString
-    case "bool"   => Type.TBool
-    case "rowid"  => Type.TRowId
-    case "type"   => Type.TType
+    case "int"     => Type.TInt
+    case "integer" => Type.TInt
+    case "float"   => Type.TFloat
+    case "decimal" => Type.TFloat
+    case "real"    => Type.TFloat
+    case "date"    => Type.TDate
+    case "varchar" => Type.TString
+    case "char"    => Type.TString
+    case "string"  => Type.TString
+    case "bool"    => Type.TBool
+    case "rowid"   => Type.TRowId
+    case "type"    => Type.TType
     case _ =>  throw new SQLException("Invalid Type '" + t + "'");
   }
 

--- a/mimircore/src/main/scala/mimir/algebra/FunctionRegistry.scala
+++ b/mimircore/src/main/scala/mimir/algebra/FunctionRegistry.scala
@@ -21,22 +21,26 @@ object FunctionRegistry {
 			})
 		registerFunction("__LEFT_UNION_ROWID", _ match { 
 				case TRowId :: List() => TRowId
-				case _ => throw new TypeException(TAny, TRowId, "UNION_ROWID")
+				case TAny :: List() => TRowId
+				case x :: _ => throw new TypeException(x, TRowId, "__LEFT_UNION_ROWID")
+				case _ => throw new TypeException(null, TRowId, "__LEFT_UNION_ROWID")
 			})
 		registerFunction("__RIGHT_UNION_ROWID", _ match { 
 				case TRowId :: List() => TRowId
-				case _ => throw new TypeException(TAny, TRowId, "UNION_ROWID")
+				case TAny :: List() => TRowId
+				case x :: _ => throw new TypeException(x, TRowId, "__RIGHT_UNION_ROWID")
+				case _ => throw new TypeException(null, TRowId, "__RIGHT_UNION_ROWID")
 			})
 		registerFunction(CTables.ROW_PROBABILITY, (_) => TString)
 		registerFunction(CTables.VARIANCE, (_) => TFloat)
 		registerFunction(CTables.CONFIDENCE, (_) => TFloat)
-    registerFunction("__LIST_MIN", { (x: List[Type.T]) => 
-    		Typechecker.assertNumeric(Typechecker.escalate(x)) 
-    	})
-    registerFunction("__LIST_MAX", { (x: List[Type.T]) => 
-    		Typechecker.assertNumeric(Typechecker.escalate(x)) 
-    	})
-    registerFunction("CAST", (_) => TAny)
+	    registerFunction("__LIST_MIN", { (x: List[Type.T]) => 
+	    		Typechecker.assertNumeric(Typechecker.escalate(x)) 
+	    	})
+	    registerFunction("__LIST_MAX", { (x: List[Type.T]) => 
+	    		Typechecker.assertNumeric(Typechecker.escalate(x)) 
+	    	})
+	    registerFunction("CAST", (_) => TAny)
 	}
 
 	def registerFunction(fname: String, typechecker: List[Type.T] => Type.T): Unit =

--- a/mimircore/src/main/scala/mimir/algebra/Typechecker.scala
+++ b/mimircore/src/main/scala/mimir/algebra/Typechecker.scala
@@ -27,7 +27,7 @@ class ExpressionChecker(scope: (String => Type.T) = Map().apply _) {
 				assert(rhs, TBool, "BoolOp");
 				TBool
 			case Comparison((Eq | Neq), lhs, rhs) => 
-				Typechecker.escalate(typeOf(lhs), typeOf(rhs), "Comparison");
+				Typechecker.escalate(typeOf(lhs), typeOf(rhs), "Comparison", e);
 				TBool
 			case Comparison((Gt | Gte | Lt | Lte), lhs, rhs) =>
 				Typechecker.assertNumeric(Typechecker.escalate(typeOf(lhs), typeOf(rhs), "Comparison"));
@@ -122,6 +122,8 @@ object Typechecker {
 
 	def escalate(a: Type.T, b: Type.T): Type.T = 
 		escalate(a, b, "Escalation")
+	def escalate(a: Type.T, b: Type.T, msg: String, e: Expression): Type.T = 
+		escalate(a, b, msg + ":" + e)
 	def escalate(a: Type.T, b: Type.T, msg: String): Type.T = {
 		(a,b) match {
 			case (TAny,_) => b

--- a/mimircore/src/main/scala/mimir/ctables/CTBounds.scala
+++ b/mimircore/src/main/scala/mimir/ctables/CTBounds.scala
@@ -2,6 +2,8 @@ package mimir.ctables;
 
 import mimir.algebra._
 
+case class BoundsUnsupportedException(msg: String, context: Expression) extends Exception("Bounds error ["+msg+"] : \n"+context);
+
 object CTBounds {
   /** 
    * Returns two expressions for computing the lower and upper bounds 
@@ -127,9 +129,11 @@ object CTBounds {
 	      	}
       	// println("FALSE: "+true_if_always + " -> " + Eval.inline(true_if_always))
       	// println("TRUE: "+false_if_impossible + " -> " + Eval.inline(false_if_impossible))
- 	    return (Eval.inline(true_if_always), Eval.inline(false_if_impossible))
+   	    return (Eval.inline(true_if_always), Eval.inline(false_if_impossible))
 
       case IsNullExpression(_) => (new BoolPrimitive(false), new BoolPrimitive(true))
+
+      case _ => throw new BoundsUnsupportedException("Unsupported", expr);
     }
   }
 

--- a/mimircore/src/main/scala/mimir/ctables/CTPartition.scala
+++ b/mimircore/src/main/scala/mimir/ctables/CTPartition.scala
@@ -4,6 +4,7 @@ import java.sql.SQLException
 
 import mimir.algebra._
 import mimir.util._
+import mimir.optimizer.PropagateConditions;
 
 
 object CTPartition {

--- a/mimircore/src/main/scala/mimir/exec/BagUnionResultIterator.scala
+++ b/mimircore/src/main/scala/mimir/exec/BagUnionResultIterator.scala
@@ -35,5 +35,8 @@ class BagUnionResultIterator(lhs: ResultIterator, rhs: ResultIterator) extends R
   override def reason(ind: Int): List[(String, String)] = {
     currIter().reason(ind)
   }
-  def provenanceToken() = currIter().provenanceToken()+(if(inLHS){ ".left" } else { ".right" });
+  def provenanceToken() = new RowIdPrimitive(
+    currIter().provenanceToken().payload.toString
+    +(if(inLHS){ ".left" } else { ".right" })
+  );
 }

--- a/mimircore/src/main/scala/mimir/exec/BagUnionResultIterator.scala
+++ b/mimircore/src/main/scala/mimir/exec/BagUnionResultIterator.scala
@@ -35,4 +35,5 @@ class BagUnionResultIterator(lhs: ResultIterator, rhs: ResultIterator) extends R
   override def reason(ind: Int): List[(String, String)] = {
     currIter().reason(ind)
   }
+  def provenanceToken() = currIter().provenanceToken()+(if(inLHS){ ".left" } else { ".right" });
 }

--- a/mimircore/src/main/scala/mimir/exec/Compiler.scala
+++ b/mimircore/src/main/scala/mimir/exec/Compiler.scala
@@ -107,7 +107,7 @@ class Compiler(db: Database) {
       oper match {
         case Project(cols, src) =>
           val inputIterator = buildIterator(src);
-          println("Compiled ["+inputIterator.schema+"]: \n"+oper)
+          // println("Compiled ["+inputIterator.schema+"]: \n"+oper)
           new ProjectionResultIterator(
             db,
             inputIterator,
@@ -129,7 +129,8 @@ class Compiler(db: Database) {
       val results = db.backend.execute(
         db.convert(operWithProvenance)
       )
-      val schema = operWithProvenance.schema.
+      val schemaList = operWithProvenance.schema
+      val schema = schemaList.
                       map( _._1 ).
                       zipWithIndex.
                       toMap
@@ -139,6 +140,7 @@ class Compiler(db: Database) {
       }
       new ResultSetIterator(
         results, 
+        schemaList.toMap,
         oper.schema.map( _._1 ).map( schema(_) ),
         List(schema(CTPercolator.ROWID_KEY))
       )
@@ -193,57 +195,83 @@ class Compiler(db: Database) {
         Project(
           cols.flatMap {
             case ProjectArg(name, expr) =>
+
+              // This is a gnarly hack that needs to be completely rewritten.  Excising for now
               expr match {
                 case Function("BOUNDS", subexp) => {
-                  if (subexp.length != 1)
-                    throw new SQLException("BOUNDS() expects 1 argument, got " + subexp.length)
-                  val bounds = CTBounds.compile(subexp(0))
                   List(
-                    ProjectArg(name + "_MIN", bounds._1),
-                    ProjectArg(name + "_MAX", bounds._2)
+                    ProjectArg(name + "_MIN", NullPrimitive()),
+                    ProjectArg(name + "_MAX", NullPrimitive())
                   )
+                  // if (subexp.length != 1)
+                  //   throw new SQLException("BOUNDS() expects 1 argument, got " + subexp.length)
+                  // try {
+                  //   val bounds = CTBounds.compile(subexp(0))
+                  //   List(
+                  //     ProjectArg(name + "_MIN", bounds._1),
+                  //     ProjectArg(name + "_MAX", bounds._2)
+                  //   )
+                  // } catch {
+                  //   case BoundsUnsupportedException(_,_) =>
+                  //     List(
+                  //       ProjectArg(name + "_MIN", StringPrimitive("Unknown")),
+                  //       ProjectArg(name + "_MAX", StringPrimitive("Unknown"))
+                  //     )
+                  // }
                 }
 
                 case Function(CTables.CONFIDENCE, subexp) => {
-                  if (subexp.isEmpty)
-                    throw new SQLException(CTables.CONFIDENCE + "() expects at 2 arguments" +
-                      "(expression, percentile), got " + subexp.length)
-                  val percentile = {
-                    if(subexp.length == 1)
-                      FloatPrimitive(50)
-                    else subexp(1)
-                  }
-                  val ex = CTAnalyzer.compileSample(subexp(0), Var(CTables.SEED_EXP))
-                  List(ProjectArg(name + "_CONF", Function(CTables.CONFIDENCE, List(ex, percentile))))
+                  List(
+                    ProjectArg(name + "_CONF", NullPrimitive())
+                  )
+                  // if (subexp.isEmpty)
+                  //   throw new SQLException(CTables.CONFIDENCE + "() expects at 2 arguments" +
+                  //     "(expression, percentile), got " + subexp.length)
+                  // val percentile = {
+                  //   if(subexp.length == 1)
+                  //     FloatPrimitive(50)
+                  //   else subexp(1)
+                  // }
+                  // val ex = CTAnalyzer.compileSample(subexp(0), Var(CTables.SEED_EXP))
+                  // List(ProjectArg(name + "_CONF", Function(CTables.CONFIDENCE, List(ex, percentile))))
                 }
 
                 case Function(CTables.VARIANCE, subexp) => {
-                  if (subexp.length != 1)
-                    throw new SQLException(CTables.VARIANCE + "() expects 1 argument, got " + subexp.length)
-                  val ex = CTAnalyzer.compileSample(subexp(0), Var(CTables.SEED_EXP))
-                  List(ProjectArg(name + "_VAR", Function(CTables.VARIANCE, List(ex))))
+                  List(
+                    ProjectArg(name + "_VAR", NullPrimitive())
+                  )
+                  // if (subexp.length != 1)
+                  //   throw new SQLException(CTables.VARIANCE + "() expects 1 argument, got " + subexp.length)
+                  // val ex = CTAnalyzer.compileSample(subexp(0), Var(CTables.SEED_EXP))
+                  // List(ProjectArg(name + "_VAR", Function(CTables.VARIANCE, List(ex))))
                 }
 
                 case Function("SAMPLE", subexp) => {
-                  if (subexp.isEmpty)
-                    throw new SQLException("SAMPLE() expects at least 1 argument " +
-                      "(expression, seed[optional]), got " + subexp.length)
-                  val ex = {
-                    if(subexp.length == 1) CTAnalyzer.compileSample(subexp(0))
-                    else CTAnalyzer.compileSample(subexp(0), subexp(1))
-                  }
-                  List(ProjectArg(name + "_SAMPLE", ex))
+                  List(
+                    ProjectArg(name + "_SAMPLE", NullPrimitive())
+                  )
+                  // if (subexp.isEmpty)
+                  //   throw new SQLException("SAMPLE() expects at least 1 argument " +
+                  //     "(expression, seed[optional]), got " + subexp.length)
+                  // val ex = {
+                  //   if(subexp.length == 1) CTAnalyzer.compileSample(subexp(0))
+                  //   else CTAnalyzer.compileSample(subexp(0), subexp(1))
+                  // }
+                  // List(ProjectArg(name + "_SAMPLE", ex))
                 }
 
                 case Function(CTables.ROW_PROBABILITY, subexp) => {
-                  val exp = p.get(CTables.conditionColumn)
-                  exp match {
-                    case None => List(ProjectArg(name + "_" + CTables.ROW_PROBABILITY, FloatPrimitive(1)))
-                    case Some(cond) => {
-                      val func = Function(CTables.ROW_PROBABILITY, List(CTAnalyzer.compileSample(cond, Var(CTables.SEED_EXP))))
-                      List(ProjectArg(name + "_" + CTables.ROW_PROBABILITY, func))
-                    }
-                  }
+                  List(
+                    ProjectArg(name + CTables.ROW_PROBABILITY, NullPrimitive())
+                  )
+                  // val exp = p.get(CTables.conditionColumn)
+                  // exp match {
+                  //   case None => List(ProjectArg(name + "_" + CTables.ROW_PROBABILITY, FloatPrimitive(1)))
+                  //   case Some(cond) => {
+                  //     val func = Function(CTables.ROW_PROBABILITY, List(CTAnalyzer.compileSample(cond, Var(CTables.SEED_EXP))))
+                  //     List(ProjectArg(name + "_" + CTables.ROW_PROBABILITY, func))
+                  //   }
+                  // }
                 }
 
                 case _ => List(ProjectArg(name, expr))

--- a/mimircore/src/main/scala/mimir/exec/NDInlineResultIterator.scala
+++ b/mimircore/src/main/scala/mimir/exec/NDInlineResultIterator.scala
@@ -7,7 +7,8 @@ import mimir.algebra._;
 class NDInlineResultIterator(src: ResultIterator, 
                              querySchema: List[(String, Type.T)],
                              colDeterminism: List[Expression], 
-                             rowDeterminism: Expression) 
+                             rowDeterminism: Expression,
+                             provenance: Expression) 
   extends ResultIterator
 {
   val schemaMap = {
@@ -36,4 +37,5 @@ class NDInlineResultIterator(src: ResultIterator,
   override def reason(v: Int): List[(String, String)] = {
     throw new SQLException("Must call reason on a query compiled in classical mode")
   }
+  def provenanceToken() = Eval.eval(provenance).asInstanceOf[RowIdPrimitive];
 }

--- a/mimircore/src/main/scala/mimir/exec/ProjectionResultIterator.scala
+++ b/mimircore/src/main/scala/mimir/exec/ProjectionResultIterator.scala
@@ -144,4 +144,6 @@ class ProjectionResultIterator(
     val evaluated = Eval.inline(expr)
     CTables.getVGTerms(evaluated).map((vgterm) => vgterm.reason()).distinct
   }
+
+  def provenanceToken() = src.provenanceToken();
 }

--- a/mimircore/src/main/scala/mimir/exec/ResultIterator.scala
+++ b/mimircore/src/main/scala/mimir/exec/ResultIterator.scala
@@ -2,29 +2,107 @@ package mimir.exec;
 
 import mimir.algebra._;
 
+/**
+ * An abstract interface for result iterators.  The level of 
+ * complexity is somewhere between java's native iterators and
+ * the overwhelming nonsense that is JDBC.  
+ *
+ * For general use, the following pattern should be used:
+ * 
+ * val iterator = ...
+ * iterator.open()
+ * while(iterator.getNext()){
+ *   // iterator(n) returns the nth (0 = first) column of the current row.
+ *   // iterator.deterministicRow() returns true if the current row is deterministic
+ *   // etc...
+ * }
+ * iterator.close()
+ */
+
 abstract class ResultIterator {
-  def apply(v: Int): PrimitiveValue;
-  def deterministicRow(): Boolean;
-  def deterministicCol(v: Int): Boolean;
-  def missingRows(): Boolean;
+  /**
+   * Prepare the result iterator for use and position the cursor 
+   * **before** the first row to be returned.  In other words,
+   * the cursor will not point at valid data until getNext() is
+   * called at least once.  
+   */
   def open()
+  /**
+   * Advance the cursor; Return false if there are no more rows.
+   */
   def getNext(): Boolean;
+  /**
+   * Release resources allocated with the result iterator.
+   * Must be called once the iterator is no longer needed.
+   */
   def close();
-  def numCols: Int;
+
+  /**
+   * Scala shorthand for operator().  Get the value for column N in the current row
+   * e.g., iterator(0) (or equivalently iterator.apply(0)) returns the first column.
+   */
+  def apply(v: Int): PrimitiveValue;
+  /**
+   * Returns true if the current row is deterministic (i.e., independent of any var terms)
+   */
+  def deterministicRow(): Boolean;
+  /**
+   * Returns true if column N of the current row is deterministic (i.e., independent of any var terms).  N = 0 is the first column
+   */
+  def deterministicCol(v: Int): Boolean;
+
+  /**
+   * Returns the number of missing rows encountered **so far**.  In general, this method should only be called once the entire expression
+   * has been fully evaluated.
+   */
+  def missingRows(): Boolean;
+
+  /**
+   * Return the schema of the given expression
+   */
   def schema: List[(String,Type.T)];
+  /**
+   * Return the number of columns (i.e., iterator.schema().size())
+   */
+  def numCols: Int;
+
+  /**
+   * Apply a transformation to all columns (e.g., stringify)
+   */
   def map[X](fn: (PrimitiveValue) => X) =
     (0 until numCols).map( (i) => fn(this(i)) )
+
+  /**
+   * Return the current row as a list
+   */
   def currentRow(): List[PrimitiveValue] =
     map( (x) => x ).toList
+
+  /**
+   * Shorthand foreach operator
+   */
   def foreachRow(fn: ResultIterator => Unit): Unit = {
     open()
     while(getNext()){ fn(this) }
     close()
   }
+
+  /**
+   * A list of lists containing all rows
+   */
   def allRows(): List[List[PrimitiveValue]] = { 
     var ret = List[List[PrimitiveValue]]()
     foreachRow( (x) => { ret = ret ++ List(currentRow()) } )
     return ret;
   }
+
+  /**
+   * A list of explanations for the indicated column
+   */
   def reason(ind: Int): List[(String, String)] = List()
+
+  /**
+   * A unique identifier for every output that can be unwrapped to generate per-row provenance
+   */
+  def provenanceToken(): RowIdPrimitive
 }

--- a/mimircore/src/main/scala/mimir/exec/ResultSetIterator.scala
+++ b/mimircore/src/main/scala/mimir/exec/ResultSetIterator.scala
@@ -7,62 +7,66 @@ import mimir.sql.JDBCUtils;
 import mimir.algebra._;
 import mimir.algebra.Type._;
 
-class ResultSetIterator(src: ResultSet, visibleColumns: List[Int], provenanceTokenColumns: List[Int]) extends ResultIterator
+class ResultSetIterator(src: ResultSet, visibleSchema: Map[String,Type.T], visibleColumns: List[Int], provenanceTokenColumns: List[Int]) extends ResultIterator
 {
   
   val meta = src.getMetaData();
-  var extract: List[() => PrimitiveValue] = 
-    visibleColumns.map( { case (col) => {
-      // A few columns have to be special cased to hard-coded types
-      // since their actual type varies by back-end
-      val t = 
-        meta.getColumnName(col+1) match {
-          case mimir.ctables.CTPercolator.ROWID_KEY => TRowId
-          case _ => JDBCUtils.convertSqlType(meta.getColumnType(col+1))
-        }
-
-      t match {
-        case TString => 
-          () => { 
-            new StringPrimitive(src.getString(col+1))
+  val schema: List[(String,Type.T)] = 
+    visibleColumns.map( (i) => {
+      val colName = meta.getColumnName(i+1).toUpperCase();
+      (
+        colName,
+        visibleSchema.getOrElse(colName, 
+          colName match {
+            case mimir.ctables.CTPercolator.ROWID_KEY => TRowId
+            case _ => JDBCUtils.convertSqlType(meta.getColumnType(i+1))
           }
-        
-        case TFloat => 
-          () => { 
-            new FloatPrimitive(src.getDouble(col+1))
-          }
-        
-        case TInt => 
-          () => {
-            new IntPrimitive(src.getLong(col+1))
-          }
-        case TRowId =>
-          () => {
-            new RowIdPrimitive(src.getString(col+1))
-          }
-        case TDate =>
-          () => {
-            if(meta.getColumnType(col+1) == java.sql.Types.TIMESTAMP) {
-              val calendar = Calendar.getInstance()
-              try{
-                calendar.setTime(src.getDate(col+1))
-                new DatePrimitive(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DATE))
-              } catch {
-                case e: NullPointerException =>
-                  new NullPrimitive
+        )
+      )
+    }).toList
+  val extract: List[() => PrimitiveValue] = 
+    schema.map(_._2).zipWithIndex.map( {
+      case (t, colIdx) =>
+        val col = visibleColumns(colIdx)
+        t match {
+          case TString => 
+            () => { 
+              new StringPrimitive(src.getString(col+1))
+            }
+          
+          case TFloat => 
+            () => { 
+              new FloatPrimitive(src.getDouble(col+1))
+            }
+          
+          case TInt => 
+            () => {
+              new IntPrimitive(src.getLong(col+1))
+            }
+          case TRowId =>
+            () => {
+              new RowIdPrimitive(src.getString(col+1))
+            }
+          case TDate =>
+            () => {
+              if(meta.getColumnType(col+1) == java.sql.Types.TIMESTAMP) {
+                val calendar = Calendar.getInstance()
+                try{
+                  calendar.setTime(src.getDate(col+1))
+                  new DatePrimitive(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DATE))
+                } catch {
+                  case e: NullPointerException =>
+                    new NullPrimitive
+                }
+              }
+              else {
+                throw new UnsupportedOperationException()
               }
             }
-            else {
-              throw new UnsupportedOperationException()
-            }
-          }
-      }
+
+          case TAny =>
+            () => { NullPrimitive() }
     }}).toList
-  var schema: List[(String,Type.T)] = 
-    visibleColumns.map( (i) => (
-      meta.getColumnName(i+1),
-      JDBCUtils.convertSqlType(meta.getColumnType(i+1))
-    ) ).toList
   var isFirst = true;
   var empty = false;
   
@@ -71,7 +75,7 @@ class ResultSetIterator(src: ResultSet, visibleColumns: List[Int], provenanceTok
     if(src.wasNull()){ return new NullPrimitive(); }
     else { return ret; }
   }
-  def numCols: Int = extract.length
+  def numCols: Int = schema.length
   
   def open() = {
     if(!src.isBeforeFirst) empty = true

--- a/mimircore/src/main/scala/mimir/lenses/MissingValueLens.scala
+++ b/mimircore/src/main/scala/mimir/lenses/MissingValueLens.scala
@@ -173,7 +173,7 @@ case class MissingValueAnalysis(model: MissingValueModel, args: List[Expression]
 }
 
 class MissingValueModel(lens: MissingValueLens, name: String)
-  extends SingleVarModel(Type.TInt) {
+  extends SingleVarModel(Type.TAny) {
   var learner: Classifier =
     Analysis.getLearner("moa.classifiers.bayes.NaiveBayes");
   var data: Instances = null;

--- a/mimircore/src/main/scala/mimir/optimizer/ExpressionOptimizer.scala
+++ b/mimircore/src/main/scala/mimir/optimizer/ExpressionOptimizer.scala
@@ -1,6 +1,7 @@
-package mimir.algebra;
+package mimir.optimizer;
 
 import mimir.ctables._;
+import mimir.algebra._;
 
 abstract class ExpressionOptimizerRule {
 	def apply(e: Expression): Expression
@@ -26,8 +27,15 @@ object ExpressionOptimizer {
 		PropagateConditions
 	)
 
-	def optimize(e:Expression, opts: List[ExpressionOptimizerRule]): Expression = 
-		opts.foldLeft(e)( (currE, f) => f(currE) )
+	def optimize(e:Expression, opts: List[ExpressionOptimizerRule]): Expression = {
+		try {
+			opts.foldLeft(e)( (currE, f) => f(currE) )
+		} catch { 
+			case TypeException(t1,t2,msg) => 
+				throw TypeException(t1, t2, msg+" in "+e);
+		}
+
+	}
 
 	def optimize(e: Expression): Expression =
 		optimize(e, standardOptimizatins)

--- a/mimircore/src/main/scala/mimir/optimizer/FlattenBooleanConditionals.scala
+++ b/mimircore/src/main/scala/mimir/optimizer/FlattenBooleanConditionals.scala
@@ -1,4 +1,6 @@
-package mimir.algebra;
+package mimir.optimizer;
+
+import mimir.algebra._;
 
 object FlattenBooleanConditionals extends TopDownExpressionOptimizerRule {
 

--- a/mimircore/src/main/scala/mimir/optimizer/PropagateConditions.scala
+++ b/mimircore/src/main/scala/mimir/optimizer/PropagateConditions.scala
@@ -1,6 +1,7 @@
-package mimir.algebra;
+package mimir.optimizer;
 
 import mimir.ctables._;
+import mimir.algebra._;
 
 object PropagateConditions extends ExpressionOptimizerRule {
 

--- a/mimircore/src/main/scala/mimir/optimizer/PullUpBranches.scala
+++ b/mimircore/src/main/scala/mimir/optimizer/PullUpBranches.scala
@@ -1,6 +1,7 @@
-package mimir.algebra;
+package mimir.optimizer;
 
 import mimir.ctables._;
+import mimir.algebra._;
 
 object PullUpBranches extends TopDownExpressionOptimizerRule {
 

--- a/mimircore/src/main/scala/mimir/sql/JDBCBackend.scala
+++ b/mimircore/src/main/scala/mimir/sql/JDBCBackend.scala
@@ -82,27 +82,37 @@ class JDBCBackend(backend: String, filename: String) extends Backend
   def execute(sel: String): ResultSet = 
   {
     //println(sel)
-    if(conn == null) {
-      throw new SQLException("Trying to use unopened connection!")
+    try {
+      if(conn == null) {
+        throw new SQLException("Trying to use unopened connection!")
+      }
+      val stmt = conn.createStatement()
+      val ret = stmt.executeQuery(sel)
+      stmt.closeOnCompletion()
+      ret
+    } catch { 
+      case e: SQLException => println(e.toString+"during\n"+sel)
+        throw new SQLException("Error", e)
     }
-    val stmt = conn.createStatement()
-    val ret = stmt.executeQuery(sel)
-    stmt.closeOnCompletion()
-    ret
   }
   def execute(sel: String, args: List[String]): ResultSet = 
   {
     //println(""+sel+" <- "+args)
-    if(conn == null) {
-      throw new SQLException("Trying to use unopened connection!")
+    try {
+      if(conn == null) {
+        throw new SQLException("Trying to use unopened connection!")
+      }
+      val stmt = conn.prepareStatement(sel)
+      var i: Int = 0
+      args.map( (a) => {
+        i += 1
+        stmt.setString(i, a)
+      })
+      stmt.executeQuery()
+    } catch { 
+      case e: SQLException => println(e.toString+"during\n"+sel+" <- "+args)
+        throw new SQLException("Error", e)
     }
-    val stmt = conn.prepareStatement(sel)
-    var i: Int = 0
-    args.map( (a) => {
-      i += 1
-      stmt.setString(i, a)
-    })
-    stmt.executeQuery()
   }
   
   def update(upd: String): Unit =

--- a/mimircore/src/main/scala/mimir/sql/SqlToRA.scala
+++ b/mimircore/src/main/scala/mimir/sql/SqlToRA.scala
@@ -326,7 +326,11 @@ class SqlToRA(db: Database)
             map( (o : Any) => convert(o.asInstanceOf[net.sf.jsqlparser.expression.Expression], bindings) ).
             toList
         }
-      return mimir.algebra.Function(name, parameters)
+      name match {
+        case "ROWID" => CTPercolator.ROWID_KEY
+        case _ => return mimir.algebra.Function(name, parameters)
+      }
+      
       // unhandled("Expression[Function:"+name+"]")
     }
     if(e.isInstanceOf[net.sf.jsqlparser.expression.CaseExpression]){

--- a/mimircore/src/test/scala/mimir/ctables/CTPercolatorSpec.scala
+++ b/mimircore/src/test/scala/mimir/ctables/CTPercolatorSpec.scala
@@ -393,26 +393,6 @@ object CTPercolatorSpec extends Specification {
     }
   }
 
-  "The Analysis Compiler" should {
-
-    "Compile bounds analyses correctly for deterministic queries" in {
-      // Remember, test_0 is a uniform distribution
-      analyze("""
-        PROJECT[A <= BOUNDS(R_A)](R)
-      """) must be equalTo oper("""
-        PROJECT[A_MIN <= R_A, A_MAX <= R_A](R)
-      """)
-    }
-    "Compile bounds analyses correctly for non-deterministic queries" in {
-      // Remember, test_0 is a uniform distribution
-      analyze("""
-        PROJECT[A <= BOUNDS({{ test_0[R_A, R_B] }})](R)
-      """) must be equalTo oper("""
-        PROJECT[A_MIN <= R_A, A_MAX <= R_B](R)
-      """)
-    }
-  }
-
   "The Optimizer Should" should {
     "Inline functions correctly" in {
       InlineProjections.optimize(oper("""

--- a/mimircore/src/test/scala/mimir/demo/SimpleDemoScript.scala
+++ b/mimircore/src/test/scala/mimir/demo/SimpleDemoScript.scala
@@ -29,8 +29,13 @@ object SimpleDemoScript extends Specification with FileMatchers {
 	def stmt(s: String) = {
 		new MimirJSqlParser(new StringReader(s)).Statement()
 	}
-	def query(s: String) = 
-		db.query(db.convert(stmt(s).asInstanceOf[net.sf.jsqlparser.statement.select.Select]))
+	def query(s: String) = {
+		val query = db.convert(
+			stmt(s).asInstanceOf[net.sf.jsqlparser.statement.select.Select]
+		)
+		db.check(query);
+		db.query(query)
+	}
 	def lens(s: String) =
 		db.createLens(stmt(s).asInstanceOf[mimir.sql.CreateLens])
 	def update(s: Statement) = 

--- a/mimircore/src/test/scala/mimir/optimizer/ExpressionOptimizerSpec.scala
+++ b/mimircore/src/test/scala/mimir/optimizer/ExpressionOptimizerSpec.scala
@@ -1,4 +1,4 @@
-package mimir.algebra;
+package mimir.optimizer;
 
 import java.io.{StringReader,FileReader}
 

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -158,7 +158,7 @@ $( document ).ready(function() {
 
                 var data_params_query = 'queryjson?query=SELECT BOUNDS('+col
                                         +'), VAR('+col+'), CONFIDENCE('+col+') FROM ('+query
-                                        +') AS TEMP WHERE ROWID = '+row+';&db='+db;
+                                        +') AS TEMP WHERE ROWID() = '+row+';&db='+db;
 
                 var vgterms_query = 'vgterms?query='+query+';&row='+row+'&ind='+ col_index
                                         +'&db='+db;
@@ -255,7 +255,7 @@ $( document ).ready(function() {
                 var fault = false;
                 var errormessage = "";
 
-                var prob_query = 'queryjson?query=SELECT PROB() FROM ('+query+') AS TEMP WHERE ROWID = '+row+';&db='+db;
+                var prob_query = 'queryjson?query=SELECT PROB() FROM ('+query+') AS TEMP WHERE ROWID() = '+row+';&db='+db;
                 var vgterms_query = 'vgterms?query='+query+';&row='+row+'&ind='+-1+'&db='+db;
 
                 if (content == null) {

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -158,7 +158,7 @@ $( document ).ready(function() {
 
                 var data_params_query = 'queryjson?query=SELECT BOUNDS('+col
                                         +'), VAR('+col+'), CONFIDENCE('+col+') FROM ('+query
-                                        +') AS TEMP WHERE ROWID() = '+row+';&db='+db;
+                                        +') AS TEMP WHERE ROWID() = ROWID(\''+row+'\');&db='+db;
 
                 var vgterms_query = 'vgterms?query='+query+';&row='+row+'&ind='+ col_index
                                         +'&db='+db;
@@ -255,7 +255,7 @@ $( document ).ready(function() {
                 var fault = false;
                 var errormessage = "";
 
-                var prob_query = 'queryjson?query=SELECT PROB() FROM ('+query+') AS TEMP WHERE ROWID() = '+row+';&db='+db;
+                var prob_query = 'queryjson?query=SELECT PROB() FROM ('+query+') AS TEMP WHERE ROWID() = ROWID(\''+row+'\');&db='+db;
                 var vgterms_query = 'vgterms?query='+query+';&row='+row+'&ind='+-1+'&db='+db;
 
                 if (content == null) {


### PR DESCRIPTION
Some major bugfixes throughout the codebase dealing with several corner cases in how the UI interacts with the backend database.  The two key changes that broke the demo were the recent updates mandating type-safety in queries, and changes in the evaluation pipeline --- The GUI (and several of its indirect dependencies) made quite a few significant assumptions about both, and when they changed in the VLDB push everything broke.  

These changes fix most of the demo steps.

Explanations are still broken in this version, but they're *less* broken than before (i.e., getVarTerms works, and opening an explain window no longer triggers an error).  Transitioning to the inline/hybrid evaluation strategy basically broke the Compiler's ability to safely rewrite BOUNDS(), CONFIDENCE(), etc... These functions are now deprecated and are replaced by NULL.  Rather than patch over the issue, we should transition to explicitly using explanation objects.