### PR TITLE
List causes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,16 @@ lazy val parser = taskKey[Unit]("Builds the SQL Parser")
 
 parser := {
   val logger = streams.value.log
-  Process("rm -f src/main/java/mimir/parser/*.java") ! logger match {
+  Process(List(
+    "rm", "-f",
+    "src/main/java/mimir/parser/MimirJSqlParser.java",
+    "src/main/java/mimir/parser/MimirJSqlParserConstants.java",
+    "src/main/java/mimir/parser/MimirJSqlParserTokenManager.java",
+    "src/main/java/mimir/parser/ParseException.java",
+    "src/main/java/mimir/parser/SimpleCharStream.java",
+    "src/main/java/mimir/parser/Token.java",
+    "src/main/java/mimir/parser/TokenMgrError.java"
+  )) ! logger match {
     case 0 => // Success
     case n => sys.error(s"Could not clean up after old SQL Parser: $n")
   }

--- a/src/main/java/mimir/parser/JSqlParserCC.jj
+++ b/src/main/java/mimir/parser/JSqlParserCC.jj
@@ -175,6 +175,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_IS:"IS">
 |   <K_IN:"IN">
 |   <K_OR:"OR">
+|   <K_OF:"OF">
 |   <K_ON:"ON">
 |   <K_ALL: "ALL">
 |   <K_AND: "AND">
@@ -378,23 +379,24 @@ Explain Explain():
 
 Analyze Analyze():
 	{
-		Analyze analyze=new Analyze();
 		SelectBody selectBody = null;
 		String col = null;
+    PrimitiveValue rowid = null;
 	}
 {
-	<K_ANALYZE> col = RelObjectName() <K_IN> selectBody = SelectBody()
+	<K_ANALYZE> 
+  [ 
+    [
+      col = RelObjectName() 
+      <K_OF>
+    ] 
+    rowid = Literal()
+    <K_IN>
+  ]
+  selectBody = SelectBody()
 	{ 
-		analyze.setSelectBody(selectBody);
-		if(col.toUpperCase().equals("COND")){
-		  analyze.setColumn("__MIMIR_CONDITION");
-		} else {
-  		analyze.setColumn(col);
-  	}
-	}
-	{
-  		return analyze;
-	}
+    return new Analyze(selectBody, rowid, col);
+  }
 }
 
 CreateLens CreateLens():

--- a/src/main/java/mimir/parser/MimirJSqlParser.java
+++ b/src/main/java/mimir/parser/MimirJSqlParser.java
@@ -132,11 +132,11 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     case K_REPLACE:
     case K_TRUNCATE:
     case K_FEEDBACK:
-    case 91:
+    case 92:
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
       case K_WITH:
       case K_SELECT:
-      case 91:
+      case 92:
         stm = Select();
         break;
       case K_CREATE:
@@ -181,8 +181,8 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         throw new ParseException();
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 89:
-        jj_consume_token(89);
+      case 90:
+        jj_consume_token(90);
         break;
       case 0:
         jj_consume_token(0);
@@ -221,8 +221,8 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     case S_INTEGER:
     case S_IDENTIFIER:
     case S_CHAR_LITERAL:
-    case 91:
-    case 94:
+    case 92:
+    case 95:
       stm = CreateTable();
       break;
     default:
@@ -246,38 +246,38 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     label_1:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 90:
+      case 91:
         ;
         break;
       default:
         jj_la1[4] = jj_gen;
         break label_1;
       }
-      jj_consume_token(90);
+      jj_consume_token(91);
       tempStr = RelObjectName();
                                       model += ":" + tempStr;
     }
     idx = jj_consume_token(S_INTEGER);
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-    case 91:
-      jj_consume_token(91);
+    case 92:
+      jj_consume_token(92);
       temp = Literal();
                          args.add(temp);
       label_2:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 92:
+        case 93:
           ;
           break;
         default:
           jj_la1[5] = jj_gen;
           break label_2;
         }
-        jj_consume_token(92);
+        jj_consume_token(93);
         temp = Literal();
                               args.add(temp);
       }
-      jj_consume_token(93);
+      jj_consume_token(94);
       break;
     default:
       jj_la1[6] = jj_gen;
@@ -301,22 +301,22 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     table = TableWithAlias();
     jj_consume_token(K_SET);
     tableColumn = Column();
-    jj_consume_token(94);
+    jj_consume_token(95);
     value = SimpleExpression();
                                                                 columns.add(tableColumn); expList.add(value);
     label_3:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 92:
+      case 93:
         ;
         break;
       default:
         jj_la1[7] = jj_gen;
         break label_3;
       }
-      jj_consume_token(92);
+      jj_consume_token(93);
       tableColumn = Column();
-      jj_consume_token(94);
+      jj_consume_token(95);
       value = SimpleExpression();
                                                                             columns.add(tableColumn); expList.add(value);
     }
@@ -348,20 +348,40 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   final public Analyze Analyze() throws ParseException {
-                Analyze analyze=new Analyze();
                 SelectBody selectBody = null;
                 String col = null;
+    PrimitiveValue rowid = null;
     jj_consume_token(K_ANALYZE);
-    col = RelObjectName();
-    jj_consume_token(K_IN);
+    switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+    case S_DOUBLE:
+    case S_INTEGER:
+    case S_IDENTIFIER:
+    case S_CHAR_LITERAL:
+    case S_QUOTED_IDENTIFIER:
+    case 109:
+    case 110:
+    case 113:
+    case 115:
+    case 116:
+      switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+      case S_IDENTIFIER:
+      case S_QUOTED_IDENTIFIER:
+        col = RelObjectName();
+        jj_consume_token(K_OF);
+        break;
+      default:
+        jj_la1[9] = jj_gen;
+        ;
+      }
+      rowid = Literal();
+      jj_consume_token(K_IN);
+      break;
+    default:
+      jj_la1[10] = jj_gen;
+      ;
+    }
     selectBody = SelectBody();
-                analyze.setSelectBody(selectBody);
-                if(col.toUpperCase().equals("COND")){
-                  analyze.setColumn("__MIMIR_CONDITION");
-                } else {
-                analyze.setColumn(col);
-        }
-                {if (true) return analyze;}
+    {if (true) return new Analyze(selectBody, rowid, col);}
     throw new Error("Missing return statement in function");
   }
 
@@ -377,7 +397,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     body = SelectBody();
     jj_consume_token(K_WITH);
     lensType = RelObjectName();
-    jj_consume_token(91);
+    jj_consume_token(92);
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
     case K_NULL:
     case K_CASE:
@@ -387,14 +407,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     case S_IDENTIFIER:
     case S_CHAR_LITERAL:
     case S_QUOTED_IDENTIFIER:
-    case 91:
-    case 97:
-    case 108:
+    case 92:
+    case 98:
     case 109:
-    case 112:
-    case 114:
+    case 110:
+    case 113:
     case 115:
     case 116:
+    case 117:
       e = SimpleExpression();
                                      args.add(e);
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -406,32 +426,32 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       case S_IDENTIFIER:
       case S_CHAR_LITERAL:
       case S_QUOTED_IDENTIFIER:
-      case 91:
-      case 97:
-      case 108:
+      case 92:
+      case 98:
       case 109:
-      case 112:
-      case 114:
+      case 110:
+      case 113:
       case 115:
       case 116:
+      case 117:
         e = SimpleExpression();
                                 args.add(e);
         break;
       default:
-        jj_la1[9] = jj_gen;
+        jj_la1[11] = jj_gen;
         ;
       }
       label_4:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 92:
+        case 93:
           ;
           break;
         default:
-          jj_la1[10] = jj_gen;
+          jj_la1[12] = jj_gen;
           break label_4;
         }
-        jj_consume_token(92);
+        jj_consume_token(93);
         e = SimpleExpression();
                                            args.add(e);
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -443,28 +463,28 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         case S_IDENTIFIER:
         case S_CHAR_LITERAL:
         case S_QUOTED_IDENTIFIER:
-        case 91:
-        case 97:
-        case 108:
+        case 92:
+        case 98:
         case 109:
-        case 112:
-        case 114:
+        case 110:
+        case 113:
         case 115:
         case 116:
+        case 117:
           e = SimpleExpression();
                                      args.add(e);
           break;
         default:
-          jj_la1[11] = jj_gen;
+          jj_la1[13] = jj_gen;
           ;
         }
       }
       break;
     default:
-      jj_la1[12] = jj_gen;
+      jj_la1[14] = jj_gen;
       ;
     }
-    jj_consume_token(93);
+    jj_consume_token(94);
         {if (true) return new CreateLens(lensName, body, lensType, args);}
     throw new Error("Missing return statement in function");
   }
@@ -492,13 +512,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
           ;
           break;
         default:
-          jj_la1[13] = jj_gen;
+          jj_la1[15] = jj_gen;
           break label_5;
         }
       }
       break;
     default:
-      jj_la1[14] = jj_gen;
+      jj_la1[16] = jj_gen;
       ;
     }
         createView.setTable(table);
@@ -523,7 +543,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       jj_consume_token(K_INTO);
       break;
     default:
-      jj_la1[15] = jj_gen;
+      jj_la1[17] = jj_gen;
       ;
     }
     table = Table();
@@ -531,22 +551,22 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     case K_SET:
       jj_consume_token(K_SET);
       tableColumn = Column();
-      jj_consume_token(94);
+      jj_consume_token(95);
       value = SimpleExpression();
                                                                                 columns.add(tableColumn); expList.add(value);
       label_6:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 92:
+        case 93:
           ;
           break;
         default:
-          jj_la1[16] = jj_gen;
+          jj_la1[18] = jj_gen;
           break label_6;
         }
-        jj_consume_token(92);
+        jj_consume_token(93);
         tableColumn = Column();
-        jj_consume_token(94);
+        jj_consume_token(95);
         value = SimpleExpression();
                                                                                    columns.add(tableColumn); expList.add(value);
       }
@@ -554,66 +574,66 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       break;
     case K_SELECT:
     case K_VALUES:
-    case 91:
+    case 92:
       if (jj_2_1(2)) {
-        jj_consume_token(91);
+        jj_consume_token(92);
         tableColumn = Column();
                                                               columns.add(tableColumn);
         label_7:
         while (true) {
           switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-          case 92:
+          case 93:
             ;
             break;
           default:
-            jj_la1[17] = jj_gen;
+            jj_la1[19] = jj_gen;
             break label_7;
           }
-          jj_consume_token(92);
+          jj_consume_token(93);
           tableColumn = Column();
                                                                                                                       columns.add(tableColumn);
         }
-        jj_consume_token(93);
+        jj_consume_token(94);
       } else {
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
       case K_VALUES:
         jj_consume_token(K_VALUES);
-        jj_consume_token(91);
+        jj_consume_token(92);
         exp = PrimaryExpression();
                                                                           expList.add(exp);
         label_8:
         while (true) {
           switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-          case 92:
+          case 93:
             ;
             break;
           default:
-            jj_la1[18] = jj_gen;
+            jj_la1[20] = jj_gen;
             break label_8;
           }
-          jj_consume_token(92);
+          jj_consume_token(93);
           exp = PrimaryExpression();
                                                                                 expList.add(exp);
         }
-        jj_consume_token(93);
+        jj_consume_token(94);
                                                                                                              itemsList = new ExpressionList(expList);
         break;
       case K_SELECT:
-      case 91:
+      case 92:
                                           replace.setUseValues(false);
         itemsList = SubSelect();
         break;
       default:
-        jj_la1[19] = jj_gen;
+        jj_la1[21] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
                                 replace.setItemsList(itemsList);
       break;
     default:
-      jj_la1[20] = jj_gen;
+      jj_la1[22] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -638,75 +658,75 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       jj_consume_token(K_INTO);
       break;
     default:
-      jj_la1[21] = jj_gen;
+      jj_la1[23] = jj_gen;
       ;
     }
     table = Table();
     if (jj_2_2(2)) {
-      jj_consume_token(91);
+      jj_consume_token(92);
       tableColumn = Column();
                                               columns.add(tableColumn);
       label_9:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 92:
+        case 93:
           ;
           break;
         default:
-          jj_la1[22] = jj_gen;
+          jj_la1[24] = jj_gen;
           break label_9;
         }
-        jj_consume_token(92);
+        jj_consume_token(93);
         tableColumn = Column();
                                                                                                       columns.add(tableColumn);
       }
-      jj_consume_token(93);
+      jj_consume_token(94);
     } else {
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
     case K_VALUES:
       jj_consume_token(K_VALUES);
-      jj_consume_token(91);
+      jj_consume_token(92);
       exp = SimpleExpression();
                                                          primaryExpList.add(exp);
       label_10:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 92:
+        case 93:
           ;
           break;
         default:
-          jj_la1[23] = jj_gen;
+          jj_la1[25] = jj_gen;
           break label_10;
         }
-        jj_consume_token(92);
+        jj_consume_token(93);
         exp = SimpleExpression();
                                                                primaryExpList.add(exp);
       }
-      jj_consume_token(93);
+      jj_consume_token(94);
                                                                                                    itemsList = new ExpressionList(primaryExpList);
       break;
     case K_SELECT:
-    case 91:
+    case 92:
       if (jj_2_3(2)) {
-        jj_consume_token(91);
+        jj_consume_token(92);
       } else {
         ;
       }
                           insert.setUseValues(false);
       itemsList = SubSelect();
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 93:
-        jj_consume_token(93);
+      case 94:
+        jj_consume_token(94);
         break;
       default:
-        jj_la1[24] = jj_gen;
+        jj_la1[26] = jj_gen;
         ;
       }
       break;
     default:
-      jj_la1[25] = jj_gen;
+      jj_la1[27] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -728,7 +748,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       jj_consume_token(K_FROM);
       break;
     default:
-      jj_la1[26] = jj_gen;
+      jj_la1[28] = jj_gen;
       ;
     }
     table = TableWithAlias();
@@ -738,7 +758,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                            delete.setWhere(where);
       break;
     default:
-      jj_la1[27] = jj_gen;
+      jj_la1[29] = jj_gen;
       ;
     }
         delete.setTable(table);
@@ -753,21 +773,21 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     // [schema.][tabella.]colonna
         name1 = RelObjectName();
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-    case 95:
-      jj_consume_token(95);
+    case 96:
+      jj_consume_token(96);
       name2 = RelObjectName();
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 95:
-        jj_consume_token(95);
+      case 96:
+        jj_consume_token(96);
         name3 = RelObjectName();
         break;
       default:
-        jj_la1[28] = jj_gen;
+        jj_la1[30] = jj_gen;
         ;
       }
       break;
     default:
-      jj_la1[29] = jj_gen;
+      jj_la1[31] = jj_gen;
       ;
     }
         String colName = null;
@@ -797,7 +817,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       tk = jj_consume_token(S_QUOTED_IDENTIFIER);
       break;
     default:
-      jj_la1[30] = jj_gen;
+      jj_la1[32] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -817,7 +837,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                        table.setAlias(alias);
       break;
     default:
-      jj_la1[31] = jj_gen;
+      jj_la1[33] = jj_gen;
       ;
     }
           {if (true) return table;}
@@ -830,7 +850,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         String name2 = null;
     if (jj_2_4(3)) {
       name1 = RelObjectName();
-      jj_consume_token(95);
+      jj_consume_token(96);
       name2 = RelObjectName();
                                                                    table = new Table(name1, name2);
     } else {
@@ -841,7 +861,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                         table = new Table(null, name1);
         break;
       default:
-        jj_la1[32] = jj_gen;
+        jj_la1[34] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -860,7 +880,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                             select.setWithItemsList(with);
       break;
     default:
-      jj_la1[33] = jj_gen;
+      jj_la1[35] = jj_gen;
       ;
     }
     selectBody = SelectBody();
@@ -879,7 +899,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         selectBody = PlainSelect();
         break;
       default:
-        jj_la1[34] = jj_gen;
+        jj_la1[36] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -914,24 +934,24 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
         case K_ON:
           jj_consume_token(K_ON);
-          jj_consume_token(91);
+          jj_consume_token(92);
           distinctOn = SelectItemsList();
                                                                            plainSelect.getDistinct().setOnSelectItems(distinctOn);
-          jj_consume_token(93);
+          jj_consume_token(94);
           break;
         default:
-          jj_la1[35] = jj_gen;
+          jj_la1[37] = jj_gen;
           ;
         }
         break;
       default:
-        jj_la1[36] = jj_gen;
+        jj_la1[38] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
     default:
-      jj_la1[37] = jj_gen;
+      jj_la1[39] = jj_gen;
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -940,7 +960,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                       plainSelect.setTop(top);
       break;
     default:
-      jj_la1[38] = jj_gen;
+      jj_la1[40] = jj_gen;
       ;
     }
     selectItems = SelectItemsList();
@@ -949,7 +969,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       IntoClause();
       break;
     default:
-      jj_la1[39] = jj_gen;
+      jj_la1[41] = jj_gen;
       ;
     }
     jj_consume_token(K_FROM);
@@ -961,7 +981,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                             plainSelect.setWhere(where);
       break;
     default:
-      jj_la1[40] = jj_gen;
+      jj_la1[42] = jj_gen;
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -970,7 +990,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                                           plainSelect.setGroupByColumnReferences(groupByColumnReferences);
       break;
     default:
-      jj_la1[41] = jj_gen;
+      jj_la1[43] = jj_gen;
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -979,7 +999,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                         plainSelect.setHaving(having);
       break;
     default:
-      jj_la1[42] = jj_gen;
+      jj_la1[44] = jj_gen;
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -988,7 +1008,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                                                          plainSelect.setOrderByElements(orderByElements);
       break;
     default:
-      jj_la1[43] = jj_gen;
+      jj_la1[45] = jj_gen;
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -998,7 +1018,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                           plainSelect.setLimit(limit);
       break;
     default:
-      jj_la1[44] = jj_gen;
+      jj_la1[46] = jj_gen;
       ;
     }
                 plainSelect.setSelectItems(selectItems);
@@ -1016,11 +1036,11 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         PlainSelect select = null;
         ArrayList selects = new ArrayList();
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-    case 91:
-      jj_consume_token(91);
+    case 92:
+      jj_consume_token(92);
       select = PlainSelect();
                                                   selects.add(select);
-      jj_consume_token(93);
+      jj_consume_token(94);
       jj_consume_token(K_UNION);
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
       case K_ALL:
@@ -1035,19 +1055,19 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                                                                                   union.setDistinct(true);
           break;
         default:
-          jj_la1[45] = jj_gen;
+          jj_la1[47] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
         break;
       default:
-        jj_la1[46] = jj_gen;
+        jj_la1[48] = jj_gen;
         ;
       }
-      jj_consume_token(91);
+      jj_consume_token(92);
       select = PlainSelect();
                                                   selects.add(select);
-      jj_consume_token(93);
+      jj_consume_token(94);
       label_11:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -1055,7 +1075,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
           ;
           break;
         default:
-          jj_la1[47] = jj_gen;
+          jj_la1[49] = jj_gen;
           break label_11;
         }
         jj_consume_token(K_UNION);
@@ -1070,19 +1090,19 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
             jj_consume_token(K_DISTINCT);
             break;
           default:
-            jj_la1[48] = jj_gen;
+            jj_la1[50] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
           break;
         default:
-          jj_la1[49] = jj_gen;
+          jj_la1[51] = jj_gen;
           ;
         }
-        jj_consume_token(91);
+        jj_consume_token(92);
         select = PlainSelect();
                                                                                                selects.add(select);
-        jj_consume_token(93);
+        jj_consume_token(94);
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
       case K_ORDER:
@@ -1090,7 +1110,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                                             union.setOrderByElements(orderByElements);
         break;
       default:
-        jj_la1[50] = jj_gen;
+        jj_la1[52] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -1100,7 +1120,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                         union.setLimit(limit);
         break;
       default:
-        jj_la1[51] = jj_gen;
+        jj_la1[53] = jj_gen;
         ;
       }
       break;
@@ -1121,13 +1141,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                                                                                   union.setDistinct(true);
           break;
         default:
-          jj_la1[52] = jj_gen;
+          jj_la1[54] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
         break;
       default:
-        jj_la1[53] = jj_gen;
+        jj_la1[55] = jj_gen;
         ;
       }
       select = PlainSelect();
@@ -1139,7 +1159,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
           ;
           break;
         default:
-          jj_la1[54] = jj_gen;
+          jj_la1[56] = jj_gen;
           break label_12;
         }
         jj_consume_token(K_UNION);
@@ -1154,13 +1174,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
             jj_consume_token(K_DISTINCT);
             break;
           default:
-            jj_la1[55] = jj_gen;
+            jj_la1[57] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
           break;
         default:
-          jj_la1[56] = jj_gen;
+          jj_la1[58] = jj_gen;
           ;
         }
         select = PlainSelect();
@@ -1168,7 +1188,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       }
       break;
     default:
-      jj_la1[57] = jj_gen;
+      jj_la1[59] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1186,14 +1206,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     label_13:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 92:
+      case 93:
         ;
         break;
       default:
-        jj_la1[58] = jj_gen;
+        jj_la1[60] = jj_gen;
         break label_13;
       }
-      jj_consume_token(92);
+      jj_consume_token(93);
       with = WithItem();
                                                                                      withItemsList.add(with);
     }
@@ -1209,21 +1229,21 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     name = RelObjectName();
                                 with.setName(name);
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-    case 91:
-      jj_consume_token(91);
+    case 92:
+      jj_consume_token(92);
       selectItems = SelectItemsList();
