### PR TITLE
Repair key

### DIFF
--- a/src/main/scala/mimir/Database.scala
+++ b/src/main/scala/mimir/Database.scala
@@ -318,7 +318,7 @@ case class Database(backend: Backend)
         val t = lens.getType().toUpperCase()
         val name = lens.getName()
         val query = sql.convert(lens.getSelectBody())
-        val args = lens.getArgs().map(sql.convert(_)).toList
+        val args = lens.getArgs().map(sql.convert(_, x => x)).toList
 
         lenses.createLens(t, name, query, args)
       }

--- a/src/main/scala/mimir/algebra/AggregateRegistry.scala
+++ b/src/main/scala/mimir/algebra/AggregateRegistry.scala
@@ -21,6 +21,7 @@ object AggregateRegistry
     register("GROUP_AND", List(TBool()), TBool())
     register("GROUP_OR", List(TBool()), TBool())
     register("JSON_GROUP_ARRAY", List(TString()), TString())
+    register("FIRST", (t:Seq[Type]) => t.head)
   }
 
   def register(

--- a/src/main/scala/mimir/algebra/Typechecker.scala
+++ b/src/main/scala/mimir/algebra/Typechecker.scala
@@ -132,7 +132,7 @@ object Typechecker {
 				)
 
 				/* Send schema to parent operator */
-				val sch = groupBySchema ++ aggSchema ++ srcSchema
+				val sch = groupBySchema ++ aggSchema
 				//println(sch)
 				sch
 

--- a/src/main/scala/mimir/lenses/KeyRepairLens.scala
+++ b/src/main/scala/mimir/lenses/KeyRepairLens.scala
@@ -1,0 +1,72 @@
+package mimir.lenses;
+
+import java.sql._
+
+import mimir.Database
+import mimir.models._
+import mimir.algebra._
+import mimir.ctables._
+
+object KeyRepairLens {
+  def create(
+    db: Database, 
+    name: String, 
+    query: Operator, 
+    args:Seq[Expression]
+  ): (Operator, Seq[Model]) =
+  {
+
+    val schema = query.schema
+    val schemaMap = schema.toMap
+    val keys: Seq[String] = args.map {
+      case Var(col) => {
+        if(schemaMap contains col){ col }
+        else {
+          throw new SQLException(s"Invalid column: $col in KeyRepairLens $name")
+        }
+      }
+      case somethingElse => throw new SQLException(s"Invalid argument ($somethingElse) for KeyRepairLens $name")
+    }
+    val values: Seq[(String, Model)] = 
+      schema.map(_._1).filterNot( keys contains _ ).
+      map { col => 
+        val model =
+          new KeyRepairModel(
+            s"$name:$col", 
+            name, 
+            query, 
+            keys.map { k => (k, schemaMap(k)) }, 
+            col
+          )
+        model.reconnectToDatabase(db)
+        ( col, model )
+      }
+
+    (
+      Project(
+        keys.map { col => ProjectArg(col, Var(col))} ++
+        values.map { case (col, model) => 
+          ProjectArg(col, 
+            Conditional(
+              Comparison(Cmp.Lte, Var(s"MIMIR_KR_COUNT_$col"), IntPrimitive(1)),
+              Var(col),
+              VGTerm(model, 0, keys.map(Var(_)))
+            )
+          )
+        },
+        Aggregate(
+          keys.map(Var(_)),
+          values.flatMap { case (col, _) => 
+            List(
+              AggFunction("FIRST", false, List(Var(col)), col),
+              AggFunction("COUNT", true, List(Var(col)), s"MIMIR_KR_COUNT_$col")
+            )
+          },
+          query
+        )
+      ),
+      values.map(_._2)
+    )
+
+  }
+}

--- a/src/main/scala/mimir/lenses/LensManager.scala
+++ b/src/main/scala/mimir/lenses/LensManager.scala
@@ -15,7 +15,8 @@ class LensManager(db: Database) {
                               (Operator,TraversableOnce[Model]))](
     "MISSING_VALUE"     -> MissingValueLens.create _,
     "SCHEMA_MATCHING"   -> SchemaMatchingLens.create _,
-    "TYPE_INFERENCE"    -> TypeInferenceLens.create _
+    "TYPE_INFERENCE"    -> TypeInferenceLens.create _,
+    "KEY_REPAIR"        -> KeyRepairLens.create _
   )
 
   def init(): Unit =

