### PR TITLE
Add "text" as a column type (for SQLite)

### DIFF
--- a/src/main/scala/mimir/algebra/Expression.scala
+++ b/src/main/scala/mimir/algebra/Expression.scala
@@ -62,6 +62,7 @@ object Type extends Enumeration {
     case "varchar" => Type.TString
     case "char"    => Type.TString
     case "string"  => Type.TString
+    case "text"    => Type.TString
     case "bool"    => Type.TBool
     case "rowid"   => Type.TRowId
     case "type"    => Type.TType


### PR DESCRIPTION
When I tried to run mimir-ui to use the most recent commit of mimir, mimir-ui crashed because of (at least) one column from sqlite db tables in mimir-ui is defined as "text" but here no matching exists for "text" type. This PR adds a "text" type to TString conversion. 