-      jj_consume_token(93);
+      jj_consume_token(94);
                                                    with.setWithItemList(selectItems);
       break;
     default:
-      jj_la1[59] = jj_gen;
+      jj_la1[61] = jj_gen;
       ;
     }
     jj_consume_token(K_AS);
-    jj_consume_token(91);
+    jj_consume_token(92);
     selectBody = SelectBody();
                                          with.setSelectBody(selectBody);
-    jj_consume_token(93);
+    jj_consume_token(94);
            {if (true) return with;}
     throw new Error("Missing return statement in function");
   }
@@ -1236,14 +1256,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     label_14:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 92:
+      case 93:
         ;
         break;
       default:
-        jj_la1[60] = jj_gen;
+        jj_la1[62] = jj_gen;
         break label_14;
       }
-      jj_consume_token(92);
+      jj_consume_token(93);
       selectItem = SelectItem();
                                                                                                 selectItemsList.add(selectItem);
     }
@@ -1261,12 +1281,12 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         Expression expression = null;
         SubSelect subSelect = null;
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-    case 96:
-      jj_consume_token(96);
+    case 97:
+      jj_consume_token(97);
            selectItem = new AllColumns();
       break;
     default:
-      jj_la1[62] = jj_gen;
+      jj_la1[64] = jj_gen;
       if (jj_2_6(2147483647)) {
         selectItem = AllTableColumns();
       } else {
@@ -1279,14 +1299,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         case S_IDENTIFIER:
         case S_CHAR_LITERAL:
         case S_QUOTED_IDENTIFIER:
-        case 91:
-        case 97:
-        case 108:
+        case 92:
+        case 98:
         case 109:
-        case 112:
-        case 114:
+        case 110:
+        case 113:
         case 115:
         case 116:
+        case 117:
           expression = SimpleExpression();
                                          selectExpressionItem = new SelectExpressionItem(); selectExpressionItem.setExpression(expression);
           switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -1297,13 +1317,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                           selectExpressionItem.setAlias(alias);
             break;
           default:
-            jj_la1[61] = jj_gen;
+            jj_la1[63] = jj_gen;
             ;
           }
                                                                                      selectItem = selectExpressionItem;
           break;
         default:
-          jj_la1[63] = jj_gen;
+          jj_la1[65] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -1316,8 +1336,8 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   final public AllTableColumns AllTableColumns() throws ParseException {
         Table table = null;
     table = Table();
-    jj_consume_token(95);
     jj_consume_token(96);
+    jj_consume_token(97);
                 {if (true) return new AllTableColumns(table);}
     throw new Error("Missing return statement in function");
   }
@@ -1329,7 +1349,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       jj_consume_token(K_AS);
       break;
     default:
-      jj_la1[64] = jj_gen;
+      jj_la1[66] = jj_gen;
       ;
     }
     retval = RelObjectName();
@@ -1343,14 +1363,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     label_15:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 92:
+      case 93:
         ;
         break;
       default:
-        jj_la1[65] = jj_gen;
+        jj_la1[67] = jj_gen;
         break label_15;
       }
-      jj_consume_token(92);
+      jj_consume_token(93);
       Table();
     }
   }
@@ -1359,30 +1379,30 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         FromItem fromItem = null;
         String alias = null;
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-    case 91:
-      jj_consume_token(91);
+    case 92:
+      jj_consume_token(92);
       if (jj_2_7(2147483647)) {
         fromItem = SubJoin();
       } else {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
         case K_SELECT:
-        case 91:
+        case 92:
           fromItem = SubSelect();
           break;
         default:
-          jj_la1[66] = jj_gen;
+          jj_la1[68] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
       }
-      jj_consume_token(93);
+      jj_consume_token(94);
       break;
     case S_IDENTIFIER:
     case S_QUOTED_IDENTIFIER:
       fromItem = Table();
       break;
     default:
-      jj_la1[67] = jj_gen;
+      jj_la1[69] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1394,7 +1414,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                          fromItem.setAlias(alias);
       break;
     default:
-      jj_la1[68] = jj_gen;
+      jj_la1[70] = jj_gen;
       ;
     }
                 {if (true) return fromItem;}
@@ -1426,11 +1446,11 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       case K_OUTER:
       case K_RIGHT:
       case K_NATURAL:
-      case 92:
+      case 93:
         ;
         break;
       default:
-        jj_la1[69] = jj_gen;
+        jj_la1[71] = jj_gen;
         break label_16;
       }
       join = JoinerExpression();
@@ -1469,13 +1489,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                 join.setNatural(true);
         break;
       default:
-        jj_la1[70] = jj_gen;
+        jj_la1[72] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
     default:
-      jj_la1[71] = jj_gen;
+      jj_la1[73] = jj_gen;
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -1491,25 +1511,25 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                               join.setInner(true);
         break;
       default:
-        jj_la1[72] = jj_gen;
+        jj_la1[74] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
     default:
-      jj_la1[73] = jj_gen;
+      jj_la1[75] = jj_gen;
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
     case K_JOIN:
       jj_consume_token(K_JOIN);
       break;
-    case 92:
-      jj_consume_token(92);
+    case 93:
+      jj_consume_token(93);
                                join.setSimple(true);
       break;
     default:
-      jj_la1[74] = jj_gen;
+      jj_la1[76] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1525,34 +1545,34 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         break;
       case K_USING:
         jj_consume_token(K_USING);
-        jj_consume_token(91);
+        jj_consume_token(92);
         tableColumn = Column();
                                                        columns = new ArrayList(); columns.add(tableColumn);
         label_17:
         while (true) {
           switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-          case 92:
+          case 93:
             ;
             break;
           default:
-            jj_la1[75] = jj_gen;
+            jj_la1[77] = jj_gen;
             break label_17;
           }
-          jj_consume_token(92);
+          jj_consume_token(93);
           tableColumn = Column();
                                                             columns.add(tableColumn);
         }
-        jj_consume_token(93);
+        jj_consume_token(94);
                     join.setUsingColumns(columns);
         break;
       default:
-        jj_la1[76] = jj_gen;
+        jj_la1[78] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
     default:
-      jj_la1[77] = jj_gen;
+      jj_la1[79] = jj_gen;
       ;
     }
         join.setRightItem(right);
@@ -1586,14 +1606,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     label_18:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 92:
+      case 93:
         ;
         break;
       default:
-        jj_la1[78] = jj_gen;
+        jj_la1[80] = jj_gen;
         break label_18;
       }
-      jj_consume_token(92);
+      jj_consume_token(93);
       columnReference = SimpleExpression();
                                               columnReferences.add(columnReference);
     }
@@ -1619,14 +1639,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     label_19:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 92:
+      case 93:
         ;
         break;
       default:
-        jj_la1[79] = jj_gen;
+        jj_la1[81] = jj_gen;
         break label_19;
       }
-      jj_consume_token(92);
+      jj_consume_token(93);
       orderByElement = OrderByElement();
                                                orderByList.add(orderByElement);
     }
@@ -1651,13 +1671,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                            orderByElement.setAsc(false);
         break;
       default:
-        jj_la1[80] = jj_gen;
+        jj_la1[82] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
     default:
-      jj_la1[81] = jj_gen;
+      jj_la1[83] = jj_gen;
       ;
     }
         orderByElement.setExpression(columnReference);
@@ -1675,27 +1695,27 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         token = jj_consume_token(S_INTEGER);
                                                                     limit.setOffset(Long.parseLong(token.image));
         break;
-      case 97:
-        jj_consume_token(97);
+      case 98:
+        jj_consume_token(98);
                                                       limit.setOffsetJdbcParameter(true);
         break;
       default:
-        jj_la1[82] = jj_gen;
+        jj_la1[84] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
-      jj_consume_token(92);
+      jj_consume_token(93);
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
       case S_INTEGER:
         token = jj_consume_token(S_INTEGER);
                                                     limit.setRowCount(Long.parseLong(token.image));
         break;
-      case 97:
-        jj_consume_token(97);
+      case 98:
+        jj_consume_token(98);
                                                                                                               limit.setRowCountJdbcParameter(true);
         break;
       default:
-        jj_la1[83] = jj_gen;
+        jj_la1[85] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -1708,12 +1728,12 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
           token = jj_consume_token(S_INTEGER);
                                                       limit.setOffset(Long.parseLong(token.image));
           break;
-        case 97:
-          jj_consume_token(97);
+        case 98:
+          jj_consume_token(98);
                                                                                                               limit.setOffsetJdbcParameter(true);
           break;
         default:
-          jj_la1[84] = jj_gen;
+          jj_la1[86] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -1725,8 +1745,8 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
           token = jj_consume_token(S_INTEGER);
                                                             limit.setRowCount(Long.parseLong(token.image));
           break;
-        case 97:
-          jj_consume_token(97);
+        case 98:
+          jj_consume_token(98);
                                               limit.setRowCountJdbcParameter(true);
           break;
         case K_ALL:
@@ -1734,7 +1754,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                                   limit.setLimitAll(true);
           break;
         default:
-          jj_la1[85] = jj_gen;
+          jj_la1[87] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -1746,23 +1766,23 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
             token = jj_consume_token(S_INTEGER);
                                                               limit.setOffset(Long.parseLong(token.image));
             break;
-          case 97:
-            jj_consume_token(97);
+          case 98:
+            jj_consume_token(98);
                                                                                                                       limit.setOffsetJdbcParameter(true);
             break;
           default:
-            jj_la1[86] = jj_gen;
+            jj_la1[88] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
           break;
         default:
-          jj_la1[87] = jj_gen;
+          jj_la1[89] = jj_gen;
           ;
         }
         break;
       default:
-        jj_la1[88] = jj_gen;
+        jj_la1[90] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -1780,12 +1800,12 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       token = jj_consume_token(S_INTEGER);
                                     top.setRowCount(Long.parseLong(token.image));
       break;
-    case 97:
-      jj_consume_token(97);
+    case 98:
+      jj_consume_token(98);
                       top.setRowCountJdbcParameter(true);
       break;
     default:
-      jj_la1[89] = jj_gen;
+      jj_la1[91] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1799,13 +1819,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       retval = OrExpression();
     } else {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 91:
-        jj_consume_token(91);
+      case 92:
+        jj_consume_token(92);
         retval = Expression();
-        jj_consume_token(93);
+        jj_consume_token(94);
         break;
       default:
-        jj_la1[90] = jj_gen;
+        jj_la1[92] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -1842,26 +1862,26 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     } else {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
       case K_NOT:
-      case 91:
+      case 92:
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
         case K_NOT:
           jj_consume_token(K_NOT);
                         not = true;
           break;
         default:
-          jj_la1[91] = jj_gen;
+          jj_la1[93] = jj_gen;
           ;
         }
-        jj_consume_token(91);
+        jj_consume_token(92);
         left = OrExpression();
-        jj_consume_token(93);
+        jj_consume_token(94);
         if (not) {
           left = new InverseExpression(left);
           not = false;
         }
         break;
       default:
-        jj_la1[92] = jj_gen;
+        jj_la1[94] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -1880,26 +1900,26 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       } else {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
         case K_NOT:
-        case 91:
+        case 92:
           switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
           case K_NOT:
             jj_consume_token(K_NOT);
                                 not = true;
             break;
           default:
-            jj_la1[93] = jj_gen;
+            jj_la1[95] = jj_gen;
             ;
           }
-          jj_consume_token(91);
+          jj_consume_token(92);
           right = OrExpression();
-          jj_consume_token(93);
+          jj_consume_token(94);
           if (not) {
             right = new InverseExpression(right);
             not = false;
           }
           break;
         default:
-          jj_la1[94] = jj_gen;
+          jj_la1[96] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -1929,18 +1949,18 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       case S_IDENTIFIER:
       case S_CHAR_LITERAL:
       case S_QUOTED_IDENTIFIER:
-      case 91:
-      case 97:
-      case 108:
+      case 92:
+      case 98:
       case 109:
-      case 112:
-      case 114:
+      case 110:
+      case 113:
       case 115:
       case 116:
+      case 117:
         result = RegularCondition();
         break;
       default:
-        jj_la1[95] = jj_gen;
+        jj_la1[97] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -1960,54 +1980,54 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                     not = true;
       break;
     default:
-      jj_la1[96] = jj_gen;
+      jj_la1[98] = jj_gen;
       ;
     }
     leftExpression = ComparisonItem();
                                           result = leftExpression;
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-    case 98:
-      jj_consume_token(98);
-              result = new GreaterThan();
-      break;
     case 99:
       jj_consume_token(99);
-                result = new MinorThan();
-      break;
-    case 94:
-      jj_consume_token(94);
-                result = new EqualsTo();
+              result = new GreaterThan();
       break;
     case 100:
       jj_consume_token(100);
-                 result = new GreaterThanEquals();
+                result = new MinorThan();
+      break;
+    case 95:
+      jj_consume_token(95);
+                result = new EqualsTo();
       break;
     case 101:
       jj_consume_token(101);
-                 result = new MinorThanEquals();
+                 result = new GreaterThanEquals();
       break;
     case 102:
+      jj_consume_token(102);
+                 result = new MinorThanEquals();
+      break;
     case 103:
+    case 104:
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 102:
-        jj_consume_token(102);
-        break;
       case 103:
         jj_consume_token(103);
         break;
+      case 104:
+        jj_consume_token(104);
+        break;
       default:
-        jj_la1[97] = jj_gen;
+        jj_la1[99] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
                           result = new NotEqualsTo();
       break;
-    case 104:
-      jj_consume_token(104);
+    case 105:
+      jj_consume_token(105);
                  result = new Matches();
       break;
     default:
-      jj_la1[98] = jj_gen;
+      jj_la1[100] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2042,18 +2062,18 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       case S_IDENTIFIER:
       case S_CHAR_LITERAL:
       case S_QUOTED_IDENTIFIER:
-      case 91:
-      case 97:
-      case 108:
+      case 92:
+      case 98:
       case 109:
-      case 112:
-      case 114:
+      case 110:
+      case 113:
       case 115:
       case 116:
+      case 117:
         result = LikeExpression();
         break;
       default:
-        jj_la1[99] = jj_gen;
+        jj_la1[101] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -2073,11 +2093,11 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                result.setNot(true);
       break;
     default:
-      jj_la1[100] = jj_gen;
+      jj_la1[102] = jj_gen;
       ;
     }
     jj_consume_token(K_IN);
-    jj_consume_token(91);
+    jj_consume_token(92);
     if (jj_2_19(2147483647)) {
       itemsList = SubSelect();
     } else {
@@ -2090,23 +2110,23 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       case S_IDENTIFIER:
       case S_CHAR_LITERAL:
       case S_QUOTED_IDENTIFIER:
-      case 91:
-      case 97:
-      case 108:
+      case 92:
+      case 98:
       case 109:
-      case 112:
-      case 114:
+      case 110:
+      case 113:
       case 115:
       case 116:
+      case 117:
         itemsList = SimpleExpressionList();
         break;
       default:
-        jj_la1[101] = jj_gen;
+        jj_la1[103] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
     }
-    jj_consume_token(93);
+    jj_consume_token(94);
                 result.setLeftExpression(leftExpression);
                 result.setItemsList(itemsList);
                 {if (true) return result;}
@@ -2125,7 +2145,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                        result.setNot(true);
       break;
     default:
-      jj_la1[102] = jj_gen;
+      jj_la1[104] = jj_gen;
       ;
     }
     jj_consume_token(K_BETWEEN);
@@ -2150,7 +2170,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                result.setNot(true);
       break;
     default:
-      jj_la1[103] = jj_gen;
+      jj_la1[105] = jj_gen;
       ;
     }
     jj_consume_token(K_LIKE);
@@ -2162,7 +2182,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                          result.setEscape((StringValue.parseEscaped(token.image)).getValue());
       break;
     default:
-      jj_la1[104] = jj_gen;
+      jj_la1[106] = jj_gen;
       ;
     }
                 result.setLeftExpression(leftExpression);
@@ -2182,7 +2202,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                       result.setNot(true);
       break;
     default:
-      jj_la1[105] = jj_gen;
+      jj_la1[107] = jj_gen;
       ;
     }
     jj_consume_token(K_NULL);
@@ -2200,7 +2220,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                result.setNot(true);
       break;
     default:
-      jj_la1[106] = jj_gen;
+      jj_la1[108] = jj_gen;
       ;
     }
     jj_consume_token(K_EXISTS);
@@ -2219,14 +2239,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     label_22:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 92:
+      case 93:
         ;
         break;
       default:
-        jj_la1[107] = jj_gen;
+        jj_la1[109] = jj_gen;
         break label_22;
       }
-      jj_consume_token(92);
+      jj_consume_token(93);
       expr = Expression();
                                                                           expressions.add(expr);
     }
@@ -2244,14 +2264,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     label_23:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 92:
+      case 93:
         ;
         break;
       default:
-        jj_la1[108] = jj_gen;
+        jj_la1[110] = jj_gen;
         break label_23;
       }
-      jj_consume_token(92);
+      jj_consume_token(93);
       expr = SimpleExpression();
                                                                                       expressions.add(expr);
     }
@@ -2278,18 +2298,18 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     case S_IDENTIFIER:
     case S_CHAR_LITERAL:
     case S_QUOTED_IDENTIFIER:
-    case 91:
-    case 97:
-    case 108:
+    case 92:
+    case 98:
     case 109:
-    case 112:
-    case 114:
+    case 110:
+    case 113:
     case 115:
     case 116:
+    case 117:
       retval = SimpleExpression();
       break;
     default:
-      jj_la1[109] = jj_gen;
+      jj_la1[111] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2301,9 +2321,9 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         AllComparisonExpression retval = null;
         SubSelect subselect = null;
     jj_consume_token(K_ALL);
-    jj_consume_token(91);
+    jj_consume_token(92);
     subselect = SubSelect();
-    jj_consume_token(93);
+    jj_consume_token(94);
                                          retval = new AllComparisonExpression(subselect);
       {if (true) return retval;}
     throw new Error("Missing return statement in function");
@@ -2320,13 +2340,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       jj_consume_token(K_SOME);
       break;
     default:
-      jj_la1[110] = jj_gen;
+      jj_la1[112] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
-    jj_consume_token(91);
+    jj_consume_token(92);
     subselect = SubSelect();
-    jj_consume_token(93);
+    jj_consume_token(94);
                                                       retval = new AnyComparisonExpression(subselect);
       {if (true) return retval;}
     throw new Error("Missing return statement in function");
@@ -2338,13 +2358,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       retval = BitwiseAndOr();
     } else {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 91:
-        jj_consume_token(91);
+      case 92:
+        jj_consume_token(92);
         retval = BitwiseAndOr();
-        jj_consume_token(93);
+        jj_consume_token(94);
         break;
       default:
-        jj_la1[111] = jj_gen;
+        jj_la1[113] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -2362,14 +2382,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     label_24:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 105:
+      case 106:
         ;
         break;
       default:
-        jj_la1[112] = jj_gen;
+        jj_la1[114] = jj_gen;
         break label_24;
       }
-      jj_consume_token(105);
+      jj_consume_token(106);
       rightExpression = AdditiveExpression();
                         Concat binExp = new Concat();
                         binExp.setLeftExpression(leftExpression);
@@ -2395,16 +2415,16 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         break label_25;
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 106:
-        jj_consume_token(106);
-                                              result = new BitwiseOr();
-        break;
       case 107:
         jj_consume_token(107);
+                                              result = new BitwiseOr();
+        break;
+      case 108:
+        jj_consume_token(108);
                                               result = new BitwiseAnd();
         break;
       default:
-        jj_la1[113] = jj_gen;
+        jj_la1[115] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -2432,16 +2452,16 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         break label_26;
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 108:
-        jj_consume_token(108);
-                            result = new Addition();
-        break;
       case 109:
         jj_consume_token(109);
+                            result = new Addition();
+        break;
+      case 110:
+        jj_consume_token(110);
                                                                         result = new Subtraction();
         break;
       default:
-        jj_la1[114] = jj_gen;
+        jj_la1[116] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -2463,13 +2483,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       leftExpression = BitwiseXor();
     } else {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 91:
-        jj_consume_token(91);
+      case 92:
+        jj_consume_token(92);
         leftExpression = AdditiveExpression();
-        jj_consume_token(93);
+        jj_consume_token(94);
         break;
       default:
-        jj_la1[115] = jj_gen;
+        jj_la1[117] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -2483,16 +2503,16 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         break label_27;
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 96:
-        jj_consume_token(96);
+      case 97:
+        jj_consume_token(97);
                             result = new Multiplication();
         break;
-      case 110:
-        jj_consume_token(110);
+      case 111:
+        jj_consume_token(111);
                                                                         result = new Division();
         break;
       default:
-        jj_la1[116] = jj_gen;
+        jj_la1[118] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -2500,13 +2520,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         rightExpression = BitwiseXor();
       } else {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 91:
-          jj_consume_token(91);
+        case 92:
+          jj_consume_token(92);
           rightExpression = AdditiveExpression();
-          jj_consume_token(93);
+          jj_consume_token(94);
           break;
         default:
-          jj_la1[117] = jj_gen;
+          jj_la1[119] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -2529,14 +2549,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     label_28:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 111:
+      case 112:
         ;
         break;
       default:
-        jj_la1[118] = jj_gen;
+        jj_la1[120] = jj_gen;
         break label_28;
       }
-      jj_consume_token(111);
+      jj_consume_token(112);
       rightExpression = PrimaryExpression();
                         BitwiseXor binExp = new BitwiseXor();
                         binExp.setLeftExpression(leftExpression);