--- a/src/main/scala/mimir/models/KeyRepairModel.scala
+++ b/src/main/scala/mimir/models/KeyRepairModel.scala
@@ -1,0 +1,69 @@
+package mimir.models;
+
+import scala.util.Random
+
+import mimir.algebra._
+import mimir.util._
+
+/**
+ * A model representing a key-repair choice.
+ * 
+ * The index is ignored.
+ * The one argument is a value for the key.  
+ * The return value is an integer identifying the ordinal position of the selected value, starting with 0.
+ */
+@SerialVersionUID(1000L)
+class KeyRepairModel(name: String, context: String, source: Operator, keys: Seq[(String, Type)], target: String) 
+  extends Model(name)
+  with FiniteDiscreteDomain 
+  with NeedsDatabase 
+{
+  val choices = scala.collection.mutable.Map[List[PrimitiveValue], PrimitiveValue]();
+
+  def varType(idx: Int, args: Seq[Type]): Type = TInt()
+  def argTypes(idx: Int) = keys.map(_._2)
+
+  def bestGuess(idx: Int, args: Seq[PrimitiveValue]): PrimitiveValue =
+    choices.get(args.toList) match {
+      case Some(choice) => choice
+      case None => getDomain(idx, args).sortBy(_._1.toString).head._1
+    }
+
+  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue]): PrimitiveValue = 
+    RandUtils.pickFromWeightedList(randomness, getDomain(idx, args))
+
+  def reason(idx: Int, args: Seq[PrimitiveValue]): String =
+  {
+    choices.get(args.toList) match {
+      case None => {
+        val possibilities = getDomain(idx, args)
+        s"In $context, there were ${possibilities.length} options for $target on the row for <${args.map(_.toString).mkString(", ")}>, and I arbitrarilly picked ${possibilities.sortBy(_.toString).head}"
+      }
+      case Some(choice) => 
+        s"In $context, you told me to use ${choice.toString} for $target on the row for <${args.map(_.toString).mkString(", ")}>"
+    }
+  }
+
+  def feedback(idx: Int, args: Seq[PrimitiveValue], v: PrimitiveValue): Unit =
+    choices(args.toList) = v
+  def isAcknowledged(idx: Int, args: Seq[PrimitiveValue]): Boolean =
+    choices contains args.toList
+
+
+  final def getDomain(idx: Int, args: Seq[PrimitiveValue]): Seq[(PrimitiveValue,Double)] =
+  {
+    db.query(
+      OperatorUtils.projectColumns(List(target), 
+        Select(
+          ExpressionUtils.makeAnd(
+            keys.map(_._1).zip(args).map { 
+              case (k,v) => Comparison(Cmp.Eq, Var(k), v)
+            }
+          ),
+          source
+        )
+      )
+    ).mapRows( _(0) ).map( (_, 1.0) ).toSeq
+  }
+
+}

--- a/src/main/scala/mimir/models/ModelManager.scala
+++ b/src/main/scala/mimir/models/ModelManager.scala
@@ -264,3 +264,8 @@ class ModelManager(db:Database)
 trait NeedsReconnectToDatabase {
   def reconnectToDatabase(db: Database)
 }
+trait NeedsDatabase extends NeedsReconnectToDatabase 
+{
+  @transient var db:Database = null
+  def reconnectToDatabase(db: Database) = { this.db = db }
+}

--- a/src/main/scala/mimir/sql/sqlite/SQLiteCompat.scala
+++ b/src/main/scala/mimir/sql/sqlite/SQLiteCompat.scala
@@ -17,6 +17,7 @@ object SQLiteCompat {
     org.sqlite.Function.create(conn,"OTHERTEST", OtherTest)
     org.sqlite.Function.create(conn,"AGGTEST", AggTest)
     org.sqlite.Function.create(conn, "BOOLAND", BoolAnd)
+    org.sqlite.Function.create(conn, "FIRST", First)
   }
   
   def getTableSchema(conn:java.sql.Connection, table: String): Option[List[(String, Type)]] =
@@ -144,6 +145,17 @@ object OtherTest extends org.sqlite.Function {
     } catch {
       case _: java.sql.SQLDataException => throw new java.sql.SQLDataException();
     }
+  }
+}
+
+object First extends org.sqlite.Function.Aggregate {
+  var firstVal: String = null;
+  @Override
+  def xStep(): Unit = {
+    if(firstVal == null){ firstVal = value_text(0); }
+  }
+  def xFinal(): Unit = {
+    if(firstVal == null){ result(); } else { result(firstVal); }
   }
 }
 

--- a/src/test/scala/mimir/lenses/RepairKeySpec.scala
+++ b/src/test/scala/mimir/lenses/RepairKeySpec.scala
@@ -50,8 +50,14 @@ object KeyRepairSpec
       result(1)._3 must be equalTo true
       // The input is deterministic, so the row itself is deterministic
       result(1)._6 must be equalTo true