@@ -2561,46 +2581,23 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     case K_CASE:
       retval = CaseWhenExpression();
       break;
-    case 97:
-      jj_consume_token(97);
+    case 98:
+      jj_consume_token(98);
                 retval = new JdbcParameter();
       break;
     default:
-      jj_la1[131] = jj_gen;
+      jj_la1[133] = jj_gen;
       if (jj_2_26(2147483647)) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 108:
         case 109:
+        case 110:
           switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-          case 108:
-            jj_consume_token(108);
-            break;
           case 109:
             jj_consume_token(109);
+            break;
+          case 110:
+            jj_consume_token(110);
                                                               isInverse = true;
-            break;
-          default:
-            jj_la1[119] = jj_gen;
-            jj_consume_token(-1);
-            throw new ParseException();
-          }
-          break;
-        default:
-          jj_la1[120] = jj_gen;
-          ;
-        }
-        retval = Function();
-      } else if (jj_2_27(2147483647)) {
-        switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 108:
-        case 109:
-          switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-          case 108:
-            jj_consume_token(108);
-            break;
-          case 109:
-            jj_consume_token(109);
-                                                                    tmp = "-";
             break;
           default:
             jj_la1[121] = jj_gen;
@@ -2612,19 +2609,18 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
           jj_la1[122] = jj_gen;
           ;
         }
-        token = jj_consume_token(S_DOUBLE);
-                                                                                                      retval = new DoubleValue(tmp+token.image);
-      } else if (jj_2_28(2147483647)) {
+        retval = Function();
+      } else if (jj_2_27(2147483647)) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 108:
         case 109:
+        case 110:
           switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-          case 108:
-            jj_consume_token(108);
-            break;
           case 109:
             jj_consume_token(109);
-                                                                            tmp = "-";
+            break;
+          case 110:
+            jj_consume_token(110);
+                                                                    tmp = "-";
             break;
           default:
             jj_la1[123] = jj_gen;
@@ -2636,19 +2632,19 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
           jj_la1[124] = jj_gen;
           ;
         }
-        token = jj_consume_token(S_INTEGER);
-                                                                                                               retval = new LongValue(tmp+token.image);
-      } else if (jj_2_29(2)) {
+        token = jj_consume_token(S_DOUBLE);
+                                                                                                      retval = new DoubleValue(tmp+token.image);
+      } else if (jj_2_28(2147483647)) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 108:
         case 109:
+        case 110:
           switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-          case 108:
-            jj_consume_token(108);
-            break;
           case 109:
             jj_consume_token(109);
-                                      isInverse = true;
+            break;
+          case 110:
+            jj_consume_token(110);
+                                                                            tmp = "-";
             break;
           default:
             jj_la1[125] = jj_gen;
@@ -2660,18 +2656,19 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
           jj_la1[126] = jj_gen;
           ;
         }
-        retval = Column();
-      } else if (jj_2_30(2)) {
+        token = jj_consume_token(S_INTEGER);
+                                                                                                               retval = new LongValue(tmp+token.image);
+      } else if (jj_2_29(2)) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 108:
         case 109:
+        case 110:
           switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-          case 108:
-            jj_consume_token(108);
-            break;
           case 109:
             jj_consume_token(109);
-                                     isInverse = true;
+            break;
+          case 110:
+            jj_consume_token(110);
+                                      isInverse = true;
             break;
           default:
             jj_la1[127] = jj_gen;
@@ -2683,63 +2680,86 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
           jj_la1[128] = jj_gen;
           ;
         }
-        jj_consume_token(91);
+        retval = Column();
+      } else if (jj_2_30(2)) {
+        switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+        case 109:
+        case 110:
+          switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+          case 109:
+            jj_consume_token(109);
+            break;
+          case 110:
+            jj_consume_token(110);
+                                     isInverse = true;
+            break;
+          default:
+            jj_la1[129] = jj_gen;
+            jj_consume_token(-1);
+            throw new ParseException();
+          }
+          break;
+        default:
+          jj_la1[130] = jj_gen;
+          ;
+        }
+        jj_consume_token(92);
         retval = PrimaryExpression();
-        jj_consume_token(93);
+        jj_consume_token(94);
       } else {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
         case S_CHAR_LITERAL:
           token = jj_consume_token(S_CHAR_LITERAL);
                                    retval = StringValue.parseEscaped(token.image);
           break;
-        case 91:
-        case 108:
+        case 92:
         case 109:
+        case 110:
           switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-          case 108:
           case 109:
+          case 110:
             switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-            case 108:
-              jj_consume_token(108);
-              break;
             case 109:
               jj_consume_token(109);
+              break;
+            case 110:
+              jj_consume_token(110);
                         isInverse = true;
               break;
             default:
-              jj_la1[129] = jj_gen;
+              jj_la1[131] = jj_gen;
               jj_consume_token(-1);
               throw new ParseException();
             }
             break;
           default:
-            jj_la1[130] = jj_gen;
+            jj_la1[132] = jj_gen;
             ;
           }
-          jj_consume_token(91);
+          jj_consume_token(92);
           retval = SubSelect();
-          jj_consume_token(93);
+          jj_consume_token(94);
           break;
-        case 112:
-          jj_consume_token(112);
-          token = jj_consume_token(S_CHAR_LITERAL);
+        case 113:
           jj_consume_token(113);
-                                                  retval = new DateValue(token.image);
-          break;
-        case 114:
+          token = jj_consume_token(S_CHAR_LITERAL);
           jj_consume_token(114);
-          token = jj_consume_token(S_CHAR_LITERAL);
-          jj_consume_token(113);
-                                                  retval = new TimeValue(token.image);
+                                                  retval = new DateValue(token.image);
           break;
         case 115:
           jj_consume_token(115);
           token = jj_consume_token(S_CHAR_LITERAL);
-          jj_consume_token(113);
+          jj_consume_token(114);
+                                                  retval = new TimeValue(token.image);
+          break;
+        case 116:
+          jj_consume_token(116);
+          token = jj_consume_token(S_CHAR_LITERAL);
+          jj_consume_token(114);
                                                    retval = new TimestampValue(token.image);
           break;
         default:
-          jj_la1[132] = jj_gen;
+          jj_la1[134] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -2759,39 +2779,15 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   String tmp = "";
     if (jj_2_31(2147483647)) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 108:
       case 109:
+      case 110:
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 108:
-          jj_consume_token(108);
-          break;
         case 109:
           jj_consume_token(109);
+          break;
+        case 110:
+          jj_consume_token(110);
                                                       tmp = "-";
-          break;
-        default:
-          jj_la1[133] = jj_gen;
-          jj_consume_token(-1);
-          throw new ParseException();
-        }
-        break;
-      default:
-        jj_la1[134] = jj_gen;
-        ;
-      }
-      token = jj_consume_token(S_DOUBLE);
-                                                                                        retval = new DoubleValue(tmp+token.image);
-    } else if (jj_2_32(2147483647)) {
-      switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 108:
-      case 109:
-        switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 108:
-          jj_consume_token(108);
-          break;
-        case 109:
-          jj_consume_token(109);
-                                                        tmp = "-";
           break;
         default:
           jj_la1[135] = jj_gen;
@@ -2803,6 +2799,30 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         jj_la1[136] = jj_gen;
         ;
       }
+      token = jj_consume_token(S_DOUBLE);
+                                                                                        retval = new DoubleValue(tmp+token.image);
+    } else if (jj_2_32(2147483647)) {
+      switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+      case 109:
+      case 110:
+        switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+        case 109:
+          jj_consume_token(109);
+          break;
+        case 110:
+          jj_consume_token(110);
+                                                        tmp = "-";
+          break;
+        default:
+          jj_la1[137] = jj_gen;
+          jj_consume_token(-1);
+          throw new ParseException();
+        }
+        break;
+      default:
+        jj_la1[138] = jj_gen;
+        ;
+      }
       token = jj_consume_token(S_INTEGER);
                                                                                            retval = new LongValue(tmp+token.image);
     } else {
@@ -2811,26 +2831,26 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         token = jj_consume_token(S_CHAR_LITERAL);
                              retval = StringValue.parseEscaped(token.image);
         break;
-      case 112:
-        jj_consume_token(112);
-        token = jj_consume_token(S_CHAR_LITERAL);
+      case 113:
         jj_consume_token(113);
-                                        retval = new DateValue(token.image);
-        break;
-      case 114:
+        token = jj_consume_token(S_CHAR_LITERAL);
         jj_consume_token(114);
-        token = jj_consume_token(S_CHAR_LITERAL);
-        jj_consume_token(113);
-                                        retval = new TimeValue(token.image);
+                                        retval = new DateValue(token.image);
         break;
       case 115:
         jj_consume_token(115);
         token = jj_consume_token(S_CHAR_LITERAL);
-        jj_consume_token(113);
+        jj_consume_token(114);
+                                        retval = new TimeValue(token.image);
+        break;
+      case 116:
+        jj_consume_token(116);
+        token = jj_consume_token(S_CHAR_LITERAL);
+        jj_consume_token(114);
                                          retval = new TimestampValue(token.image);
         break;
       default:
-        jj_la1[137] = jj_gen;
+        jj_la1[139] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -2857,49 +2877,9 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
           ;
           break;
         default:
-          jj_la1[138] = jj_gen;
+          jj_la1[140] = jj_gen;
           break label_29;
         }
-      }
-      switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case K_ELSE:
-        jj_consume_token(K_ELSE);
-        elseExp = PrimaryExpression();
-        break;
-      default:
-        jj_la1[139] = jj_gen;
-        ;
-      }
-      break;
-    case K_NULL:
-    case K_CASE:
-    case K_REPLACE:
-    case S_DOUBLE:
-    case S_INTEGER:
-    case S_IDENTIFIER:
-    case S_CHAR_LITERAL:
-    case S_QUOTED_IDENTIFIER:
-    case 91:
-    case 97:
-    case 108:
-    case 109:
-    case 112:
-    case 114:
-    case 115:
-    case 116:
-      switchExp = PrimaryExpression();
-      label_30:
-      while (true) {
-        switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case K_WHEN:
-          ;
-          break;
-        default:
-          jj_la1[140] = jj_gen;
-          break label_30;
-        }
-        clause = WhenThenValue();
-                                        whenClauses.add(clause);
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
       case K_ELSE:
@@ -2911,8 +2891,48 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         ;
       }
       break;
+    case K_NULL:
+    case K_CASE:
+    case K_REPLACE:
+    case S_DOUBLE:
+    case S_INTEGER:
+    case S_IDENTIFIER:
+    case S_CHAR_LITERAL:
+    case S_QUOTED_IDENTIFIER:
+    case 92:
+    case 98:
+    case 109:
+    case 110:
+    case 113:
+    case 115:
+    case 116:
+    case 117:
+      switchExp = PrimaryExpression();
+      label_30:
+      while (true) {
+        switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+        case K_WHEN:
+          ;
+          break;
+        default:
+          jj_la1[142] = jj_gen;
+          break label_30;
+        }
+        clause = WhenThenValue();
+                                        whenClauses.add(clause);
+      }
+      switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+      case K_ELSE:
+        jj_consume_token(K_ELSE);
+        elseExp = PrimaryExpression();
+        break;
+      default:
+        jj_la1[143] = jj_gen;
+        ;
+      }
+      break;
     default:
-      jj_la1[142] = jj_gen;
+      jj_la1[144] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2958,12 +2978,12 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         String tmp = null;
         ExpressionList expressionList = null;
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-    case 116:
-      jj_consume_token(116);
+    case 117:
+      jj_consume_token(117);
                  retval.setEscaped(true);
       break;
     default:
-      jj_la1[143] = jj_gen;
+      jj_la1[145] = jj_gen;
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -2976,31 +2996,31 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                           funcName = "REPLACE";
       break;
     default:
-      jj_la1[144] = jj_gen;
+      jj_la1[146] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-    case 95:
-      jj_consume_token(95);
+    case 96:
+      jj_consume_token(96);
       tmp = RelObjectName();
                                   funcName+= "." + tmp;
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 95:
-        jj_consume_token(95);
+      case 96:
+        jj_consume_token(96);
         tmp = RelObjectName();
                                                                                      funcName+= "." + tmp;
         break;
       default:
-        jj_la1[145] = jj_gen;
+        jj_la1[147] = jj_gen;
         ;
       }
       break;
     default:
-      jj_la1[146] = jj_gen;
+      jj_la1[148] = jj_gen;
       ;
     }
-    jj_consume_token(91);
+    jj_consume_token(92);
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
     case K_ALL:
     case K_NULL:
@@ -3012,15 +3032,15 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     case S_IDENTIFIER:
     case S_CHAR_LITERAL:
     case S_QUOTED_IDENTIFIER:
-    case 91:
-    case 96:
+    case 92:
     case 97:
-    case 108:
+    case 98:
     case 109:
-    case 112:
-    case 114:
+    case 110:
+    case 113:
     case 115:
     case 116:
+    case 117:
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
       case K_ALL:
       case K_DISTINCT:
@@ -3034,13 +3054,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                                                   retval.setAllColumns(true);
           break;
         default:
-          jj_la1[147] = jj_gen;
+          jj_la1[149] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
         break;
       default:
-        jj_la1[148] = jj_gen;
+        jj_la1[150] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -3052,37 +3072,37 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       case S_IDENTIFIER:
       case S_CHAR_LITERAL:
       case S_QUOTED_IDENTIFIER:
-      case 91:
-      case 97:
-      case 108:
+      case 92:
+      case 98:
       case 109:
-      case 112:
-      case 114:
+      case 110:
+      case 113:
       case 115:
       case 116:
+      case 117:
         expressionList = SimpleExpressionList();
         break;
-      case 96:
-        jj_consume_token(96);
+      case 97:
+        jj_consume_token(97);
                                                                                                                                                 retval.setAllColumns(true);
         break;
       default:
-        jj_la1[149] = jj_gen;
+        jj_la1[151] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
     default:
-      jj_la1[150] = jj_gen;
+      jj_la1[152] = jj_gen;
       ;
     }
-    jj_consume_token(93);
+    jj_consume_token(94);
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-    case 113:
-      jj_consume_token(113);
+    case 114:
+      jj_consume_token(114);
       break;
     default:
-      jj_la1[151] = jj_gen;
+      jj_la1[153] = jj_gen;
       ;
     }
             retval.setParameters(expressionList);
@@ -3128,12 +3148,12 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       case S_INTEGER:
       case S_IDENTIFIER:
       case S_CHAR_LITERAL:
-      case 91:
-      case 94:
+      case 92:
+      case 95:
         ;
         break;
       default:
-        jj_la1[152] = jj_gen;
+        jj_la1[154] = jj_gen;
         break label_31;
       }
       CreateParameter();
@@ -3141,8 +3161,8 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     jj_consume_token(K_TABLE);
     table = Table();
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-    case 91:
-      jj_consume_token(91);
+    case 92:
+      jj_consume_token(92);
       columnName = jj_consume_token(S_IDENTIFIER);
       colDataType = ColDataType();
                         columnSpecs = new ArrayList();
@@ -3157,12 +3177,12 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         case S_INTEGER:
         case S_IDENTIFIER:
         case S_CHAR_LITERAL:
-        case 91:
-        case 94:
+        case 92:
+        case 95:
           ;
           break;
         default:
-          jj_la1[153] = jj_gen;
+          jj_la1[155] = jj_gen;
           break label_32;
         }
         parameter = CreateParameter();
@@ -3177,14 +3197,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       label_33:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 92:
+        case 93:
           ;
           break;
         default:
-          jj_la1[154] = jj_gen;
+          jj_la1[156] = jj_gen;
           break label_33;
         }
-        jj_consume_token(92);
+        jj_consume_token(93);
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
         case K_INDEX:
           tk = jj_consume_token(K_INDEX);
@@ -3230,12 +3250,12 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
             case S_INTEGER:
             case S_IDENTIFIER:
             case S_CHAR_LITERAL:
-            case 91:
-            case 94:
+            case 92:
+            case 95:
               ;
               break;
             default:
-              jj_la1[155] = jj_gen;
+              jj_la1[157] = jj_gen;
               break label_34;
             }
             parameter = CreateParameter();
@@ -3249,12 +3269,12 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
                                                 columnDefinitions.add(coldef);
           break;
         default:
-          jj_la1[156] = jj_gen;
+          jj_la1[158] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
       }
-      jj_consume_token(93);
+      jj_consume_token(94);
       label_35:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -3266,12 +3286,12 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         case S_INTEGER:
         case S_IDENTIFIER:
         case S_CHAR_LITERAL:
-        case 91:
-        case 94:
+        case 92:
+        case 95:
           ;
           break;
         default:
-          jj_la1[157] = jj_gen;
+          jj_la1[159] = jj_gen;
           break label_35;
         }
         parameter = CreateParameter();
@@ -3279,7 +3299,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       }
       break;
     default:
-      jj_la1[158] = jj_gen;
+      jj_la1[160] = jj_gen;
       ;
     }
                 createTable.setTable(table);
@@ -3300,7 +3320,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     tk = jj_consume_token(S_IDENTIFIER);
                               colDataType.setDataType(tk.image);
     if (jj_2_33(2)) {
-      jj_consume_token(91);
+      jj_consume_token(92);
       label_36:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -3309,7 +3329,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
           ;
           break;
         default:
-          jj_la1[159] = jj_gen;
+          jj_la1[161] = jj_gen;
           break label_36;
         }
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -3320,22 +3340,22 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
           tk = jj_consume_token(S_CHAR_LITERAL);
           break;
         default:
-          jj_la1[160] = jj_gen;
+          jj_la1[162] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
                                                                      argumentsStringList.add(tk.image);
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-        case 92:
-          jj_consume_token(92);
+        case 93:
+          jj_consume_token(93);
 
           break;
         default:
-          jj_la1[161] = jj_gen;
+          jj_la1[163] = jj_gen;
           ;
         }
       }
-      jj_consume_token(93);
+      jj_consume_token(94);
     } else {
       ;
     }
@@ -3381,15 +3401,15 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       tk = jj_consume_token(S_DOUBLE);
                                         retval = tk.image;
       break;
-    case 94:
-      jj_consume_token(94);
+    case 95:
+      jj_consume_token(95);
                               retval = "=";
       break;
-    case 91:
+    case 92:
       retval = AList();
       break;
     default:
-      jj_la1[162] = jj_gen;
+      jj_la1[164] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3400,7 +3420,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   final public String AList() throws ParseException {
         StringBuffer retval = new StringBuffer("(");
         Token tk = null;
-    jj_consume_token(91);
+    jj_consume_token(92);
     label_37:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -3411,7 +3431,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         ;
         break;
       default:
-        jj_la1[163] = jj_gen;
+        jj_la1[165] = jj_gen;
         break label_37;
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -3428,22 +3448,22 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         tk = jj_consume_token(S_IDENTIFIER);
         break;
       default:
-        jj_la1[164] = jj_gen;
+        jj_la1[166] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
                                                                                         retval.append(tk.image);
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 92:
-        jj_consume_token(92);
+      case 93:
+        jj_consume_token(93);
                                                                                                                          retval.append(",");
         break;
       default:
-        jj_la1[165] = jj_gen;
+        jj_la1[167] = jj_gen;
         ;
       }
     }
-    jj_consume_token(93);
+    jj_consume_token(94);
                 retval.append(")");
                 {if (true) return retval.toString();}
     throw new Error("Missing return statement in function");
@@ -3452,24 +3472,24 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   final public List ColumnsNamesList() throws ParseException {
         List retval = new ArrayList();
         Token tk = null;
-    jj_consume_token(91);
+    jj_consume_token(92);
     tk = jj_consume_token(S_IDENTIFIER);
                                     retval.add(tk.image);
     label_38:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-      case 92:
+      case 93:
         ;
         break;
       default:
-        jj_la1[166] = jj_gen;
+        jj_la1[168] = jj_gen;
         break label_38;
       }
-      jj_consume_token(92);
+      jj_consume_token(93);
       tk = jj_consume_token(S_IDENTIFIER);
                                           retval.add(tk.image);
     }
-    jj_consume_token(93);
+    jj_consume_token(94);
                 {if (true) return retval;}
     throw new Error("Missing return statement in function");
   }
@@ -3496,7 +3516,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       tk = jj_consume_token(K_LENS);
       break;
     default:
-      jj_la1[167] = jj_gen;
+      jj_la1[169] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3510,7 +3530,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         ;
         break;
       default:
-        jj_la1[168] = jj_gen;
+        jj_la1[170] = jj_gen;
         break label_39;
       }
       tk = jj_consume_token(S_IDENTIFIER);
@@ -3544,7 +3564,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       table = jj_consume_token(S_IDENTIFIER);
       break;
     default:
-      jj_la1[169] = jj_gen;
+      jj_la1[171] = jj_gen;
       ;
     }
     if(table == null){
@@ -3799,19 +3819,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     finally { jj_save(32, xla); }
   }
 
-  private boolean jj_3R_187() {
-    if (jj_3R_48()) return true;
-    return false;
-  }
-
   private boolean jj_3R_124() {
     if (jj_scan_token(K_UNION)) return true;
     Token xsp;
     xsp = jj_scanpos;
     if (jj_3R_169()) jj_scanpos = xsp;
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_122()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
@@ -3899,7 +3914,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_240() {
-    if (jj_scan_token(97)) return true;
+    if (jj_scan_token(98)) return true;
     return false;
   }
 
@@ -3917,19 +3932,19 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     Token xsp;
     xsp = jj_scanpos;
     if (jj_3R_186()) jj_scanpos = xsp;
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_47()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
   private boolean jj_3R_238() {
-    if (jj_scan_token(97)) return true;
+    if (jj_scan_token(98)) return true;
     return false;
   }
 
   private boolean jj_3R_102() {
-    if (jj_scan_token(111)) return true;
+    if (jj_scan_token(112)) return true;
     if (jj_3R_73()) return true;
     return false;
   }
@@ -3940,16 +3955,16 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_77() {
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_122()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     if (jj_scan_token(K_UNION)) return true;
     Token xsp;
     xsp = jj_scanpos;
     if (jj_3R_123()) jj_scanpos = xsp;
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_122()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     while (true) {
       xsp = jj_scanpos;
       if (jj_3R_124()) { jj_scanpos = xsp; break; }
@@ -3962,7 +3977,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_60() {
-    if (jj_scan_token(109)) return true;
+    if (jj_scan_token(110)) return true;
     return false;
   }
 
@@ -4011,7 +4026,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_63() {
-    if (jj_scan_token(96)) return true;
+    if (jj_scan_token(97)) return true;
     return false;
   }
 
@@ -4042,17 +4057,17 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_101() {
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_99()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
   private boolean jj_3R_228() {
     if (jj_scan_token(K_ON)) return true;
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_159()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
@@ -4072,9 +4087,9 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_246() {
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_220()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
@@ -4110,9 +4125,9 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_76() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(80)) {
+    if (jj_scan_token(81)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(87)) return true;
+    if (jj_scan_token(88)) return true;
     }
     return false;
   }
@@ -4153,7 +4168,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_59() {
-    if (jj_scan_token(108)) return true;
+    if (jj_scan_token(109)) return true;
     return false;
   }
 
@@ -4176,12 +4191,12 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_242() {
-    if (jj_scan_token(97)) return true;
+    if (jj_scan_token(98)) return true;
     return false;
   }
 
   private boolean jj_3R_230() {
-    if (jj_scan_token(97)) return true;
+    if (jj_scan_token(98)) return true;
     return false;
   }
 
@@ -4212,30 +4227,30 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_57() {
-    if (jj_scan_token(107)) return true;
+    if (jj_scan_token(108)) return true;
     return false;
   }
 
   private boolean jj_3R_56() {
-    if (jj_scan_token(106)) return true;
+    if (jj_scan_token(107)) return true;
     return false;
   }
 
   private boolean jj_3_33() {
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     Token xsp;
     while (true) {
       xsp = jj_scanpos;
       if (jj_3R_76()) { jj_scanpos = xsp; break; }
     }
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
   private boolean jj_3R_157() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(24)) {
+    if (jj_scan_token(25)) {
     jj_scanpos = xsp;
     if (jj_3R_207()) return true;
     }
@@ -4243,7 +4258,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_46() {
-    if (jj_scan_token(97)) return true;
+    if (jj_scan_token(98)) return true;
     return false;
   }
 
@@ -4384,7 +4399,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_151() {
-    if (jj_scan_token(96)) return true;
+    if (jj_scan_token(97)) return true;
     return false;
   }
 
@@ -4396,7 +4411,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     jj_scanpos = xsp;
     if (jj_3R_46()) return true;
     }
-    if (jj_scan_token(92)) return true;
+    if (jj_scan_token(93)) return true;
     xsp = jj_scanpos;
     if (jj_3R_237()) {
     jj_scanpos = xsp;
@@ -4434,7 +4449,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_147() {
-    if (jj_scan_token(105)) return true;
+    if (jj_scan_token(106)) return true;
     if (jj_3R_99()) return true;
     return false;
   }
@@ -4451,7 +4466,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
 
   private boolean jj_3_4() {
     if (jj_3R_41()) return true;
-    if (jj_scan_token(95)) return true;
+    if (jj_scan_token(96)) return true;
     if (jj_3R_41()) return true;
     return false;
   }
@@ -4477,14 +4492,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_143() {
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_55()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
   private boolean jj_3R_253() {
-    if (jj_scan_token(95)) return true;
+    if (jj_scan_token(96)) return true;
     if (jj_3R_41()) return true;
     return false;
   }
@@ -4500,7 +4515,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_236() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(30)) {
+    if (jj_scan_token(31)) {
     jj_scanpos = xsp;
     if (jj_3R_255()) return true;
     }
@@ -4518,13 +4533,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_217() {
-    if (jj_scan_token(92)) return true;
+    if (jj_scan_token(93)) return true;
     if (jj_3R_216()) return true;
     return false;
   }
 
   private boolean jj_3R_200() {
-    if (jj_scan_token(92)) return true;
+    if (jj_scan_token(93)) return true;
     if (jj_3R_91()) return true;
     return false;
   }
@@ -4554,15 +4569,15 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_41() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(84)) {
+    if (jj_scan_token(85)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(88)) return true;
+    if (jj_scan_token(89)) return true;
     }
     return false;
   }
 
   private boolean jj_3R_109() {
-    if (jj_scan_token(95)) return true;
+    if (jj_scan_token(96)) return true;
     if (jj_3R_41()) return true;
     Token xsp;
     xsp = jj_scanpos;
@@ -4573,13 +4588,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_248() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(26)) {
+    if (jj_scan_token(27)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(46)) return true;
+    if (jj_scan_token(47)) return true;
     }
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_54()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
@@ -4590,16 +4605,16 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_235() {
-    if (jj_scan_token(92)) return true;
+    if (jj_scan_token(93)) return true;
     if (jj_3R_91()) return true;
     return false;
   }
 
   private boolean jj_3R_247() {
     if (jj_scan_token(K_ALL)) return true;
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_54()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
@@ -4616,13 +4631,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_221() {
-    if (jj_scan_token(92)) return true;
+    if (jj_scan_token(93)) return true;
     if (jj_3R_40()) return true;
     return false;
   }
 
   private boolean jj_3R_148() {
-    if (jj_scan_token(95)) return true;
+    if (jj_scan_token(96)) return true;
     if (jj_3R_41()) return true;
     return false;
   }
@@ -4675,20 +4690,20 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_135() {
-    if (jj_scan_token(92)) return true;
+    if (jj_scan_token(93)) return true;
     return false;
   }
 
   private boolean jj_3R_185() {
     if (jj_scan_token(K_USING)) return true;
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_40()) return true;
     Token xsp;
     while (true) {
       xsp = jj_scanpos;
       if (jj_3R_221()) { jj_scanpos = xsp; break; }
     }
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
@@ -4759,7 +4774,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3_3() {
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     return false;
   }
 
@@ -4796,7 +4811,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     xsp = jj_scanpos;
     if (jj_3R_134()) jj_scanpos = xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(38)) {
+    if (jj_scan_token(39)) {
     jj_scanpos = xsp;
     if (jj_3R_135()) return true;
     }
@@ -4858,7 +4873,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_106() {
-    if (jj_scan_token(95)) return true;
+    if (jj_scan_token(96)) return true;
     if (jj_3R_41()) return true;
     Token xsp;
     xsp = jj_scanpos;
@@ -4867,7 +4882,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3_2() {
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_40()) return true;
     return false;
   }
@@ -4883,7 +4898,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_103() {
-    if (jj_scan_token(116)) return true;
+    if (jj_scan_token(117)) return true;
     return false;
   }
 
@@ -4898,12 +4913,12 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     }
     xsp = jj_scanpos;
     if (jj_3R_106()) jj_scanpos = xsp;
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     xsp = jj_scanpos;
     if (jj_3R_107()) jj_scanpos = xsp;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     xsp = jj_scanpos;
-    if (jj_scan_token(113)) jj_scanpos = xsp;
+    if (jj_scan_token(114)) jj_scanpos = xsp;
     return false;
   }
 
@@ -4960,7 +4975,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3_1() {
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_40()) return true;
     return false;
   }
@@ -5018,14 +5033,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_130() {
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     Token xsp;
     xsp = jj_scanpos;
     if (jj_3R_175()) {
     jj_scanpos = xsp;
     if (jj_3R_176()) return true;
     }
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
@@ -5054,7 +5069,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_234() {
-    if (jj_scan_token(92)) return true;
+    if (jj_scan_token(93)) return true;
     if (jj_3R_79()) return true;
     return false;
   }
@@ -5106,7 +5121,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_210() {
-    if (jj_scan_token(92)) return true;
+    if (jj_scan_token(93)) return true;
     if (jj_3R_209()) return true;
     return false;
   }
@@ -5117,13 +5132,13 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     xsp = jj_scanpos;
     if (jj_3R_92()) jj_scanpos = xsp;
     if (jj_scan_token(K_IN)) return true;
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     xsp = jj_scanpos;
     if (jj_3R_93()) {
     jj_scanpos = xsp;
     if (jj_3R_94()) return true;
     }
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
@@ -5143,7 +5158,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_205() {
-    if (jj_scan_token(109)) return true;
+    if (jj_scan_token(110)) return true;
     return false;
   }
 
@@ -5191,7 +5206,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_155() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(108)) {
+    if (jj_scan_token(109)) {
     jj_scanpos = xsp;
     if (jj_3R_205()) return true;
     }
@@ -5219,7 +5234,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_204() {
-    if (jj_scan_token(109)) return true;
+    if (jj_scan_token(110)) return true;
     return false;
   }
 
@@ -5255,7 +5270,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_154() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(108)) {
+    if (jj_scan_token(109)) {
     jj_scanpos = xsp;
     if (jj_3R_204()) return true;
     }
@@ -5265,31 +5280,31 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_75() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(108)) {
+    if (jj_scan_token(109)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(109)) return true;
+    if (jj_scan_token(110)) return true;
     }
     return false;
   }
 
   private boolean jj_3R_203() {
-    if (jj_scan_token(109)) return true;
+    if (jj_scan_token(110)) return true;
     return false;
   }
 
   private boolean jj_3R_43() {
     if (jj_3R_79()) return true;
-    if (jj_scan_token(95)) return true;
     if (jj_scan_token(96)) return true;
+    if (jj_scan_token(97)) return true;
     return false;
   }
 
   private boolean jj_3R_74() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(108)) {
+    if (jj_scan_token(109)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(109)) return true;
+    if (jj_scan_token(110)) return true;
     }
     return false;
   }
@@ -5318,7 +5333,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_153() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(108)) {
+    if (jj_scan_token(109)) {
     jj_scanpos = xsp;
     if (jj_3R_203()) return true;
     }
@@ -5344,37 +5359,37 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_197() {
-    if (jj_scan_token(104)) return true;
+    if (jj_scan_token(105)) return true;
     return false;
   }
 
   private boolean jj_3R_196() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(102)) {
+    if (jj_scan_token(103)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(103)) return true;
+    if (jj_scan_token(104)) return true;
     }
     return false;
   }
 
   private boolean jj_3R_195() {
-    if (jj_scan_token(101)) return true;
+    if (jj_scan_token(102)) return true;
     return false;
   }
 
   private boolean jj_3R_110() {
-    if (jj_scan_token(109)) return true;
+    if (jj_scan_token(110)) return true;
     return false;
   }
 
   private boolean jj_3R_231() {
-    if (jj_scan_token(96)) return true;
+    if (jj_scan_token(97)) return true;
     return false;
   }
 
   private boolean jj_3R_194() {
-    if (jj_scan_token(100)) return true;
+    if (jj_scan_token(101)) return true;
     return false;
   }
 
@@ -5384,7 +5399,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_108() {
-    if (jj_scan_token(109)) return true;
+    if (jj_scan_token(110)) return true;
     return false;
   }
 
@@ -5402,31 +5417,31 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_193() {
-    if (jj_scan_token(94)) return true;
+    if (jj_scan_token(95)) return true;
     return false;
   }
 
   private boolean jj_3R_192() {
-    if (jj_scan_token(99)) return true;
+    if (jj_scan_token(100)) return true;
     return false;
   }
 
   private boolean jj_3R_121() {
-    if (jj_scan_token(115)) return true;
+    if (jj_scan_token(116)) return true;
     if (jj_scan_token(S_CHAR_LITERAL)) return true;
-    if (jj_scan_token(113)) return true;
+    if (jj_scan_token(114)) return true;
     return false;
   }
 
   private boolean jj_3R_191() {
-    if (jj_scan_token(98)) return true;
+    if (jj_scan_token(99)) return true;
     return false;
   }
 
   private boolean jj_3R_72() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(108)) {
+    if (jj_scan_token(109)) {
     jj_scanpos = xsp;
     if (jj_3R_110()) return true;
     }
@@ -5436,7 +5451,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_71() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(108)) {
+    if (jj_scan_token(109)) {
     jj_scanpos = xsp;
     if (jj_3R_108()) return true;
     }
@@ -5444,9 +5459,9 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_120() {
-    if (jj_scan_token(114)) return true;
+    if (jj_scan_token(115)) return true;
     if (jj_scan_token(S_CHAR_LITERAL)) return true;
-    if (jj_scan_token(113)) return true;
+    if (jj_scan_token(114)) return true;
     return false;
   }
 
@@ -5456,14 +5471,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_206() {
-    if (jj_scan_token(109)) return true;
+    if (jj_scan_token(110)) return true;
     return false;
   }
 
   private boolean jj_3R_119() {
-    if (jj_scan_token(112)) return true;
-    if (jj_scan_token(S_CHAR_LITERAL)) return true;
     if (jj_scan_token(113)) return true;
+    if (jj_scan_token(S_CHAR_LITERAL)) return true;
+    if (jj_scan_token(114)) return true;
     return false;
   }
 
@@ -5499,9 +5514,9 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_70() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(108)) {
+    if (jj_scan_token(109)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(109)) return true;
+    if (jj_scan_token(110)) return true;
     }
     return false;
   }
@@ -5509,9 +5524,9 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_69() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(108)) {
+    if (jj_scan_token(109)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(109)) return true;
+    if (jj_scan_token(110)) return true;
     }
     return false;
   }
@@ -5524,9 +5539,9 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_67() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(108)) {
+    if (jj_scan_token(109)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(109)) return true;
+    if (jj_scan_token(110)) return true;
     }
     return false;
   }
@@ -5534,7 +5549,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_156() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(108)) {
+    if (jj_scan_token(109)) {
     jj_scanpos = xsp;
     if (jj_3R_206()) return true;
     }
@@ -5569,9 +5584,9 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     Token xsp;
     xsp = jj_scanpos;
     if (jj_3R_156()) jj_scanpos = xsp;
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_54()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
@@ -5594,9 +5609,9 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     Token xsp;
     xsp = jj_scanpos;
     if (jj_3R_72()) jj_scanpos = xsp;
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_73()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
@@ -5616,9 +5631,9 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private boolean jj_3R_174() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(24)) {
+    if (jj_scan_token(25)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(76)) return true;
+    if (jj_scan_token(77)) return true;
     }
     return false;
   }
@@ -5683,16 +5698,16 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_113() {
-    if (jj_scan_token(97)) return true;
+    if (jj_scan_token(98)) return true;
     return false;
   }
 
   private boolean jj_3R_169() {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(24)) {
+    if (jj_scan_token(25)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(76)) return true;
+    if (jj_scan_token(77)) return true;
     }
     return false;
   }
@@ -5703,7 +5718,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_64() {
-    if (jj_scan_token(110)) return true;
+    if (jj_scan_token(111)) return true;
     return false;
   }
 
@@ -5731,9 +5746,9 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     Token xsp;
     xsp = jj_scanpos;
     if (jj_3R_222()) jj_scanpos = xsp;
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_47()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
     return false;
   }
 
@@ -5752,7 +5767,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_257() {
-    if (jj_scan_token(97)) return true;
+    if (jj_scan_token(98)) return true;
     return false;
   }
 