-      // There are a number of possibilities for <A:1>[B]
+      // There are a number of possibilities for <A:1> on both columns B and C
       result(1)._4 must be equalTo false
+      result(1)._5 must be equalTo false
+
+      // The chosen values for <A:1> in columns B and C are arbitrary, but selected
+      // from a finite set of possibilities based on what's in R.
+      result(1)._1 must be oneOf(2, 3, 4)
+      result(1)._2 must be oneOf(1, 2, 3)
 
       // There is only one populated value for <A:2>[B], the other is null
       result(2)._1 must be equalTo 2

--- a/src/test/scala/mimir/lenses/RepairKeySpec.scala
+++ b/src/test/scala/mimir/lenses/RepairKeySpec.scala
@@ -1,0 +1,68 @@
+package mimir.lenses
+
+import java.io._
+import org.specs2.specification._
+
+import mimir.algebra._
+import mimir.util._
+import mimir.ctables.{VGTerm}
+import mimir.optimizer.{ResolveViews,InlineVGTerms,InlineProjections}
+import mimir.test._
+import mimir.models._
+
+object KeyRepairSpec 
+  extends SQLTestSpecification("KeyRepair") 
+  with BeforeAll 
+{
+
+  def beforeAll = 
+  {
+    update("CREATE TABLE R(A int, B int, C int)")
+    loadCSV("R", new File("test/r_test/r.csv"))
+  }
+
+  "The Key Repair Lens" should {
+
+    "Make Sane Choices" >> {
+      update("""
+        CREATE LENS R_UNIQUE_A 
+          AS SELECT * FROM R
+        WITH KEY_REPAIR(A)
+      """);
+
+      val result = query("""
+        SELECT A, B, C FROM R_UNIQUE_A
+      """).mapRows { row => 
+        row(0).asLong.toInt -> (
+          row(1).asLong.toInt, 
+          row(2).asLong.toInt, 
+          row.deterministicCol(0),
+          row.deterministicCol(1),
+          row.deterministicCol(2),
+          row.deterministicRow()
+        )
+      }.toMap[Int, (Int,Int, Boolean, Boolean, Boolean, Boolean)]
+
+      result.keys must contain(eachOf(1, 2, 4))
+      result must have size(3)
+
+      // The input is deterministic, so the key column "A" should also be deterministic
+      result(1)._3 must be equalTo true
+      // The input is deterministic, so the row itself is deterministic
+      result(1)._6 must be equalTo true
+      // There are a number of possibilities for <A:1>[B]
+      result(1)._4 must be equalTo false
+
+      // There is only one populated value for <A:2>[B], the other is null
+      result(2)._1 must be equalTo 2
+      result(2)._4 must be equalTo true
+
+      // There are two populated values for <A:2>[C], but they're both identical
+      result(2)._2 must be equalTo 1
+      result(2)._5 must be equalTo true
+    }
+
+  }
+
+}
+


### PR DESCRIPTION
Re-added a new lens modeled after the MayBMS RepairKey operator.  This lens is similar to the classical DISTINCT operator, but allows you to force a DISTINCT on a subset of the table's columns (essentially creating a new key) rather than on full set of columns.

To see the point, let's look at a few examples:

* If the source data has no duplicates at all, the Key Repair Lens is a no-op.
* If the source data has duplicates, but the entire row is duplicated, the Key Repair Lens is identical to a SELECT DISTINCT *
* Otherwise, the Key Repair Lens behaves sort of like a group-by aggregate, producing exactly one row for each distinct value of the indicated key column(s).  Values for the remaining columns are "collapsed": If there is only one distinct possibility, it is used.  Otherwise the cell becomes probabilistic.

Take the following data as an example.
```
A,B,C
1,2,3
1,3,1
2, ,1
1,2,
1,4,2
2,2,1
4,2,4
```
Let's say we create a lens with `KEY_REPAIR(A)`.  Although `A` is a key in the input, it is a key in the output.
```
A,B,C
1,?,?
2,2,1
4,2,4
```
* There is only one row where A=4, so this row is preserved intact
* There are two rows where A=2, but...
    * In both rows, C=1 (i.e., There is a functional dependency between A and C), so we have one distinct value for C.
    * In one of the two rows, B is null, so again we only have one distinct non-null value for B.
* There's a mess of rows where A = 1, so B and C are chosen essentially at random from among the possibilities: B is one of 2, 3, 4; and C is one of 1, 2, 3