@@ -5762,9 +5777,14 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   }
 
   private boolean jj_3R_66() {
-    if (jj_scan_token(91)) return true;
+    if (jj_scan_token(92)) return true;
     if (jj_3R_99()) return true;
-    if (jj_scan_token(93)) return true;
+    if (jj_scan_token(94)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_187() {
+    if (jj_3R_48()) return true;
     return false;
   }
 
@@ -5779,7 +5799,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   private Token jj_scanpos, jj_lastpos;
   private int jj_la;
   private int jj_gen;
-  final private int[] jj_la1 = new int[170];
+  final private int[] jj_la1 = new int[172];
   static private int[] jj_la1_0;
   static private int[] jj_la1_1;
   static private int[] jj_la1_2;
@@ -5791,16 +5811,16 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
       jj_la1_init_3();
    }
    private static void jj_la1_init_0() {
-      jj_la1_0 = new int[] {0x22180,0x1,0x22181,0x18000c00,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200,0x200,0x0,0x0,0x0,0x0,0x0,0x20000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x20,0x0,0x0,0x0,0x800000,0x1000000,0x1000000,0x80000000,0x0,0x0,0x0,0x0,0x0,0x0,0x1000000,0x1000000,0x0,0x1000000,0x1000000,0x0,0x0,0x1000000,0x1000000,0x0,0x1000000,0x1000000,0x0,0x0,0x0,0x0,0x20,0x0,0x0,0x20,0x0,0x0,0x0,0x20,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x800000,0x800000,0x0,0x0,0x40000000,0x40000000,0x0,0x0,0x0,0x1000000,0x0,0x0,0x0,0x0,0x0,0x10000000,0x10000000,0x10000000,0x10000000,0x15000000,0x10000000,0x0,0x0,0x0,0x10000000,0x0,0x10000000,0x10000000,0x0,0x10000000,0x10000000,0x0,0x0,0x5000000,0x4000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1000000,0x1000000,0x0,0x1000000,0x0,0x18000000,0x18000000,0x0,0x18000000,0x8000000,0x18000000,0x0,0x0,0x0,0x0,0x18000000,0x0,0x0,0x0,0x0,0xc00,0x0,0x20,};
+      jj_la1_0 = new int[] {0x22180,0x1,0x22181,0x30000c00,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200,0x200,0x0,0x0,0x0,0x0,0x0,0x40000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x20,0x0,0x0,0x0,0x1000000,0x2000000,0x2000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x2000000,0x2000000,0x0,0x2000000,0x2000000,0x0,0x0,0x2000000,0x2000000,0x0,0x2000000,0x2000000,0x0,0x0,0x0,0x0,0x20,0x0,0x0,0x20,0x0,0x0,0x0,0x20,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1000000,0x1000000,0x0,0x0,0x80000000,0x80000000,0x0,0x0,0x0,0x2000000,0x0,0x0,0x0,0x0,0x0,0x20000000,0x20000000,0x20000000,0x20000000,0x2a000000,0x20000000,0x0,0x0,0x0,0x20000000,0x0,0x20000000,0x20000000,0x0,0x20000000,0x20000000,0x0,0x0,0xa000000,0x8000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x2000000,0x2000000,0x0,0x2000000,0x0,0x30000000,0x30000000,0x0,0x30000000,0x10000000,0x30000000,0x0,0x0,0x0,0x0,0x30000000,0x0,0x0,0x0,0x0,0xc00,0x0,0x20,};
    }
    private static void jj_la1_init_1() {
-      jj_la1_1 = new int[] {0xe0010020,0x0,0xe0010020,0x20008,0x0,0x0,0x0,0x0,0x40000,0x408,0x0,0x408,0x408,0x0,0x0,0x4,0x0,0x0,0x0,0x80000000,0x80000000,0x4,0x0,0x0,0x0,0x80000000,0x100,0x40000,0x0,0x0,0x0,0x0,0x0,0x10000,0x80000000,0x0,0x0,0x0,0x0,0x4,0x40000,0x200000,0x0,0x8000000,0x2000000,0x0,0x0,0x100000,0x0,0x0,0x8000000,0x2000000,0x0,0x0,0x100000,0x0,0x0,0x80000000,0x0,0x0,0x0,0x0,0x0,0x408,0x0,0x0,0x80000000,0x0,0x0,0x150080c0,0x10008080,0x10008080,0x5000000,0x5000000,0x40,0x0,0x80000,0x80000,0x0,0x0,0x2,0x2,0x0,0x0,0x0,0x0,0x0,0x0,0x2000000,0x0,0x0,0x0,0x0,0x0,0x0,0x4408,0x0,0x0,0x0,0x408,0x0,0x408,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x4408,0x4000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x408,0x0,0x0,0x0,0x0,0x0,0x0,0x800,0x2000,0x800,0x2000,0xc08,0x0,0x0,0x0,0x0,0x0,0x0,0x408,0x408,0x0,0x8,0x8,0x0,0x8,0x800000,0x8,0x0,0x0,0x0,0x0,0x8,0x0,0x0,0x0,0x0,0x820000,0x0,0x0,};
+      jj_la1_1 = new int[] {0xc0020040,0x0,0xc0020040,0x40010,0x0,0x0,0x0,0x0,0x80000,0x0,0x0,0x810,0x0,0x810,0x810,0x0,0x0,0x8,0x0,0x0,0x0,0x0,0x0,0x8,0x0,0x0,0x0,0x0,0x200,0x80000,0x0,0x0,0x0,0x0,0x0,0x20000,0x0,0x0,0x0,0x0,0x1,0x8,0x80000,0x400000,0x0,0x10000000,0x4000000,0x0,0x0,0x200000,0x0,0x0,0x10000000,0x4000000,0x0,0x0,0x200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x810,0x0,0x0,0x0,0x0,0x0,0x2a010180,0x20010100,0x20010100,0xa000000,0xa000000,0x80,0x0,0x100000,0x100000,0x0,0x0,0x4,0x4,0x0,0x0,0x0,0x0,0x0,0x0,0x4000000,0x0,0x0,0x0,0x0,0x0,0x0,0x8810,0x0,0x0,0x0,0x810,0x0,0x810,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8810,0x8000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x810,0x0,0x0,0x0,0x0,0x0,0x0,0x1000,0x4000,0x1000,0x4000,0x1810,0x0,0x0,0x0,0x0,0x0,0x0,0x810,0x810,0x0,0x10,0x10,0x0,0x10,0x1000000,0x10,0x0,0x0,0x0,0x0,0x10,0x0,0x0,0x0,0x0,0x1040000,0x0,0x0,};
    }
    private static void jj_la1_init_2() {
-      jj_la1_2 = new int[] {0x8004a18,0x2000000,0x8004a18,0x48918080,0x4000000,0x10000000,0x8000000,0x10000000,0x0,0x9918200,0x10000000,0x9918200,0x9918200,0x0,0x0,0x0,0x10000000,0x10000000,0x10000000,0x8000020,0x8000020,0x0,0x10000000,0x10000000,0x20000000,0x8000020,0x0,0x0,0x80000000,0x80000000,0x1100000,0x1100000,0x1100000,0x0,0x0,0x0,0x1000,0x1000,0x0,0x0,0x0,0x0,0x4,0x0,0x1,0x1000,0x1000,0x0,0x1000,0x1000,0x0,0x1,0x1000,0x1000,0x0,0x1000,0x1000,0x8000000,0x10000000,0x8000000,0x10000000,0x1100000,0x0,0x9918200,0x0,0x10000000,0x8000000,0x9100000,0x1100000,0x10000100,0x100,0x100,0x0,0x0,0x10000000,0x10000000,0x0,0x0,0x10000000,0x10000000,0x0,0x0,0x10000,0x10000,0x10000,0x10000,0x10000,0x1,0x1,0x10000,0x8000000,0x0,0x8000000,0x0,0x8000000,0x9918200,0x0,0x0,0x40000000,0x9918200,0x0,0x9918200,0x0,0x0,0x40,0x0,0x0,0x10000000,0x10000000,0x9918200,0x0,0x8000000,0x0,0x0,0x0,0x8000000,0x0,0x8000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8800000,0x0,0x0,0x0,0x0,0x800000,0x0,0x0,0x0,0x0,0x9918200,0x0,0x1100200,0x80000000,0x80000000,0x1000,0x1000,0x9918200,0x9919200,0x0,0x48918080,0x48918080,0x10000000,0x48918080,0x100080,0x48918080,0x8000000,0x810000,0x810000,0x10000000,0x48918080,0x918000,0x918000,0x10000000,0x10000000,0x100000,0x100000,0x0,};
+      jj_la1_2 = new int[] {0x10009431,0x4000000,0x10009431,0x91230100,0x8000000,0x20000000,0x10000000,0x20000000,0x0,0x2200000,0x3230000,0x13230400,0x20000000,0x13230400,0x13230400,0x0,0x0,0x0,0x20000000,0x20000000,0x20000000,0x10000041,0x10000041,0x0,0x20000000,0x20000000,0x40000000,0x10000041,0x0,0x0,0x0,0x0,0x2200000,0x2200000,0x2200000,0x0,0x1,0x0,0x2000,0x2000,0x0,0x0,0x0,0x0,0x8,0x0,0x2,0x2000,0x2000,0x0,0x2000,0x2000,0x0,0x2,0x2000,0x2000,0x0,0x2000,0x2000,0x10000001,0x20000000,0x10000000,0x20000000,0x2200000,0x0,0x13230400,0x0,0x20000000,0x10000001,0x12200000,0x2200000,0x20000200,0x200,0x200,0x0,0x0,0x20000000,0x20000000,0x0,0x0,0x20000000,0x20000000,0x0,0x0,0x20000,0x20000,0x20000,0x20000,0x20000,0x2,0x2,0x20000,0x10000000,0x0,0x10000000,0x0,0x10000000,0x13230400,0x0,0x0,0x80000000,0x13230400,0x0,0x13230400,0x0,0x0,0x80,0x0,0x0,0x20000000,0x20000000,0x13230400,0x0,0x10000000,0x0,0x0,0x0,0x10000000,0x0,0x10000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x11000000,0x0,0x0,0x0,0x0,0x1000000,0x0,0x0,0x0,0x0,0x13230400,0x0,0x2200400,0x0,0x0,0x2000,0x2000,0x13230400,0x13232400,0x0,0x91230100,0x91230100,0x20000000,0x91230100,0x200100,0x91230100,0x10000000,0x1020000,0x1020000,0x20000000,0x91230100,0x1230000,0x1230000,0x20000000,0x20000000,0x200000,0x200000,0x0,};
    }
    private static void jj_la1_init_3() {
-      jj_la1_3 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1d3002,0x0,0x1d3002,0x1d3002,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1,0x1d3002,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x2,0x2,0x2,0x2,0x2,0x0,0x0,0x2,0x0,0x0,0x0,0x0,0x0,0x1d3002,0x0,0xc0,0x1fc,0x1d3002,0x0,0x1d3002,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1d3002,0x0,0x0,0x200,0xc00,0x3000,0x0,0x4001,0x0,0x8000,0x3000,0x3000,0x3000,0x3000,0x3000,0x3000,0x3000,0x3000,0x3000,0x3000,0x3000,0x3000,0x2,0xd3000,0x3000,0x3000,0x3000,0x3000,0xd0000,0x0,0x0,0x0,0x0,0x1d3002,0x100000,0x0,0x0,0x0,0x0,0x0,0x1d3003,0x1d3003,0x20000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
+      jj_la1_3 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1a6000,0x3a6004,0x0,0x3a6004,0x3a6004,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x2,0x3a6004,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x4,0x4,0x4,0x4,0x4,0x0,0x0,0x4,0x0,0x0,0x0,0x0,0x0,0x3a6004,0x0,0x180,0x3f8,0x3a6004,0x0,0x3a6004,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3a6004,0x0,0x0,0x400,0x1800,0x6000,0x0,0x8002,0x0,0x10000,0x6000,0x6000,0x6000,0x6000,0x6000,0x6000,0x6000,0x6000,0x6000,0x6000,0x6000,0x6000,0x4,0x1a6000,0x6000,0x6000,0x6000,0x6000,0x1a0000,0x0,0x0,0x0,0x0,0x3a6004,0x200000,0x0,0x1,0x1,0x0,0x0,0x3a6006,0x3a6006,0x40000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
    }
   final private JJCalls[] jj_2_rtns = new JJCalls[33];
   private boolean jj_rescan = false;
@@ -5817,7 +5837,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     token = new Token();
     jj_ntk = -1;
     jj_gen = 0;
-    for (int i = 0; i < 170; i++) jj_la1[i] = -1;
+    for (int i = 0; i < 172; i++) jj_la1[i] = -1;
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -5832,7 +5852,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     token = new Token();
     jj_ntk = -1;
     jj_gen = 0;
-    for (int i = 0; i < 170; i++) jj_la1[i] = -1;
+    for (int i = 0; i < 172; i++) jj_la1[i] = -1;
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -5843,7 +5863,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     token = new Token();
     jj_ntk = -1;
     jj_gen = 0;
-    for (int i = 0; i < 170; i++) jj_la1[i] = -1;
+    for (int i = 0; i < 172; i++) jj_la1[i] = -1;
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -5854,7 +5874,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     token = new Token();
     jj_ntk = -1;
     jj_gen = 0;
-    for (int i = 0; i < 170; i++) jj_la1[i] = -1;
+    for (int i = 0; i < 172; i++) jj_la1[i] = -1;
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -5864,7 +5884,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     token = new Token();
     jj_ntk = -1;
     jj_gen = 0;
-    for (int i = 0; i < 170; i++) jj_la1[i] = -1;
+    for (int i = 0; i < 172; i++) jj_la1[i] = -1;
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -5874,7 +5894,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
     token = new Token();
     jj_ntk = -1;
     jj_gen = 0;
-    for (int i = 0; i < 170; i++) jj_la1[i] = -1;
+    for (int i = 0; i < 172; i++) jj_la1[i] = -1;
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -5986,12 +6006,12 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
   /** Generate ParseException. */
   public ParseException generateParseException() {
     jj_expentries.clear();
-    boolean[] la1tokens = new boolean[117];
+    boolean[] la1tokens = new boolean[118];
     if (jj_kind >= 0) {
       la1tokens[jj_kind] = true;
       jj_kind = -1;
     }
-    for (int i = 0; i < 170; i++) {
+    for (int i = 0; i < 172; i++) {
       if (jj_la1[i] == jj_gen) {
         for (int j = 0; j < 32; j++) {
           if ((jj_la1_0[i] & (1<<j)) != 0) {
@@ -6009,7 +6029,7 @@ public class MimirJSqlParser implements MimirJSqlParserConstants {
         }
       }
     }
-    for (int i = 0; i < 117; i++) {
+    for (int i = 0; i < 118; i++) {
       if (la1tokens[i]) {
         jj_expentry = new int[1];
         jj_expentry[0] = i;

--- a/src/main/java/mimir/parser/MimirJSqlParserConstants.java
+++ b/src/main/java/mimir/parser/MimirJSqlParserConstants.java
@@ -70,137 +70,139 @@ public interface MimirJSqlParserConstants {
   /** RegularExpression Id. */
   int K_OR = 22;
   /** RegularExpression Id. */
-  int K_ON = 23;
+  int K_OF = 23;
   /** RegularExpression Id. */
-  int K_ALL = 24;
+  int K_ON = 24;
   /** RegularExpression Id. */
-  int K_AND = 25;
+  int K_ALL = 25;
   /** RegularExpression Id. */
-  int K_ANY = 26;
+  int K_AND = 26;
   /** RegularExpression Id. */
-  int K_KEY = 27;
+  int K_ANY = 27;
   /** RegularExpression Id. */
-  int K_NOT = 28;
+  int K_KEY = 28;
   /** RegularExpression Id. */
-  int K_SET = 29;
+  int K_NOT = 29;
   /** RegularExpression Id. */
-  int K_ASC = 30;
+  int K_SET = 30;
   /** RegularExpression Id. */
-  int K_TOP = 31;
+  int K_ASC = 31;
   /** RegularExpression Id. */
-  int K_END = 32;
+  int K_TOP = 32;
   /** RegularExpression Id. */
-  int K_DESC = 33;
+  int K_END = 33;
   /** RegularExpression Id. */
-  int K_INTO = 34;
+  int K_DESC = 34;
   /** RegularExpression Id. */
-  int K_NULL = 35;
+  int K_INTO = 35;
   /** RegularExpression Id. */
-  int K_LIKE = 36;
+  int K_NULL = 36;
   /** RegularExpression Id. */
-  int K_DROP = 37;
+  int K_LIKE = 37;
   /** RegularExpression Id. */
-  int K_JOIN = 38;
+  int K_DROP = 38;
   /** RegularExpression Id. */
-  int K_LEFT = 39;
+  int K_JOIN = 39;
   /** RegularExpression Id. */
-  int K_FROM = 40;
+  int K_LEFT = 40;
   /** RegularExpression Id. */
-  int K_OPEN = 41;
+  int K_FROM = 41;
   /** RegularExpression Id. */
-  int K_CASE = 42;
+  int K_OPEN = 42;
   /** RegularExpression Id. */
-  int K_WHEN = 43;
+  int K_CASE = 43;
   /** RegularExpression Id. */
-  int K_THEN = 44;
+  int K_WHEN = 44;
   /** RegularExpression Id. */
-  int K_ELSE = 45;
+  int K_THEN = 45;
   /** RegularExpression Id. */
-  int K_SOME = 46;
+  int K_ELSE = 46;
   /** RegularExpression Id. */
-  int K_FULL = 47;
+  int K_SOME = 47;
   /** RegularExpression Id. */
-  int K_WITH = 48;
+  int K_FULL = 48;
   /** RegularExpression Id. */
-  int K_TABLE = 49;
+  int K_WITH = 49;
   /** RegularExpression Id. */
-  int K_WHERE = 50;
+  int K_TABLE = 50;
   /** RegularExpression Id. */
-  int K_USING = 51;
+  int K_WHERE = 51;
   /** RegularExpression Id. */
-  int K_UNION = 52;
+  int K_USING = 52;
   /** RegularExpression Id. */
-  int K_GROUP = 53;
+  int K_UNION = 53;
   /** RegularExpression Id. */
-  int K_BEGIN = 54;
+  int K_GROUP = 54;
   /** RegularExpression Id. */
-  int K_INDEX = 55;
+  int K_BEGIN = 55;
   /** RegularExpression Id. */
-  int K_INNER = 56;
+  int K_INDEX = 56;
   /** RegularExpression Id. */
-  int K_LIMIT = 57;
+  int K_INNER = 57;
   /** RegularExpression Id. */
-  int K_OUTER = 58;
+  int K_LIMIT = 58;
   /** RegularExpression Id. */
-  int K_ORDER = 59;
+  int K_OUTER = 59;
   /** RegularExpression Id. */
-  int K_RIGHT = 60;
+  int K_ORDER = 60;
   /** RegularExpression Id. */
-  int K_DELETE = 61;
+  int K_RIGHT = 61;
   /** RegularExpression Id. */
-  int K_CREATE = 62;
+  int K_DELETE = 62;
   /** RegularExpression Id. */
-  int K_SELECT = 63;
+  int K_CREATE = 63;
   /** RegularExpression Id. */
-  int K_OFFSET = 64;
+  int K_SELECT = 64;
   /** RegularExpression Id. */
-  int K_EXISTS = 65;
+  int K_OFFSET = 65;
   /** RegularExpression Id. */
-  int K_HAVING = 66;
+  int K_EXISTS = 66;
   /** RegularExpression Id. */
-  int K_INSERT = 67;
+  int K_HAVING = 67;
   /** RegularExpression Id. */
-  int K_UPDATE = 68;
+  int K_INSERT = 68;
   /** RegularExpression Id. */
-  int K_VALUES = 69;
+  int K_UPDATE = 69;
   /** RegularExpression Id. */
-  int K_ESCAPE = 70;
+  int K_VALUES = 70;
   /** RegularExpression Id. */
-  int K_PRIMARY = 71;
+  int K_ESCAPE = 71;
   /** RegularExpression Id. */
-  int K_NATURAL = 72;
+  int K_PRIMARY = 72;
   /** RegularExpression Id. */
-  int K_REPLACE = 73;
+  int K_NATURAL = 73;
   /** RegularExpression Id. */
-  int K_BETWEEN = 74;
+  int K_REPLACE = 74;
   /** RegularExpression Id. */
-  int K_TRUNCATE = 75;
+  int K_BETWEEN = 75;
   /** RegularExpression Id. */
-  int K_DISTINCT = 76;
+  int K_TRUNCATE = 76;
   /** RegularExpression Id. */
-  int K_INTERSECT = 77;
+  int K_DISTINCT = 77;
   /** RegularExpression Id. */
-  int K_FEEDBACK = 78;
+  int K_INTERSECT = 78;
   /** RegularExpression Id. */
-  int S_DOUBLE = 79;
+  int K_FEEDBACK = 79;
   /** RegularExpression Id. */
-  int S_INTEGER = 80;
+  int S_DOUBLE = 80;
   /** RegularExpression Id. */
-  int DIGIT = 81;
+  int S_INTEGER = 81;
   /** RegularExpression Id. */
-  int LINE_COMMENT = 82;
+  int DIGIT = 82;
   /** RegularExpression Id. */
-  int MULTI_LINE_COMMENT = 83;
+  int LINE_COMMENT = 83;
   /** RegularExpression Id. */
-  int S_IDENTIFIER = 84;
+  int MULTI_LINE_COMMENT = 84;
   /** RegularExpression Id. */
-  int LETTER = 85;
+  int S_IDENTIFIER = 85;
   /** RegularExpression Id. */
-  int SPECIAL_CHARS = 86;
+  int LETTER = 86;
   /** RegularExpression Id. */
-  int S_CHAR_LITERAL = 87;
+  int SPECIAL_CHARS = 87;
   /** RegularExpression Id. */
-  int S_QUOTED_IDENTIFIER = 88;
+  int S_CHAR_LITERAL = 88;
+  /** RegularExpression Id. */
+  int S_QUOTED_IDENTIFIER = 89;
 
   /** Lexical state. */
   int DEFAULT = 0;
@@ -230,6 +232,7 @@ public interface MimirJSqlParserConstants {
     "\"IS\"",
     "\"IN\"",
     "\"OR\"",
+    "\"OF\"",
     "\"ON\"",
     "\"ALL\"",
     "\"AND\"",

--- a/src/main/java/mimir/parser/MimirJSqlParserTokenManager.java
+++ b/src/main/java/mimir/parser/MimirJSqlParserTokenManager.java
@@ -117,89 +117,89 @@ private final int jjStopStringLiteralDfa_0(int pos, long active0, long active1)
    switch (pos)
    {
       case 0:
-         if ((active1 & 0x400000000000L) != 0L)
+         if ((active1 & 0x800000000000L) != 0L)
             return 8;
-         if ((active0 & 0xffffffffffffffe0L) != 0L || (active1 & 0x7fffL) != 0L)
+         if ((active0 & 0xffffffffffffffe0L) != 0L || (active1 & 0xffffL) != 0L)
          {
-            jjmatchedKind = 84;
+            jjmatchedKind = 85;
             return 36;
          }
-         if ((active1 & 0x80000000L) != 0L)
+         if ((active1 & 0x100000000L) != 0L)
             return 1;
-         if ((active1 & 0x200000000000L) != 0L)
+         if ((active1 & 0x400000000000L) != 0L)
             return 5;
          return -1;
       case 1:
-         if ((active0 & 0xf67ffffbbf03fdc0L) != 0L || (active1 & 0x5ff7L) != 0L)
+         if ((active0 & 0xecfffff77e03fdc0L) != 0L || (active1 & 0xbfedL) != 0L)
          {
             if (jjmatchedPos != 1)
             {
-               jjmatchedKind = 84;
+               jjmatchedKind = 85;
                jjmatchedPos = 1;
             }
             return 36;
          }
-         if ((active0 & 0x980000440fc0220L) != 0L || (active1 & 0x2008L) != 0L)
+         if ((active0 & 0x1300000881fc0220L) != 0L || (active1 & 0x4012L) != 0L)
             return 36;
          return -1;
       case 2:
-         if ((active0 & 0xfffffffe0003efc0L) != 0L || (active1 & 0x7fffL) != 0L)
+         if ((active0 & 0xfffffffc0003efc0L) != 0L || (active1 & 0xffffL) != 0L)
          {
-            jjmatchedKind = 84;
+            jjmatchedKind = 85;
             jjmatchedPos = 2;
             return 36;
          }
-         if ((active0 & 0x1ff001000L) != 0L)
+         if ((active0 & 0x3fe001000L) != 0L)
             return 36;
          return -1;
       case 3:
-         if ((active0 & 0xfffe0000000343c0L) != 0L || (active1 & 0x7fffL) != 0L)
+         if ((active0 & 0xfffc0000000343c0L) != 0L || (active1 & 0xffffL) != 0L)
          {
-            jjmatchedKind = 84;
+            jjmatchedKind = 85;
             jjmatchedPos = 3;
             return 36;
          }
-         if ((active0 & 0x1fffe0000ac00L) != 0L)
+         if ((active0 & 0x3fffc0000ac00L) != 0L)
             return 36;
          return -1;
       case 4:
-         if ((active0 & 0xe0000000000303c0L) != 0L || (active1 & 0x7fffL) != 0L)
+         if ((active0 & 0xc0000000000303c0L) != 0L || (active1 & 0xffffL) != 0L)
          {
-            jjmatchedKind = 84;
+            jjmatchedKind = 85;
             jjmatchedPos = 4;
             return 36;
          }
-         if ((active0 & 0x1ffe000000004000L) != 0L)
+         if ((active0 & 0x3ffc000000004000L) != 0L)
             return 36;
          return -1;
       case 5:
-         if ((active0 & 0x1c0L) != 0L || (active1 & 0x7f80L) != 0L)
+         if ((active0 & 0xc000000000030200L) != 0L || (active1 & 0xffL) != 0L)
+            return 36;
+         if ((active0 & 0x1c0L) != 0L || (active1 & 0xff00L) != 0L)
          {
-            jjmatchedKind = 84;
+            jjmatchedKind = 85;
             jjmatchedPos = 5;
             return 36;
          }
-         if ((active0 & 0xe000000000030200L) != 0L || (active1 & 0x7fL) != 0L)
-            return 36;
          return -1;
       case 6:
-         if ((active0 & 0x40L) != 0L || (active1 & 0x7800L) != 0L)
+         if ((active0 & 0x40L) != 0L || (active1 & 0xf000L) != 0L)
          {
-            jjmatchedKind = 84;
+            jjmatchedKind = 85;
             jjmatchedPos = 6;
             return 36;
          }
-         if ((active0 & 0x180L) != 0L || (active1 & 0x780L) != 0L)
+         if ((active0 & 0x180L) != 0L || (active1 & 0xf00L) != 0L)
             return 36;
          return -1;
       case 7:
-         if ((active0 & 0x40L) != 0L || (active1 & 0x2000L) != 0L)
+         if ((active0 & 0x40L) != 0L || (active1 & 0x4000L) != 0L)
          {
-            jjmatchedKind = 84;
+            jjmatchedKind = 85;
             jjmatchedPos = 7;
             return 36;
          }
-         if ((active1 & 0x5800L) != 0L)
+         if ((active1 & 0xb000L) != 0L)
             return 36;
          return -1;
       default :
@@ -221,113 +221,113 @@ private int jjMoveStringLiteralDfa0_0()
    switch(curChar)
    {
       case 33:
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x8000000000L);
-      case 38:
-         return jjStopAtPos(0, 107);
-      case 40:
-         return jjStopAtPos(0, 91);
-      case 41:
-         return jjStopAtPos(0, 93);
-      case 42:
-         return jjStopAtPos(0, 96);
-      case 43:
-         return jjStopAtPos(0, 108);
-      case 44:
-         return jjStopAtPos(0, 92);
-      case 45:
-         return jjStartNfaWithStates_0(0, 109, 5);
-      case 46:
-         return jjStartNfaWithStates_0(0, 95, 1);
-      case 47:
-         return jjStartNfaWithStates_0(0, 110, 8);
-      case 58:
-         return jjStopAtPos(0, 90);
-      case 59:
-         return jjStopAtPos(0, 89);
-      case 60:
-         jjmatchedKind = 99;
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x6000000000L);
-      case 61:
-         return jjStopAtPos(0, 94);
-      case 62:
-         jjmatchedKind = 98;
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x1000000000L);
-      case 63:
-         return jjStopAtPos(0, 97);
-      case 64:
          return jjMoveStringLiteralDfa1_0(0x0L, 0x10000000000L);
+      case 38:
+         return jjStopAtPos(0, 108);
+      case 40:
+         return jjStopAtPos(0, 92);
+      case 41:
+         return jjStopAtPos(0, 94);
+      case 42:
+         return jjStopAtPos(0, 97);
+      case 43:
+         return jjStopAtPos(0, 109);
+      case 44:
+         return jjStopAtPos(0, 93);
+      case 45:
+         return jjStartNfaWithStates_0(0, 110, 5);
+      case 46:
+         return jjStartNfaWithStates_0(0, 96, 1);
+      case 47:
+         return jjStartNfaWithStates_0(0, 111, 8);
+      case 58:
+         return jjStopAtPos(0, 91);
+      case 59:
+         return jjStopAtPos(0, 90);
+      case 60:
+         jjmatchedKind = 100;
+         return jjMoveStringLiteralDfa1_0(0x0L, 0xc000000000L);
+      case 61:
+         return jjStopAtPos(0, 95);
+      case 62:
+         jjmatchedKind = 99;
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x2000000000L);
+      case 63:
+         return jjStopAtPos(0, 98);
+      case 64:
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x20000000000L);
       case 94:
-         return jjStopAtPos(0, 111);
+         return jjStopAtPos(0, 112);
       case 65:
       case 97:
-         return jjMoveStringLiteralDfa1_0(0x470042a0L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x8e0042a0L, 0x0L);
       case 66:
       case 98:
-         return jjMoveStringLiteralDfa1_0(0x40000000040000L, 0x400L);
+         return jjMoveStringLiteralDfa1_0(0x80000000040000L, 0x800L);
       case 67:
       case 99:
-         return jjMoveStringLiteralDfa1_0(0x4000040000000000L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x8000080000000000L, 0x0L);
       case 68:
       case 100:
-         return jjMoveStringLiteralDfa1_0(0x2000002200080000L, 0x1000L);
+         return jjMoveStringLiteralDfa1_0(0x4000004400080000L, 0x2000L);
       case 69:
       case 101:
-         return jjMoveStringLiteralDfa1_0(0x200100000100L, 0x42L);
+         return jjMoveStringLiteralDfa1_0(0x400200000100L, 0x84L);
       case 70:
       case 102:
-         return jjMoveStringLiteralDfa1_0(0x810000000000L, 0x4000L);
+         return jjMoveStringLiteralDfa1_0(0x1020000000000L, 0x8000L);
       case 71:
       case 103:
-         return jjMoveStringLiteralDfa1_0(0x20000000000000L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x40000000000000L, 0x0L);
       case 72:
       case 104:
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x4L);
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x8L);
       case 73:
       case 105:
-         return jjMoveStringLiteralDfa1_0(0x180000400300000L, 0x2008L);
+         return jjMoveStringLiteralDfa1_0(0x300000800300000L, 0x4010L);
       case 74:
       case 106:
-         return jjMoveStringLiteralDfa1_0(0x4000000000L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x8000000000L, 0x0L);
       case 75:
       case 107:
-         return jjMoveStringLiteralDfa1_0(0x8000000L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x10000000L, 0x0L);
       case 76:
       case 108:
-         return jjMoveStringLiteralDfa1_0(0x200009000003800L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x400012000003800L, 0x0L);
       case 78:
       case 110:
-         return jjMoveStringLiteralDfa1_0(0x810000000L, 0x100L);
+         return jjMoveStringLiteralDfa1_0(0x1020000000L, 0x200L);
       case 79:
       case 111:
-         return jjMoveStringLiteralDfa1_0(0xc00020000c00000L, 0x1L);
+         return jjMoveStringLiteralDfa1_0(0x1800040001c00000L, 0x2L);
       case 80:
       case 112:
-         return jjMoveStringLiteralDfa1_0(0x20000L, 0x80L);
+         return jjMoveStringLiteralDfa1_0(0x20000L, 0x100L);
       case 82:
       case 114:
-         return jjMoveStringLiteralDfa1_0(0x1000000000010000L, 0x200L);
+         return jjMoveStringLiteralDfa1_0(0x2000000000010000L, 0x400L);
       case 83:
       case 115:
-         return jjMoveStringLiteralDfa1_0(0x8000400020008000L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x800040008000L, 0x1L);
       case 84:
       case 116:
-         return jjMoveStringLiteralDfa1_0(0x2100080000000L, 0x800L);
+         return jjMoveStringLiteralDfa1_0(0x4200100000000L, 0x1000L);
       case 85:
       case 117:
-         return jjMoveStringLiteralDfa1_0(0x18000000000040L, 0x10L);
+         return jjMoveStringLiteralDfa1_0(0x30000000000040L, 0x20L);
       case 86:
       case 118:
-         return jjMoveStringLiteralDfa1_0(0x400L, 0x20L);
+         return jjMoveStringLiteralDfa1_0(0x400L, 0x40L);
       case 87:
       case 119:
-         return jjMoveStringLiteralDfa1_0(0x5080000000000L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0xa100000000000L, 0x0L);
       case 123:
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x1d000000000000L);
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x3a000000000000L);
       case 124:
-         jjmatchedKind = 106;
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x20000000000L);
+         jjmatchedKind = 107;
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x40000000000L);
       case 125:
-         return jjStopAtPos(0, 113);
+         return jjStopAtPos(0, 114);
       default :
          return jjMoveNfa_0(7, 0);
    }
@@ -342,44 +342,49 @@ private int jjMoveStringLiteralDfa1_0(long active0, long active1)
    switch(curChar)
    {
       case 61:
-         if ((active1 & 0x1000000000L) != 0L)
-            return jjStopAtPos(1, 100);
-         else if ((active1 & 0x2000000000L) != 0L)
+         if ((active1 & 0x2000000000L) != 0L)
             return jjStopAtPos(1, 101);
-         else if ((active1 & 0x8000000000L) != 0L)
-            return jjStopAtPos(1, 103);
+         else if ((active1 & 0x4000000000L) != 0L)
+            return jjStopAtPos(1, 102);
+         else if ((active1 & 0x10000000000L) != 0L)
+            return jjStopAtPos(1, 104);
          break;
       case 62:
-         if ((active1 & 0x4000000000L) != 0L)
-            return jjStopAtPos(1, 102);
+         if ((active1 & 0x8000000000L) != 0L)
+            return jjStopAtPos(1, 103);
          break;
       case 64:
-         if ((active1 & 0x10000000000L) != 0L)
-            return jjStopAtPos(1, 104);
+         if ((active1 & 0x20000000000L) != 0L)
+            return jjStopAtPos(1, 105);
          break;
       case 65:
       case 97:
-         return jjMoveStringLiteralDfa2_0(active0, 0x2040000008000L, active1, 0x124L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x4080000008000L, active1, 0x248L);
       case 68:
       case 100:
-         if ((active1 & 0x1000000000000L) != 0L)
-            return jjStopAtPos(1, 112);
+         if ((active1 & 0x2000000000000L) != 0L)
+            return jjStopAtPos(1, 113);
          break;
       case 69:
       case 101:
-         return jjMoveStringLiteralDfa2_0(active0, 0xa040008228011800L, active1, 0x4600L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x4080010450011800L, active1, 0x8c01L);
       case 70:
       case 102:
-         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x10000000000001L);
+         if ((active0 & 0x800000L) != 0L)
+         {
+            jjmatchedKind = 23;
+            jjmatchedPos = 1;
+         }
+         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x20000000000002L);
       case 72:
       case 104:
-         return jjMoveStringLiteralDfa2_0(active0, 0x4180000000000L, active1, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x8300000000000L, active1, 0L);
       case 73:
       case 105:
-         return jjMoveStringLiteralDfa2_0(active0, 0x1201001000000400L, active1, 0x1000L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x2402002000000400L, active1, 0x2000L);
       case 76:
       case 108:
-         return jjMoveStringLiteralDfa2_0(active0, 0x200001004000L, active1, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x400002004000L, active1, 0L);
       case 78:
       case 110:
          if ((active0 & 0x200000L) != 0L)
@@ -387,17 +392,17 @@ private int jjMoveStringLiteralDfa1_0(long active0, long active1)
             jjmatchedKind = 21;
             jjmatchedPos = 1;
          }
-         else if ((active0 & 0x800000L) != 0L)
-            return jjStartNfaWithStates_0(1, 23, 36);
-         return jjMoveStringLiteralDfa2_0(active0, 0x1900005060000c0L, active1, 0x2008L);
+         else if ((active0 & 0x1000000L) != 0L)
+            return jjStartNfaWithStates_0(1, 24, 36);
+         return jjMoveStringLiteralDfa2_0(active0, 0x320000a0c0000c0L, active1, 0x4010L);
       case 79:
       case 111:
          if ((active0 & 0x80000L) != 0L)
             return jjStartNfaWithStates_0(1, 19, 36);
-         return jjMoveStringLiteralDfa2_0(active0, 0x404090002000L, active1, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x808120002000L, active1, 0L);
       case 80:
       case 112:
-         return jjMoveStringLiteralDfa2_0(active0, 0x20000000000L, active1, 0x10L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x40000000000L, active1, 0x20L);
       case 82:
       case 114:
          if ((active0 & 0x400000L) != 0L)
@@ -405,7 +410,7 @@ private int jjMoveStringLiteralDfa1_0(long active0, long active1)
             jjmatchedKind = 22;
             jjmatchedPos = 1;
          }
-         return jjMoveStringLiteralDfa2_0(active0, 0x4820012000020000L, active1, 0x880L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x9040024000020000L, active1, 0x1100L);
       case 83:
       case 115:
          if ((active0 & 0x20L) != 0L)
@@ -415,29 +420,29 @@ private int jjMoveStringLiteralDfa1_0(long active0, long active1)
          }
          else if ((active0 & 0x100000L) != 0L)
             return jjStartNfaWithStates_0(1, 20, 36);
-         return jjMoveStringLiteralDfa2_0(active0, 0x8000040000200L, active1, 0x40L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x10000080000200L, active1, 0x80L);
       case 84:
       case 116:
-         if ((active1 & 0x4000000000000L) != 0L)
+         if ((active1 & 0x8000000000000L) != 0L)
          {
-            jjmatchedKind = 114;
+            jjmatchedKind = 115;
             jjmatchedPos = 1;
          }
-         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x8000000000000L);
+         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x10000000000000L);
       case 85:
       case 117:
-         return jjMoveStringLiteralDfa2_0(active0, 0x400800800000000L, active1, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x801001000000000L, active1, 0L);
       case 88:
       case 120:
-         return jjMoveStringLiteralDfa2_0(active0, 0x100L, active1, 0x2L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x100L, active1, 0x4L);
       case 89:
       case 121:
          if ((active0 & 0x40000L) != 0L)
             return jjStartNfaWithStates_0(1, 18, 36);
          break;
       case 124:
-         if ((active1 & 0x20000000000L) != 0L)
-            return jjStopAtPos(1, 105);
+         if ((active1 & 0x40000000000L) != 0L)
+            return jjStopAtPos(1, 106);
          break;
       default :
          break;
@@ -460,81 +465,81 @@ private int jjMoveStringLiteralDfa2_0(long old0, long active0, long old1, long a
          return jjMoveStringLiteralDfa3_0(active0, 0x22080L, active1, 0L);
       case 66:
       case 98:
-         return jjMoveStringLiteralDfa3_0(active0, 0x2000000000000L, active1, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x4000000000000L, active1, 0L);
       case 67:
       case 99:
-         if ((active0 & 0x40000000L) != 0L)
-            return jjStartNfaWithStates_0(2, 30, 36);
-         return jjMoveStringLiteralDfa3_0(active0, 0x40L, active1, 0x40L);
-      case 68:
-      case 100:
-         if ((active0 & 0x2000000L) != 0L)
-            return jjStartNfaWithStates_0(2, 25, 36);
-         else if ((active0 & 0x100000000L) != 0L)
-            return jjStartNfaWithStates_0(2, 32, 36);
-         return jjMoveStringLiteralDfa3_0(active0, 0x880000000000000L, active1, 0x10L);
-      case 69:
-      case 101:
-         return jjMoveStringLiteralDfa3_0(active0, 0x40041a0000000400L, active1, 0x4000L);
-      case 70:
-      case 102:
-         return jjMoveStringLiteralDfa3_0(active0, 0x8000000000L, active1, 0x1L);
-      case 71:
-      case 103:
-         return jjMoveStringLiteralDfa3_0(active0, 0x1040000000000000L, active1, 0L);
-      case 73:
-      case 105:
-         return jjMoveStringLiteralDfa3_0(active0, 0x18004000000000L, active1, 0x82L);
-      case 75:
-      case 107:
-         return jjMoveStringLiteralDfa3_0(active0, 0x1000000000L, active1, 0L);
-      case 76:
-      case 108:
-         if ((active0 & 0x1000000L) != 0L)
-            return jjStartNfaWithStates_0(2, 24, 36);
-         return jjMoveStringLiteralDfa3_0(active0, 0xa000800800000000L, active1, 0x20L);
-      case 77:
-      case 109:
-         return jjMoveStringLiteralDfa3_0(active0, 0x200400000000000L, active1, 0L);
-      case 78:
-      case 110:
-         if ((active1 & 0x10000000000000L) != 0L)
-            return jjStopAtPos(2, 116);
-         return jjMoveStringLiteralDfa3_0(active0, 0x100000000010800L, active1, 0L);
-      case 79:
-      case 111:
-         return jjMoveStringLiteralDfa3_0(active0, 0x20012000000000L, active1, 0L);
-      case 80:
-      case 112:
          if ((active0 & 0x80000000L) != 0L)
             return jjStartNfaWithStates_0(2, 31, 36);
-         return jjMoveStringLiteralDfa3_0(active0, 0x100L, active1, 0x200L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x40L, active1, 0x80L);
+      case 68:
+      case 100:
+         if ((active0 & 0x4000000L) != 0L)
+            return jjStartNfaWithStates_0(2, 26, 36);
+         else if ((active0 & 0x200000000L) != 0L)
+            return jjStartNfaWithStates_0(2, 33, 36);
+         return jjMoveStringLiteralDfa3_0(active0, 0x1100000000000000L, active1, 0x20L);
+      case 69:
+      case 101:
+         return jjMoveStringLiteralDfa3_0(active0, 0x8008340000000400L, active1, 0x8000L);
+      case 70:
+      case 102:
+         return jjMoveStringLiteralDfa3_0(active0, 0x10000000000L, active1, 0x2L);
+      case 71:
+      case 103:
+         return jjMoveStringLiteralDfa3_0(active0, 0x2080000000000000L, active1, 0L);
+      case 73:
+      case 105:
+         return jjMoveStringLiteralDfa3_0(active0, 0x30008000000000L, active1, 0x104L);
+      case 75:
+      case 107:
+         return jjMoveStringLiteralDfa3_0(active0, 0x2000000000L, active1, 0L);
+      case 76:
+      case 108:
+         if ((active0 & 0x2000000L) != 0L)
+            return jjStartNfaWithStates_0(2, 25, 36);
+         return jjMoveStringLiteralDfa3_0(active0, 0x4001001000000000L, active1, 0x41L);
+      case 77:
+      case 109:
+         return jjMoveStringLiteralDfa3_0(active0, 0x400800000000000L, active1, 0L);
+      case 78:
+      case 110:
+         if ((active1 & 0x20000000000000L) != 0L)
+            return jjStopAtPos(2, 117);
+         return jjMoveStringLiteralDfa3_0(active0, 0x200000000010800L, active1, 0L);
+      case 79:
+      case 111:
+         return jjMoveStringLiteralDfa3_0(active0, 0x40024000000000L, active1, 0L);
+      case 80:
+      case 112:
+         if ((active0 & 0x100000000L) != 0L)
+            return jjStartNfaWithStates_0(2, 32, 36);
+         return jjMoveStringLiteralDfa3_0(active0, 0x100L, active1, 0x400L);
       case 83:
       case 115:
-         if ((active1 & 0x8000000000000L) != 0L)
-            return jjStopAtPos(2, 115);
-         return jjMoveStringLiteralDfa3_0(active0, 0x240200000200L, active1, 0x1008L);
+         if ((active1 & 0x10000000000000L) != 0L)
+            return jjStopAtPos(2, 116);
+         return jjMoveStringLiteralDfa3_0(active0, 0x480400000200L, active1, 0x2010L);
       case 84:
       case 116:
          if ((active0 & 0x1000L) != 0L)
             return jjStartNfaWithStates_0(2, 12, 36);
-         else if ((active0 & 0x10000000L) != 0L)
-            return jjStartNfaWithStates_0(2, 28, 36);
          else if ((active0 & 0x20000000L) != 0L)
             return jjStartNfaWithStates_0(2, 29, 36);
-         return jjMoveStringLiteralDfa3_0(active0, 0x401000400004000L, active1, 0x2500L);
+         else if ((active0 & 0x40000000L) != 0L)
+            return jjStartNfaWithStates_0(2, 30, 36);
+         return jjMoveStringLiteralDfa3_0(active0, 0x802000800004000L, active1, 0x4a00L);
       case 85:
       case 117:
-         return jjMoveStringLiteralDfa3_0(active0, 0L, active1, 0x800L);
+         return jjMoveStringLiteralDfa3_0(active0, 0L, active1, 0x1000L);
       case 86:
       case 118:
-         return jjMoveStringLiteralDfa3_0(active0, 0x8000L, active1, 0x4L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x8000L, active1, 0x8L);
       case 89:
       case 121:
-         if ((active0 & 0x4000000L) != 0L)
-            return jjStartNfaWithStates_0(2, 26, 36);
-         else if ((active0 & 0x8000000L) != 0L)
+         if ((active0 & 0x8000000L) != 0L)
             return jjStartNfaWithStates_0(2, 27, 36);
+         else if ((active0 & 0x10000000L) != 0L)
+            return jjStartNfaWithStates_0(2, 28, 36);
          break;
       default :
          break;
@@ -554,95 +559,95 @@ private int jjMoveStringLiteralDfa3_0(long old0, long active0, long old1, long a
    {
       case 65:
       case 97:
-         return jjMoveStringLiteralDfa4_0(active0, 0x4000000000010000L, active1, 0x50L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x8000000000010000L, active1, 0xa0L);
       case 67:
       case 99:
-         if ((active0 & 0x200000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 33, 36);
+         if ((active0 & 0x400000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 34, 36);
          break;
       case 68:
       case 100:
          if ((active0 & 0x2000L) != 0L)
             return jjStartNfaWithStates_0(3, 13, 36);
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x4000L);
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x8000L);
       case 69:
       case 101:
          if ((active0 & 0x8000L) != 0L)
             return jjStartNfaWithStates_0(3, 15, 36);
-         else if ((active0 & 0x1000000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 36, 36);
-         else if ((active0 & 0x40000000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 42, 36);
-         else if ((active0 & 0x200000000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 45, 36);
+         else if ((active0 & 0x2000000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 37, 36);
+         else if ((active0 & 0x80000000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 43, 36);
          else if ((active0 & 0x400000000000L) != 0L)
             return jjStartNfaWithStates_0(3, 46, 36);
-         return jjMoveStringLiteralDfa4_0(active0, 0xad80000000004040L, active1, 0x2008L);
+         else if ((active0 & 0x800000000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 47, 36);
+         return jjMoveStringLiteralDfa4_0(active0, 0x5b00000000004040L, active1, 0x4011L);
       case 71:
       case 103:
          return jjMoveStringLiteralDfa4_0(active0, 0x20000L, active1, 0L);
       case 72:
       case 104:
-         if ((active0 & 0x1000000000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 48, 36);
-         return jjMoveStringLiteralDfa4_0(active0, 0x1000000000000000L, active1, 0L);
+         if ((active0 & 0x2000000000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 49, 36);
+         return jjMoveStringLiteralDfa4_0(active0, 0x2000000000000000L, active1, 0L);
       case 73:
       case 105:
-         return jjMoveStringLiteralDfa4_0(active0, 0x240000000000000L, active1, 0x4L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x480000000000000L, active1, 0x8L);
       case 76:
       case 108:
-         if ((active0 & 0x800000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 35, 36);
-         else if ((active0 & 0x800000000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 47, 36);
-         return jjMoveStringLiteralDfa4_0(active0, 0x2000000000180L, active1, 0x200L);
+         if ((active0 & 0x1000000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 36, 36);
+         else if ((active0 & 0x1000000000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 48, 36);
+         return jjMoveStringLiteralDfa4_0(active0, 0x4000000000180L, active1, 0x400L);
       case 77:
       case 109:
-         if ((active0 & 0x10000000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 40, 36);
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x80L);
+         if ((active0 & 0x20000000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 41, 36);
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x100L);
       case 78:
       case 110:
-         if ((active0 & 0x4000000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 38, 36);
-         else if ((active0 & 0x20000000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 41, 36);
-         else if ((active0 & 0x80000000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 43, 36);
+         if ((active0 & 0x8000000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 39, 36);
+         else if ((active0 & 0x40000000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 42, 36);
          else if ((active0 & 0x100000000000L) != 0L)
             return jjStartNfaWithStates_0(3, 44, 36);
-         return jjMoveStringLiteralDfa4_0(active0, 0x8000000000000L, active1, 0x800L);
+         else if ((active0 & 0x200000000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 45, 36);
+         return jjMoveStringLiteralDfa4_0(active0, 0x10000000000000L, active1, 0x1000L);
       case 79:
       case 111:
-         if ((active0 & 0x400000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 34, 36);
-         return jjMoveStringLiteralDfa4_0(active0, 0x10000000000000L, active1, 0L);
+         if ((active0 & 0x800000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 35, 36);
+         return jjMoveStringLiteralDfa4_0(active0, 0x20000000000000L, active1, 0L);
       case 80:
       case 112:
-         if ((active0 & 0x2000000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 37, 36);
+         if ((active0 & 0x4000000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 38, 36);
          break;
       case 82:
       case 114:
-         return jjMoveStringLiteralDfa4_0(active0, 0x4000000000000L, active1, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x8000000000000L, active1, 0L);
       case 83:
       case 115:
          if ((active0 & 0x800L) != 0L)
             return jjStartNfaWithStates_0(3, 11, 36);
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x3L);
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x6L);
       case 84:
       case 116:
-         if ((active0 & 0x8000000000L) != 0L)
-            return jjStartNfaWithStates_0(3, 39, 36);
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x1000L);
+         if ((active0 & 0x10000000000L) != 0L)
+            return jjStartNfaWithStates_0(3, 40, 36);
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x2000L);
       case 85:
       case 117:
-         return jjMoveStringLiteralDfa4_0(active0, 0x20000000000200L, active1, 0x120L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x40000000000200L, active1, 0x240L);
       case 87:
       case 119:
          if ((active0 & 0x400L) != 0L)
             return jjStartNfaWithStates_0(3, 10, 36);
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x400L);
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x800L);
       default :
          break;
    }
@@ -661,65 +666,65 @@ private int jjMoveStringLiteralDfa4_0(long old0, long active0, long old1, long a
    {
       case 65:
       case 97:
-         return jjMoveStringLiteralDfa5_0(active0, 0x100L, active1, 0x280L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x100L, active1, 0x500L);
       case 66:
       case 98:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x4000L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x8000L);
       case 67:
       case 99:
-         return jjMoveStringLiteralDfa5_0(active0, 0x8000000000000000L, active1, 0x800L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x1001L);
       case 69:
       case 101:
-         if ((active0 & 0x2000000000000L) != 0L)
-            return jjStartNfaWithStates_0(4, 49, 36);
-         else if ((active0 & 0x4000000000000L) != 0L)
+         if ((active0 & 0x4000000000000L) != 0L)
             return jjStartNfaWithStates_0(4, 50, 36);
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x421L);
+         else if ((active0 & 0x8000000000000L) != 0L)
+            return jjStartNfaWithStates_0(4, 51, 36);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x842L);
       case 71:
       case 103:
-         if ((active0 & 0x8000000000000L) != 0L)
-            return jjStartNfaWithStates_0(4, 51, 36);
+         if ((active0 & 0x10000000000000L) != 0L)
+            return jjStartNfaWithStates_0(4, 52, 36);
          break;
       case 73:
       case 105:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x1000L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x2000L);
       case 77:
       case 109:
          return jjMoveStringLiteralDfa5_0(active0, 0x30200L, active1, 0L);
       case 78:
       case 110:
-         if ((active0 & 0x10000000000000L) != 0L)
-            return jjStartNfaWithStates_0(4, 52, 36);
-         else if ((active0 & 0x40000000000000L) != 0L)
-            return jjStartNfaWithStates_0(4, 54, 36);
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x4L);
-      case 80:
-      case 112:
          if ((active0 & 0x20000000000000L) != 0L)
             return jjStartNfaWithStates_0(4, 53, 36);
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x40L);
+         else if ((active0 & 0x80000000000000L) != 0L)
+            return jjStartNfaWithStates_0(4, 55, 36);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x8L);
+      case 80:
+      case 112:
+         if ((active0 & 0x40000000000000L) != 0L)
+            return jjStartNfaWithStates_0(4, 54, 36);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x80L);
       case 82:
       case 114:
          if ((active0 & 0x4000L) != 0L)
             return jjStartNfaWithStates_0(4, 14, 36);
-         else if ((active0 & 0x100000000000000L) != 0L)
-            return jjStartNfaWithStates_0(4, 56, 36);
-         else if ((active0 & 0x400000000000000L) != 0L)
-            return jjStartNfaWithStates_0(4, 58, 36);
+         else if ((active0 & 0x200000000000000L) != 0L)
+            return jjStartNfaWithStates_0(4, 57, 36);
          else if ((active0 & 0x800000000000000L) != 0L)
             return jjStartNfaWithStates_0(4, 59, 36);
-         return jjMoveStringLiteralDfa5_0(active0, 0x40L, active1, 0x2108L);
-      case 84:
-      case 116:
-         if ((active0 & 0x200000000000000L) != 0L)
-            return jjStartNfaWithStates_0(4, 57, 36);
          else if ((active0 & 0x1000000000000000L) != 0L)
             return jjStartNfaWithStates_0(4, 60, 36);
-         return jjMoveStringLiteralDfa5_0(active0, 0x6000000000000000L, active1, 0x12L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x40L, active1, 0x4210L);
+      case 84:
+      case 116:
+         if ((active0 & 0x400000000000000L) != 0L)
+            return jjStartNfaWithStates_0(4, 58, 36);
+         else if ((active0 & 0x2000000000000000L) != 0L)
+            return jjStartNfaWithStates_0(4, 61, 36);
+         return jjMoveStringLiteralDfa5_0(active0, 0xc000000000000000L, active1, 0x24L);
       case 88:
       case 120:
-         if ((active0 & 0x80000000000000L) != 0L)
-            return jjStartNfaWithStates_0(4, 55, 36);
+         if ((active0 & 0x100000000000000L) != 0L)
+            return jjStartNfaWithStates_0(4, 56, 36);
          break;
       case 89:
       case 121:
@@ -744,54 +749,54 @@ private int jjMoveStringLiteralDfa5_0(long old0, long active0, long old1, long a
       case 97:
          if ((active0 & 0x20000L) != 0L)
             return jjStartNfaWithStates_0(5, 17, 36);
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x4900L);
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x9200L);
       case 67:
       case 99:
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x200L);
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x400L);
       case 69:
       case 101:
          if ((active0 & 0x200L) != 0L)
             return jjStartNfaWithStates_0(5, 9, 36);
          else if ((active0 & 0x10000L) != 0L)
             return jjStartNfaWithStates_0(5, 16, 36);
-         else if ((active0 & 0x2000000000000000L) != 0L)
-            return jjStartNfaWithStates_0(5, 61, 36);
          else if ((active0 & 0x4000000000000000L) != 0L)
             return jjStartNfaWithStates_0(5, 62, 36);
-         else if ((active1 & 0x10L) != 0L)
-            return jjStartNfaWithStates_0(5, 68, 36);
-         else if ((active1 & 0x40L) != 0L)
-            return jjStartNfaWithStates_0(5, 70, 36);
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x400L);
+         else if ((active0 & 0x8000000000000000L) != 0L)
+            return jjStartNfaWithStates_0(5, 63, 36);
+         else if ((active1 & 0x20L) != 0L)
+            return jjStartNfaWithStates_0(5, 69, 36);
+         else if ((active1 & 0x80L) != 0L)
+            return jjStartNfaWithStates_0(5, 71, 36);
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x800L);
       case 71:
       case 103:
-         if ((active1 & 0x4L) != 0L)
-            return jjStartNfaWithStates_0(5, 66, 36);
+         if ((active1 & 0x8L) != 0L)
+            return jjStartNfaWithStates_0(5, 67, 36);
          break;
       case 73:
       case 105:
          return jjMoveStringLiteralDfa6_0(active0, 0x100L, active1, 0L);
       case 78:
       case 110:
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x1000L);
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x2000L);
       case 82:
       case 114:
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x80L);
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x100L);
       case 83:
       case 115:
-         if ((active1 & 0x2L) != 0L)
-            return jjStartNfaWithStates_0(5, 65, 36);
-         else if ((active1 & 0x20L) != 0L)
-            return jjStartNfaWithStates_0(5, 69, 36);
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x2000L);
+         if ((active1 & 0x4L) != 0L)
+            return jjStartNfaWithStates_0(5, 66, 36);
+         else if ((active1 & 0x40L) != 0L)
+            return jjStartNfaWithStates_0(5, 70, 36);
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x4000L);
       case 84:
       case 116:
-         if ((active0 & 0x8000000000000000L) != 0L)
-            return jjStartNfaWithStates_0(5, 63, 36);
-         else if ((active1 & 0x1L) != 0L)
+         if ((active1 & 0x1L) != 0L)
             return jjStartNfaWithStates_0(5, 64, 36);
-         else if ((active1 & 0x8L) != 0L)
-            return jjStartNfaWithStates_0(5, 67, 36);
+         else if ((active1 & 0x2L) != 0L)
+            return jjStartNfaWithStates_0(5, 65, 36);
+         else if ((active1 & 0x10L) != 0L)
+            return jjStartNfaWithStates_0(5, 68, 36);
          return jjMoveStringLiteralDfa6_0(active0, 0x40L, active1, 0L);
       case 90:
       case 122:
@@ -817,33 +822,33 @@ private int jjMoveStringLiteralDfa6_0(long old0, long active0, long old1, long a
          return jjMoveStringLiteralDfa7_0(active0, 0x40L, active1, 0L);
       case 67:
       case 99:
-         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x5000L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0xa000L);
       case 69:
       case 101:
          if ((active0 & 0x80L) != 0L)
             return jjStartNfaWithStates_0(6, 7, 36);
-         else if ((active1 & 0x200L) != 0L)
-            return jjStartNfaWithStates_0(6, 73, 36);
-         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x2000L);
+         else if ((active1 & 0x400L) != 0L)
+            return jjStartNfaWithStates_0(6, 74, 36);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x4000L);
       case 76:
       case 108:
-         if ((active1 & 0x100L) != 0L)
-            return jjStartNfaWithStates_0(6, 72, 36);
+         if ((active1 & 0x200L) != 0L)
+            return jjStartNfaWithStates_0(6, 73, 36);
          break;
       case 78:
       case 110:
          if ((active0 & 0x100L) != 0L)
             return jjStartNfaWithStates_0(6, 8, 36);
-         else if ((active1 & 0x400L) != 0L)
-            return jjStartNfaWithStates_0(6, 74, 36);
+         else if ((active1 & 0x800L) != 0L)
+            return jjStartNfaWithStates_0(6, 75, 36);
          break;
       case 84:
       case 116:
-         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x800L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x1000L);
       case 89:
       case 121:
-         if ((active1 & 0x80L) != 0L)
-            return jjStartNfaWithStates_0(6, 71, 36);
+         if ((active1 & 0x100L) != 0L)
+            return jjStartNfaWithStates_0(6, 72, 36);
          break;
       default :
          break;
@@ -863,24 +868,24 @@ private int jjMoveStringLiteralDfa7_0(long old0, long active0, long old1, long a
    {
       case 67:
       case 99:
-         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x2000L);
+         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x4000L);
       case 69:
       case 101:
-         if ((active1 & 0x800L) != 0L)
-            return jjStartNfaWithStates_0(7, 75, 36);
+         if ((active1 & 0x1000L) != 0L)
+            return jjStartNfaWithStates_0(7, 76, 36);
          break;
       case 73:
       case 105:
          return jjMoveStringLiteralDfa8_0(active0, 0x40L, active1, 0L);
       case 75:
       case 107:
-         if ((active1 & 0x4000L) != 0L)
-            return jjStartNfaWithStates_0(7, 78, 36);
+         if ((active1 & 0x8000L) != 0L)
+            return jjStartNfaWithStates_0(7, 79, 36);
          break;
       case 84:
       case 116:
-         if ((active1 & 0x1000L) != 0L)
-            return jjStartNfaWithStates_0(7, 76, 36);
+         if ((active1 & 0x2000L) != 0L)
+            return jjStartNfaWithStates_0(7, 77, 36);
          break;
       default :
          break;
@@ -905,8 +910,8 @@ private int jjMoveStringLiteralDfa8_0(long old0, long active0, long old1, long a
          break;
       case 84:
       case 116:
-         if ((active1 & 0x2000L) != 0L)
-            return jjStartNfaWithStates_0(8, 77, 36);
+         if ((active1 & 0x4000L) != 0L)
+            return jjStartNfaWithStates_0(8, 78, 36);
          break;
       default :
          break;
@@ -946,15 +951,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 16:
                   if ((0x3ff001000000000L & l) == 0L)
                      break;
-                  if (kind > 84)
-                     kind = 84;
+                  if (kind > 85)
+                     kind = 85;
                   jjCheckNAdd(16);
                   break;
                case 7:
                   if ((0x3ff000000000000L & l) != 0L)
                   {
-                     if (kind > 80)
-                        kind = 80;
+                     if (kind > 81)
+                        kind = 81;
                      jjCheckNAddStates(0, 5);
                   }
                   else if (curChar == 34)
@@ -975,8 +980,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 1:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 79)
-                     kind = 79;
+                  if (kind > 80)
+                     kind = 80;
                   jjCheckNAddTwoStates(1, 2);
                   break;
                case 3:
@@ -986,22 +991,22 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 4:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 79)
-                     kind = 79;
+                  if (kind > 80)
+                     kind = 80;
                   jjCheckNAdd(4);
                   break;
                case 5:
                   if (curChar != 45)
                      break;
-                  if (kind > 82)
-                     kind = 82;
+                  if (kind > 83)
+                     kind = 83;
                   jjCheckNAdd(6);
                   break;
                case 6:
                   if ((0xffffffffffffdbffL & l) == 0L)
                      break;
-                  if (kind > 82)
-                     kind = 82;
+                  if (kind > 83)
+                     kind = 83;
                   jjCheckNAdd(6);
                   break;
                case 8:
@@ -1025,8 +1030,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjCheckNAddTwoStates(12, 10);
                   break;
                case 13:
-                  if (curChar == 47 && kind > 83)
-                     kind = 83;
+                  if (curChar == 47 && kind > 84)
+                     kind = 84;
                   break;
                case 14:
                   if (curChar == 47)
@@ -1043,8 +1048,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 19:
                   if (curChar != 39)
                      break;
-                  if (kind > 87)
-                     kind = 87;
+                  if (kind > 88)
+                     kind = 88;
                   jjstateSet[jjnewStateCnt++] = 20;
                   break;
                case 20:
@@ -1064,8 +1069,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjCheckNAddTwoStates(23, 24);
                   break;
                case 24:
-                  if (curChar == 34 && kind > 88)
-                     kind = 88;
+                  if (curChar == 34 && kind > 89)
+                     kind = 89;
                   break;
                case 26:
                   if ((0xffffffffffffdbffL & l) != 0L)
@@ -1074,8 +1079,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 28:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 80)
-                     kind = 80;
+                  if (kind > 81)
+                     kind = 81;
                   jjCheckNAddStates(0, 5);
                   break;
                case 29:
@@ -1097,15 +1102,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 34:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 79)
-                     kind = 79;
+                  if (kind > 80)
+                     kind = 80;
                   jjCheckNAdd(34);
                   break;
                case 35:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 80)
-                     kind = 80;
+                  if (kind > 81)
+                     kind = 81;
                   jjCheckNAdd(35);
                   break;
                default : break;
@@ -1122,22 +1127,22 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 36:
                   if ((0x7fffffe87fffffeL & l) != 0L)
                   {
-                     if (kind > 84)
-                        kind = 84;
+                     if (kind > 85)
+                        kind = 85;
                      jjCheckNAdd(16);
                   }
                   if ((0x7fffffe87fffffeL & l) != 0L)
                   {
-                     if (kind > 84)
-                        kind = 84;
+                     if (kind > 85)
+                        kind = 85;
                      jjCheckNAddTwoStates(15, 16);
                   }
                   break;
                case 7:
                   if ((0x7fffffe87fffffeL & l) != 0L)
                   {
-                     if (kind > 84)
-                        kind = 84;
+                     if (kind > 85)
+                        kind = 85;
                      jjCheckNAddTwoStates(15, 16);
                   }
                   else if (curChar == 96)
@@ -1148,8 +1153,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjAddStates(14, 15);
                   break;
                case 6:
-                  if (kind > 82)
-                     kind = 82;
+                  if (kind > 83)
+                     kind = 83;
                   jjstateSet[jjnewStateCnt++] = 6;
                   break;
                case 9:
@@ -1162,15 +1167,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 15:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
-                  if (kind > 84)
-                     kind = 84;
+                  if (kind > 85)
+                     kind = 85;
                   jjCheckNAddTwoStates(15, 16);
                   break;
                case 16:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
-                  if (kind > 84)
-                     kind = 84;
+                  if (kind > 85)
+                     kind = 85;
                   jjCheckNAdd(16);
                   break;
                case 18:
@@ -1191,8 +1196,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjCheckNAddTwoStates(26, 27);
                   break;
                case 27:
-                  if (curChar == 96 && kind > 88)
-                     kind = 88;
+                  if (curChar == 96 && kind > 89)
+                     kind = 89;
                   break;
                case 32:
                   if ((0x2000000020L & l) != 0L)
@@ -1213,8 +1218,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 6:
                   if ((jjbitVec0[i2] & l2) == 0L)
                      break;
-                  if (kind > 82)
-                     kind = 82;
+                  if (kind > 83)
+                     kind = 83;
                   jjstateSet[jjnewStateCnt++] = 6;
                   break;
                case 9:
@@ -1272,22 +1277,23 @@ null, null, null, null, null, null, null, null, null, null, null, null, null, nu
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
-null, null, null, null, null, null, "\73", "\72", "\50", "\54", "\51", "\75", "\56", 
-"\52", "\77", "\76", "\74", "\76\75", "\74\75", "\74\76", "\41\75", "\100\100", 
-"\174\174", "\174", "\46", "\53", "\55", "\57", "\136", null, "\175", null, null, null, };
+null, null, null, null, null, null, null, "\73", "\72", "\50", "\54", "\51", "\75", 
+"\56", "\52", "\77", "\76", "\74", "\76\75", "\74\75", "\74\76", "\41\75", 
+"\100\100", "\174\174", "\174", "\46", "\53", "\55", "\57", "\136", null, "\175", null, 
+null, null, };
 
 /** Lexer state names. */
 public static final String[] lexStateNames = {
    "DEFAULT",
 };
 static final long[] jjtoToken = {
-   0xffffffffffffffe1L, 0x1fffffff91ffffL, 
+   0xffffffffffffffe1L, 0x3fffffff23ffffL, 
 };
 static final long[] jjtoSkip = {
-   0x1eL, 0xc0000L, 
+   0x1eL, 0x180000L, 
 };
 static final long[] jjtoSpecial = {
-   0x0L, 0xc0000L, 
+   0x0L, 0x180000L, 
 };
 protected SimpleCharStream input_stream;
 private final int[] jjrounds = new int[36];

--- a/src/main/java/mimir/sql/Analyze.java
+++ b/src/main/java/mimir/sql/Analyze.java
@@ -1,5 +1,6 @@
 package mimir.sql;
 
+import net.sf.jsqlparser.expression.PrimitiveValue;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.Select;
@@ -8,11 +9,19 @@ import net.sf.jsqlparser.statement.select.SelectBody;
 public class Analyze implements Statement{
 	private SelectBody selectBody;
 	private String column;
+	private PrimitiveValue rowid;
 
-	public SelectBody getSelectBody() {
-		return selectBody;
+	public Analyze(SelectBody selectBody, PrimitiveValue rowid, String column)
+	{
+		this.selectBody = selectBody;
+		this.column = column;
+		this.rowid = rowid;
 	}
 
+	public SelectBody getSelectBody() 
+	{
+		return selectBody;
+	}
 	public void setSelectBody(SelectBody selectBody) {
 		this.selectBody = selectBody;
 	}
@@ -24,6 +33,15 @@ public class Analyze implements Statement{
 	public void setColumn(String column)
 	{
 		this.column = column;
+	}
+
+	public PrimitiveValue getRowid()
+	{
+		return rowid;
+	}
+	public void setRowid(PrimitiveValue rowid)
+	{
+		this.rowid = rowid;
 	}
 
 	@Override

--- a/src/main/java/mimir/sql/Analyze.java
+++ b/src/main/java/mimir/sql/Analyze.java
@@ -9,13 +9,13 @@ import net.sf.jsqlparser.statement.select.SelectBody;
 public class Analyze implements Statement{
 	private SelectBody selectBody;
 	private String column;
-	private PrimitiveValue rowid;
+	private PrimitiveValue rowId;
 
 	public Analyze(SelectBody selectBody, PrimitiveValue rowid, String column)
 	{
 		this.selectBody = selectBody;
 		this.column = column;
-		this.rowid = rowid;
+		this.rowId = rowId;
 	}
 
 	public SelectBody getSelectBody() 
@@ -35,13 +35,13 @@ public class Analyze implements Statement{
 		this.column = column;
 	}
 
-	public PrimitiveValue getRowid()
+	public PrimitiveValue getRowId()
 	{
-		return rowid;
+		return rowId;
 	}
-	public void setRowid(PrimitiveValue rowid)
+	public void setRowId(PrimitiveValue rowid)
 	{
-		this.rowid = rowid;
+		this.rowId = rowId;
 	}
 
 	@Override

--- a/src/main/scala/mimir/Database.scala
+++ b/src/main/scala/mimir/Database.scala
@@ -11,7 +11,7 @@ import mimir.models.Model
 import mimir.exec.{Compiler, ResultIterator, ResultSetIterator}
 import mimir.lenses.{LensManager, BestGuessCache}
 import mimir.parser.OperatorParser
-import mimir.sql.{SqlToRA,RAToSql,Backend,CreateLens,CreateView,Explain,Feedback,Load}
+import mimir.sql.{SqlToRA,RAToSql,Backend,CreateLens,CreateView,Explain,Feedback,Load,Pragma,Analyze}
 import mimir.optimizer.{InlineVGTerms, ResolveViews}
 import mimir.util.{LoadCSV,ExperimentalOptions}
 import mimir.web.WebIterator
@@ -297,9 +297,13 @@ case class Database(backend: Backend)
   def update(stmt: Statement)
   {
     stmt match {
-      case sel:  Select     => throw new SQLException("Can't evaluate SELECT as an update")
-      case expl: Explain    => throw new SQLException("Can't evaluate EXPLAIN as an update")
+      /********** QUERY STATEMENTS **********/
+      case _: Select   => throw new SQLException("Can't evaluate SELECT as an update")
+      case _: Explain  => throw new SQLException("Can't evaluate EXPLAIN as an update")
+      case _: Pragma   => throw new SQLException("Can't evaluate PRAGMA as an update")
+      case _: Analyze  => throw new SQLException("Can't evaluate ANALYZE as an update")
 
+      /********** FEEDBACK STATEMENTS **********/
       case feedback: Feedback => {
         val name = feedback.getModel().toUpperCase()
         val idx = feedback.getIdx()
@@ -314,6 +318,7 @@ case class Database(backend: Backend)
         }
       }
 
+      /********** CREATE LENS STATEMENTS **********/
       case lens: CreateLens => {
         val t = lens.getType().toUpperCase()
         val name = lens.getName()
@@ -322,8 +327,11 @@ case class Database(backend: Backend)
 
         lenses.createLens(t, name, query, args)
       }
+
+      /********** CREATE VIEW STATEMENTS **********/
       case view: CreateView => views.createView(view.getTable().getName().toUpperCase, 
                                                 sql.convert(view.getSelectBody()))
+      /********** LOAD STATEMENTS **********/
       case load: Load => {
         // Assign a default table name if needed
         val target = 
@@ -335,21 +343,23 @@ case class Database(backend: Backend)
         loadTable(target, load.getFile)
       }
 
+      /********** DROP STATEMENTS **********/
       case drop: Drop     => {
-          drop.getType().toUpperCase match {
-            case "TABLE" | "INDEX" => 
-              backend.update(drop.toString());
+        drop.getType().toUpperCase match {
+          case "TABLE" | "INDEX" => 
+            backend.update(drop.toString());
 
-            case "VIEW" =>
-              views.dropView(drop.getName().toUpperCase);
+          case "VIEW" =>
+            views.dropView(drop.getName().toUpperCase);
 
-            case "LENS" =>
-              lenses.dropLens(drop.getName().toUpperCase)
+          case "LENS" =>
+            lenses.dropLens(drop.getName().toUpperCase)
 
-            case _ =>
-              throw new SQLException("Invalid drop type '"+drop.getType()+"'")
-          }
+          case _ =>
+            throw new SQLException("Invalid drop type '"+drop.getType()+"'")
+        }
       }
+
       case _                => backend.update(stmt.toString())
     }
   }

--- a/src/main/scala/mimir/algebra/Operator.scala
+++ b/src/main/scala/mimir/algebra/Operator.scala
@@ -256,10 +256,10 @@ case class Table(name: String,
  *
  * (e.g., as in SELECT * FROM FOO ORDER BY bar ASC)
  */
-case class SortColumn(expr: Expression, ascending:Boolean)
+case class SortColumn(expression: Expression, ascending:Boolean)
 {
   override def toString() = 
-    (expr + " " + (if(ascending){"ASC"}else{"DESC"}))
+    (expression + " " + (if(ascending){"ASC"}else{"DESC"}))
 }
 /**
  * Indicates that the source operator's output should be sorted in the
@@ -277,7 +277,7 @@ case class Sort(sorts:Seq[SortColumn], src: Operator) extends Operator
   }
   def children: List[Operator] = List(src)
   def rebuild(x: Seq[Operator]) = Sort(sorts, x(0))
-  def expressions = sorts.map(_.expr)
+  def expressions = sorts.map(_.expression)
   def rebuildExpressions(x: Seq[Expression]) = 
     Sort(x.zip(sorts).map { col => SortColumn(col._1, col._2.ascending) }, src)
 }

--- a/src/main/scala/mimir/algebra/OperatorUtils.scala
+++ b/src/main/scala/mimir/algebra/OperatorUtils.scala
@@ -49,6 +49,15 @@ object OperatorUtils {
     else { return Union(head, makeUnion(tail)) }
   }
 
+  def makeDistinct(oper: Operator): Operator = 
+  {
+    Aggregate(
+      oper.schema.map(_._1).map(Var(_)),
+      Seq(),
+      oper
+    )
+  }
+
   def extractProjections(oper: Operator): (Seq[ProjectArg], Operator) =
   {
     oper match {

--- a/src/main/scala/mimir/algebra/QueryNamer.scala
+++ b/src/main/scala/mimir/algebra/QueryNamer.scala
@@ -36,7 +36,7 @@ object QueryNamer
 			case Limit(_, _, src) =>
 				nameQuery(src)
 			case Sort(cols, src) =>
-				nameQuery(src)+"_BY_"+cols.flatMap(col => ExpressionUtils.getColumns(col.expr)).mkString("_")
+				nameQuery(src)+"_BY_"+cols.flatMap(col => ExpressionUtils.getColumns(col.expression)).mkString("_")
 		}
 	}
 

--- a/src/main/scala/mimir/ctables/CTExplainer.scala
+++ b/src/main/scala/mimir/ctables/CTExplainer.scala
@@ -228,7 +228,7 @@ class CTExplainer(db: Database) extends LazyLogging {
 	{
 		logger.trace(s"GETTING REASONS: $expr")
 		expr match {
-			case v: VGTerm => Map(v.model.name -> makeReason(v, v.args.map(Eval.eval(_,tuple))))
+			case v: VGTerm => Map(v.model.name -> new Reason(v.model, v.idx, v.args.map(Eval.eval(_,tuple))))
 
 			case Conditional(c, t, e) =>
 				(
@@ -300,30 +300,5 @@ class CTExplainer(db: Database) extends LazyLogging {
 		val tuple = finalSchema.map(_._1).zip(baseData.head).toMap
 
 		(tuple, columnExprs, rowCondition)
-	}
-
-	def makeReason(term: VGTerm, v: Seq[PrimitiveValue]): Reason =
-		makeReason(term.model, term.idx, v)
-	def makeReason(model: Model, idx: Int, v: Seq[PrimitiveValue]): Reason =
-	{
-    Reason(
-      model.reason(idx, v),
-      model.name,
-      idx,
-      v,
-      makeRepair(model, idx, v)
-    )
-	}
-
-	def makeRepair(term: VGTerm, v: Seq[PrimitiveValue]): Repair =
-		makeRepair(term.model, term.idx, v)
-	def makeRepair(model: Model, idx: Int, v: Seq[PrimitiveValue]): Repair =
-	{
-		model match {
-			case finite:( Model with FiniteDiscreteDomain ) =>
-				RepairFromList(finite.getDomain(idx, v))
-			case _ => 
-				RepairByType(model.varType(idx, v.map(_.getType)))
-		}
 	}
 }

--- a/src/main/scala/mimir/ctables/CTExplainer.scala
+++ b/src/main/scala/mimir/ctables/CTExplainer.scala
@@ -304,6 +304,7 @@ class CTExplainer(db: Database) extends LazyLogging {
 
 	def explainEverything(oper: Operator): Seq[ReasonSet] =
 	{
+		logger.trace("Explain Everything: \n"+oper)
 		oper match {
 			case Table(_,_,_) => Seq()
 

--- a/src/main/scala/mimir/ctables/Reason.scala
+++ b/src/main/scala/mimir/ctables/Reason.scala
@@ -1,24 +1,31 @@
 package mimir.ctables
 
 import mimir.algebra._
+import mimir.models._
 import mimir.util.JSONBuilder
 
-case class Reason(
-  val reason: String,
-  val model: String,
+class Reason(
+  val model: Model,
   val idx: Int,
-  val args: Seq[PrimitiveValue],
-  val repair: Repair
+  val args: Seq[PrimitiveValue]
 ){
   override def toString: String = 
     reason+" ("+model+";"+idx+"["+args.mkString(", ")+"])"
 
+  def reason: String =
+    model.reason(idx, args)
+
+  def repair: Repair = 
+    Repair.makeRepair(model, idx, args)
+
   def toJSON: String =
     JSONBuilder.dict(Map(
       "english" -> JSONBuilder.string(reason),
-      "source"  -> JSONBuilder.string(model),
+      "source"  -> JSONBuilder.string(model.name),
       "varid"   -> JSONBuilder.int(idx),
       "args"    -> JSONBuilder.list( args.map( x => JSONBuilder.string(x.toString)).toList ),
       "repair"  -> repair.toJSON
     ))
 }
+
+case class ReasonSet(model: String, idx: Int, args: Operator)

--- a/src/main/scala/mimir/ctables/Reason.scala
+++ b/src/main/scala/mimir/ctables/Reason.scala
@@ -26,6 +26,31 @@ class Reason(
       "args"    -> JSONBuilder.list( args.map( x => JSONBuilder.string(x.toString)).toList ),
       "repair"  -> repair.toJSON
     ))
+
+  def equals(r: Reason): Boolean = 
+    model.name.equals(r.model.name) && 
+      (idx == r.idx) && 
+      (args.equals(r.args))
+
+  override def hashCode: Int = 
+    model.hashCode * idx * args.map(_.hashCode).sum
 }
 
-case class ReasonSet(model: String, idx: Int, args: Operator)
+class ReasonSet(model: Model, idx: Int, argLookup: Set[Operator])
+
+object ReasonSet
+{
+  def make(v:VGTerm, input: Operator): ReasonSet =
+  {
+    if(v.args.isEmpty){ return new ReasonSet(v.model, v.idx, Set()); }
+
+    val args =
+      v.args.zipWithIndex.map { case (expr, i) => ProjectArg("ARG_"+i, expr) }
+
+    return new ReasonSet(
+      v.model,
+      v.idx,
+      Set(Project(args, input))
+    );
+  }
+}

--- a/src/main/scala/mimir/ctables/Reason.scala
+++ b/src/main/scala/mimir/ctables/Reason.scala
@@ -37,14 +37,16 @@ class Reason(
     model.hashCode * idx * args.map(_.hashCode).sum
 }
 
-class ReasonSet(model: Model, idx: Int, argLookup: Option[Operator])
+class ReasonSet(val model: Model, val idx: Int, argLookup: Option[Operator])
 {
   def size(db: Database): Long =
   {
     argLookup match {
       case Some(query) => 
         db.query(
-          Aggregate(List(), List(AggFunction("COUNT", true, List(), "COUNT")), query)
+          Aggregate(List(), List(AggFunction("COUNT", false, List(), "COUNT")), 
+            OperatorUtils.makeDistinct(query)
+          )
         ).allRows.head(0).asLong
       case None => 
         1

--- a/src/main/scala/mimir/ctables/Reason.scala
+++ b/src/main/scala/mimir/ctables/Reason.scala
@@ -52,26 +52,28 @@ class ReasonSet(val model: Model, val idx: Int, argLookup: Option[Operator])
         1
     }
   }
-  def all(db: Database): Iterable[Reason] = 
+  def allArgs(db: Database): Iterable[Seq[PrimitiveValue]] =
   {
     argLookup match {
-      case Some(query) =>
-        db.query(query).mapRows( row => new Reason(model, idx, row.currentRow) )
-      case None => 
-        new Some(new Reason(model, idx, List()))
+      case Some(query) => db.query(query).allRows
+      case None =>  List(Seq())
     }
   }
-  def take(db: Database, count: Int): Iterable[Reason] = 
+  def takeArgs(db: Database, count: Int): Iterable[Seq[PrimitiveValue]] = 
   {
     if(count < 1){ return None }
     argLookup match {
-      case Some(query) =>
-        db.query(
-          Limit(0, Some(count), query)
-        ).mapRows( row => new Reason(model, idx, row.currentRow) )
-      case None => 
-        new Some(new Reason(model, idx, List()))
+      case Some(query) => db.query(Limit(0, Some(count), query)).allRows
+      case None =>  List(Seq())
     }
+  }
+  def all(db: Database): Iterable[Reason] = 
+  {
+    allArgs(db).map( new Reason(model, idx, _) )
+  }
+  def take(db: Database, count: Int): Iterable[Reason] = 
+  {
+    takeArgs(db, count).map( new Reason(model, idx, _) )
   }
 }
 

--- a/src/main/scala/mimir/ctables/Reason.scala
+++ b/src/main/scala/mimir/ctables/Reason.scala
@@ -39,7 +39,7 @@ class Reason(
 
 class ReasonSet(model: Model, idx: Int, argLookup: Option[Operator])
 {
-  def countReasons(db: Database): Long =
+  def size(db: Database): Long =
   {
     argLookup match {
       case Some(query) => 
@@ -50,7 +50,7 @@ class ReasonSet(model: Model, idx: Int, argLookup: Option[Operator])
         1
     }
   }
-  def allReasons(db: Database): Iterable[Reason] = 
+  def all(db: Database): Iterable[Reason] = 
   {
     argLookup match {
       case Some(query) =>
@@ -59,7 +59,7 @@ class ReasonSet(model: Model, idx: Int, argLookup: Option[Operator])
         new Some(new Reason(model, idx, List()))
     }
   }
-  def someReasons(db: Database, count: Int): Iterable[Reason] = 
+  def take(db: Database, count: Int): Iterable[Reason] = 
   {
     if(count < 1){ return None }
     argLookup match {

--- a/src/main/scala/mimir/ctables/Repair.scala
+++ b/src/main/scala/mimir/ctables/Repair.scala
@@ -1,11 +1,27 @@
 package mimir.ctables
 
 import mimir.algebra._
+import mimir.models._
 import mimir.util._
 
 sealed trait Repair
 {
   def toJSON: String
+}
+
+object Repair
+{
+  def makeRepair(term: VGTerm, v: Seq[PrimitiveValue]): Repair =
+    makeRepair(term.model, term.idx, v)
+  def makeRepair(model: Model, idx: Int, v: Seq[PrimitiveValue]): Repair =
+  {
+    model match {
+      case finite:( Model with FiniteDiscreteDomain ) =>
+        RepairFromList(finite.getDomain(idx, v))
+      case _ => 
+        RepairByType(model.varType(idx, v.map(_.getType)))
+    }
+  }
 }
 
 case class RepairFromList(choices: Seq[(PrimitiveValue, Double)])

--- a/src/main/scala/mimir/exec/ResultIterator.scala
+++ b/src/main/scala/mimir/exec/ResultIterator.scala
@@ -118,11 +118,6 @@ abstract class ResultIterator {
     mapRows(_.currentRow())
 
   /**
-   * A list of explanations for the indicated column
-   */
-  def reason(ind: Int): Seq[Reason] = Seq()
-
-  /**
    * A unique identifier for every output that can be unwrapped to generate per-row provenance
    */
   def provenanceToken(): RowIdPrimitive

--- a/src/main/scala/mimir/optimizer/ProjectRedundantColumns.scala
+++ b/src/main/scala/mimir/optimizer/ProjectRedundantColumns.scala
@@ -43,7 +43,7 @@ object ProjectRedundantColumns {
 
       case Sort(cols, source) => {
         val childDependencies = 
-          cols.map(_.expr).flatMap(ExpressionUtils.getColumns(_)) ++ dependencies
+          cols.map(_.expression).flatMap(ExpressionUtils.getColumns(_)) ++ dependencies
 
         Sort(cols, apply(source, childDependencies.toSet))
       }

--- a/src/main/scala/mimir/sql/RAToSql.scala
+++ b/src/main/scala/mimir/sql/RAToSql.scala
@@ -222,7 +222,7 @@ class RAToSql(db: Database)
           //
           ob.setExpression(
             convert(
-              Eval.inline(col.expr, sortBindings),
+              Eval.inline(col.expression, sortBindings),
               schemas
             ))
           ob.setAsc(col.ascending)

--- a/src/test/scala/mimir/demo/SimpleDemoScript.scala
+++ b/src/test/scala/mimir/demo/SimpleDemoScript.scala
@@ -387,7 +387,7 @@ object SimpleDemoScript
 						) r, Product p
 						""", "1|right|3", "RATING")
 				)
-			explain0.reasons.map(_.model.replaceAll(":.*", "")) must contain(eachOf(
+			explain0.reasons.map(_.model.name.replaceAll(":.*", "")) must contain(eachOf(
 				"RATINGS2FINAL",
 				"RATINGS2"
 			))

--- a/src/test/scala/mimir/lenses/AnalyzeSpec.scala
+++ b/src/test/scala/mimir/lenses/AnalyzeSpec.scala
@@ -1,0 +1,43 @@
+package mimir.lenses
+
+import java.io._
+import org.specs2.specification._
+import org.specs2.mutable._
+import mimir.test._
+
+object AnalyzeSpec 
+  extends SQLTestSpecification("AnalyzeTests")
+  with BeforeAll
+{
+
+  def beforeAll = 
+  {
+    update("CREATE TABLE R(A string, B int, C int)")
+    loadCSV("R", new File("test/r_test/r.csv"))
+    update("CREATE LENS TI AS SELECT * FROM R WITH TYPE_INFERENCE(0.5)")
+    update("CREATE LENS MV AS SELECT * FROM TI WITH MISSING_VALUE('B', 'C')")
+  }
+
+  "The CTExplainer" should {
+
+    "Explain everything" >> {
+
+      val resultSets = explainEverything("SELECT * FROM MV")
+      
+      resultSets.map( _.model.name ) must contain(eachOf(
+         "MV:WEKA:B", "MV:WEKA:C", "TI"
+      ))
+
+      resultSets.map {
+        set => (set.model.name -> set.size(db)) 
+      }.toMap must contain(eachOf(
+        ("MV:WEKA:B" -> 1l),
+        ("MV:WEKA:C" -> 1l),
+        ("TI" -> 1l)
+      ))
+
+
+    }
+  }
+
+}

--- a/src/test/scala/mimir/test/SQLTestSpecification.scala
+++ b/src/test/scala/mimir/test/SQLTestSpecification.scala
@@ -11,6 +11,7 @@ import mimir.sql._
 import mimir.algebra._
 import mimir.util._
 import mimir.exec._
+import mimir.optimizer._
 
 object DBTestInstances
 {
@@ -93,17 +94,28 @@ abstract class SQLTestSpecification(val tempDBName:String, config: Map[String,St
     query(s).mapRows( _.currentRow ).head
   def table(t: String) =
     db.getTableOperator(t)
-  def explainRow(s: String, t: String) = {
-    val query = db.sql.convert(
+  def resolveViews(q: Operator) =
+    ResolveViews(db,q)
+  def explainRow(s: String, t: String) = 
+  {
+    val query = resolveViews(db.sql.convert(
       stmt(s).asInstanceOf[net.sf.jsqlparser.statement.select.Select]
-    )
+    ))
     db.explainRow(query, RowIdPrimitive(t))
   }
-  def explainCell(s: String, t: String, a:String) = {
-    val query = db.sql.convert(
+  def explainCell(s: String, t: String, a:String) = 
+  {
+    val query = resolveViews(db.sql.convert(
       stmt(s).asInstanceOf[net.sf.jsqlparser.statement.select.Select]
-    )
+    ))
     db.explainCell(query, RowIdPrimitive(t), a)
+  }
+  def explainEverything(s: String) = 
+  {
+    val query = resolveViews(db.sql.convert(
+      stmt(s).asInstanceOf[net.sf.jsqlparser.statement.select.Select]
+    ))
+    db.explainer.explainEverything(query)
   }
   def update(s: Statement) = 
     db.update(s)


### PR DESCRIPTION
* Added CTExplainer.explainEverything to generate a ReasonSet summarizing everything that could inject nondeterminism into a query.
* Added ReasonSet, a compact encoding of a set of sources of nondeterminism that all stem from the same model: A ReasonSet is a Model, Index, and a query to generate a list of arguments 
* Added support for `ANALYZE`, a text interface front-end for CTExplainer (since `EXPLAIN` is already part of SQL): Syntax is:
    * `ANALYZE colname OF rowid IN query` : explainCell
    * `ANALYZE rowid IN query` : explainRow
    * `ANALYZE query` : explainEverything