### PR TITLE
Added a "Hint" parameter to VGTerms

### DIFF
--- a/src/main/scala/mimir/ctables/CTExplainer.scala
+++ b/src/main/scala/mimir/ctables/CTExplainer.scala
@@ -20,7 +20,7 @@ abstract class Explanation(
 ) {
 	def fields: List[(String, PrimitiveValue)]
 
-	override def toString(): String = {
+	override def toString(): String = { 
 		(fields ++ List( 
 			("Reasons", reasons.map("\n    "+_.toString).mkString("")),
 			("Token", JSONBuilder.string(token.v))
@@ -228,7 +228,9 @@ class CTExplainer(db: Database) extends LazyLogging {
 	{
 		logger.trace(s"GETTING REASONS: $expr")
 		expr match {
-			case v: VGTerm => Map(v.model.name -> makeReason(v, v.args.map(Eval.eval(_,tuple))))
+			case v: VGTerm => Map(v.model.name -> 
+				makeReason(v, v.args.map(Eval.eval(_,tuple)), v.hints.map(Eval.eval(_,tuple)))
+			)
 
 			case Conditional(c, t, e) =>
 				(
@@ -302,12 +304,12 @@ class CTExplainer(db: Database) extends LazyLogging {
 		(tuple, columnExprs, rowCondition)
 	}
 
-	def makeReason(term: VGTerm, v: Seq[PrimitiveValue]): Reason =
-		makeReason(term.model, term.idx, v)
-	def makeReason(model: Model, idx: Int, v: Seq[PrimitiveValue]): Reason =
+	def makeReason(term: VGTerm, v: Seq[PrimitiveValue], h: Seq[PrimitiveValue]): Reason =
+		makeReason(term.model, term.idx, v, h)
+	def makeReason(model: Model, idx: Int, v: Seq[PrimitiveValue], h: Seq[PrimitiveValue]): Reason =
 	{
     Reason(
-      model.reason(idx, v),
+      model.reason(idx, v, h),
       model.name,
       idx,
       v,

--- a/src/main/scala/mimir/ctables/CTables.scala
+++ b/src/main/scala/mimir/ctables/CTables.scala
@@ -4,22 +4,6 @@ import mimir.algebra._
 import mimir.models._
 import scala.util._
 
-case class VGTerm(
-  model: Model, 
-  idx: Int,
-  args: Seq[Expression]
-) extends Proc(args) {
-  override def toString() = "{{ "+model.name+";"+idx+"["+args.mkString(", ")+"] }}"
-  override def getType(bindings: Seq[Type]):Type = model.varType(idx, bindings)
-  override def children: Seq[Expression] = args
-  override def rebuild(x: Seq[Expression]) = VGTerm(model, idx, x)
-  def get(v: Seq[PrimitiveValue]): PrimitiveValue = 
-  {
-    // println("VGTerm: Get")
-    model.bestGuess(idx, v)
-  }
-}
-
 object CTables 
 {
 
@@ -42,7 +26,7 @@ object CTables
    */
   def isProbabilistic(expr: Expression): Boolean = 
   expr match {
-    case VGTerm(_, _, _) => true
+    case VGTerm(_, _, _, _) => true
     case _ => expr.children.exists( isProbabilistic(_) )
   }
 

--- a/src/main/scala/mimir/ctables/VGTerm.scala
+++ b/src/main/scala/mimir/ctables/VGTerm.scala
@@ -1,0 +1,25 @@
+package mimir.ctables
+
+import mimir.algebra._
+import mimir.models._
+import scala.util._
+
+case class VGTerm(
+  model: Model, 
+  idx: Int,
+  args: Seq[Expression],
+  hints: Seq[Expression]
+) extends Proc(args++hints) {
+  override def toString() = "{{ "+model.name+";"+idx+"["+args.mkString(", ")+"]["+hints.mkString(", ")+"] }}"
+  override def getType(bindings: Seq[Type]):Type = model.varType(idx, bindings)
+  override def children: Seq[Expression] = args ++ hints
+  override def rebuild(x: Seq[Expression]) = {
+    val (a, h) = x.splitAt(args.length)
+    VGTerm(model, idx, a, h)
+  }
+  def get(v: Seq[PrimitiveValue]): PrimitiveValue = 
+  {
+    val (a, h) = v.splitAt(args.length)
+    model.bestGuess(idx, a, h)
+  }
+}

--- a/src/main/scala/mimir/ctables/VGTermSampler.scala
+++ b/src/main/scala/mimir/ctables/VGTermSampler.scala
@@ -1,0 +1,34 @@
+package mimir.ctables
+
+import mimir.algebra._
+import scala.util._
+import mimir.models._
+import java.sql.SQLException
+
+case class VGTermSampler(
+  model: Model, 
+  idx: Int, 
+  args: Seq[Expression], 
+  hints: Seq[Expression], 
+  seed: Expression
+) 
+  extends Proc(  (seed :: (args.toList ++ hints.toList))  )
+{
+  def getType(argTypes: Seq[Type]): Type =
+    model.varType(idx, argTypes)
+  def get(v: Seq[PrimitiveValue]): PrimitiveValue = 
+  {
+    if(v.size < 1){ throw new SQLException("Internal error.  Expecting seed.") }
+    val seed = v.head
+    val (argValues, hintValues) = v.tail.splitAt(args.length)
+    val seedForThisVar = ((seed.asLong * argValues.hashCode) + 13) * model.name.hashCode
+    model.sample(idx, new Random(seedForThisVar), argValues, hintValues)
+  }
+  def rebuild(v: Seq[Expression]) = 
+  {
+    if(v.size < 1){ throw new SQLException("Internal error.  Expecting seed.") }
+    var (a, h) = v.tail.splitAt(args.length)
+    VGTermSampler(model, idx, a, h, v.head)
+  }
+
+}

--- a/src/main/scala/mimir/lenses/KeyRepairLens.scala
+++ b/src/main/scala/mimir/lenses/KeyRepairLens.scala
@@ -50,7 +50,7 @@ object KeyRepairLens {
             Conditional(
               Comparison(Cmp.Lte, Var(s"MIMIR_KR_COUNT_$col"), IntPrimitive(1)),
               Var(col),
-              VGTerm(model, 0, keys.map(Var(_)))
+              VGTerm(model, 0, keys.map(Var(_)), Seq())
             )
           )
         },

--- a/src/main/scala/mimir/lenses/TypeInferenceLens.scala
+++ b/src/main/scala/mimir/lenses/TypeInferenceLens.scala
@@ -50,9 +50,9 @@ object TypeInferenceLens extends LazyLogging
       query.schema.map(_._1).map( col => {
         if(columnIndexes contains col){
           ProjectArg(col, 
-            Function("CAST", List(
+            Function("CAST", Seq(
               Var(col),
-              VGTerm(model, columnIndexes(col), List[Expression]())
+              VGTerm(model, columnIndexes(col), Seq(), Seq())
             ))
           )
         } else {

--- a/src/main/scala/mimir/models/BasicModels.scala
+++ b/src/main/scala/mimir/models/BasicModels.scala
@@ -6,10 +6,11 @@ import scala.util._
 
 object UniformDistribution extends Model("UNIFORM") with Serializable {
   def argTypes(idx: Int) = List(TFloat(), TFloat())
+  def hintTypes(idx: Int) = Seq()
   def varType(idx: Int, argTypes: Seq[Type]) = TFloat()
-  def bestGuess(idx: Int, args: Seq[PrimitiveValue]) = 
+  def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]) = 
     FloatPrimitive((args(0).asDouble + args(1).asDouble) / 2.0)
-  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue]) = {
+  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]) = {
     val low = args(0).asDouble
     val high = args(1).asDouble
     FloatPrimitive(
@@ -31,7 +32,7 @@ object UniformDistribution extends Model("UNIFORM") with Serializable {
     )
 
 
-  def reason(idx: Int, args: Seq[PrimitiveValue]): String = 
+  def reason(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): String = 
     "I put in a random value between "+args(0)+" and "+args(1)
 
   def feedback(idx: Int, args: Seq[PrimitiveValue], v: PrimitiveValue): Unit =
@@ -48,10 +49,11 @@ case class NoOpModel(override val name: String, reasonText:String)
   var acked = false
 
   def argTypes(idx: Int) = List(TAny())
+  def hintTypes(idx: Int) = Seq()
   def varType(idx: Int, args: Seq[Type]) = args(0)
-  def bestGuess(idx: Int, args: Seq[PrimitiveValue]) = args(0)
-  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue]) = args(0)
-  def reason(idx: Int, args: Seq[PrimitiveValue]): String = reasonText
+  def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]) = args(0)
+  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]) = args(0)
+  def reason(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): String = reasonText
   def feedback(idx: Int, args: Seq[PrimitiveValue], v: PrimitiveValue): Unit = { acked = true }
   def isAcknowledged (idx: Int, args: Seq[PrimitiveValue]): Boolean = acked
 }

--- a/src/main/scala/mimir/models/DefaultMetaModel.scala
+++ b/src/main/scala/mimir/models/DefaultMetaModel.scala
@@ -19,11 +19,11 @@ class DefaultMetaModel(name: String, context: String, models: Seq[String])
   with FiniteDiscreteDomain
 {
   def varType(idx: Int, args: Seq[Type]): Type = TString()
-  def bestGuess(idx: Int, args: Seq[PrimitiveValue]): PrimitiveValue =
+  def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): PrimitiveValue =
     choices.getOrElse(idx, StringPrimitive(models.head))
-  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue]): PrimitiveValue =
+  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): PrimitiveValue =
     StringPrimitive(RandUtils.pickFromList(randomness, models))
-  def reason(idx: Int, args: Seq[PrimitiveValue]): String =
+  def reason(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): String =
   {
     choices.get(idx) match {
       case None => {

--- a/src/main/scala/mimir/models/EditDistanceMatchModel.scala
+++ b/src/main/scala/mimir/models/EditDistanceMatchModel.scala
@@ -105,7 +105,7 @@ class EditDistanceMatchModel(
   } 
   def varType(idx: Int, t: Seq[Type]) = TString()
 
-  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue]): PrimitiveValue = 
+  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): PrimitiveValue = 
   {
     StringPrimitive(
       RandUtils.pickFromWeightedList(randomness, colMapping)
@@ -118,7 +118,7 @@ class EditDistanceMatchModel(
     sourceCandidates.contains(v.asString)
   }
 
-  def reason(idx: Int, args: Seq[PrimitiveValue]): String = {
+  def reason(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): String = {
     choices.get(idx) match {
       case None => {
         val sourceName = colMapping.maxBy(_._2)._1
@@ -140,7 +140,7 @@ class EditDistanceMatchModel(
     }
   }
 
-  def bestGuess(idx: Int, args: Seq[PrimitiveValue]): PrimitiveValue = 
+  def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): PrimitiveValue = 
   {
     choices.get(idx) match { 
       case None => {

--- a/src/main/scala/mimir/models/KeyRepairModel.scala
+++ b/src/main/scala/mimir/models/KeyRepairModel.scala
@@ -22,17 +22,18 @@ class KeyRepairModel(name: String, context: String, source: Operator, keys: Seq[
 
   def varType(idx: Int, args: Seq[Type]): Type = TInt()
   def argTypes(idx: Int) = keys.map(_._2)
+  def hintTypes(idx: Int) = Seq()
 
-  def bestGuess(idx: Int, args: Seq[PrimitiveValue]): PrimitiveValue =
+  def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): PrimitiveValue =
     choices.get(args.toList) match {
       case Some(choice) => choice
       case None => getDomain(idx, args).sortBy(_._1.toString).head._1
     }
 
-  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue]): PrimitiveValue = 
+  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): PrimitiveValue = 
     RandUtils.pickFromWeightedList(randomness, getDomain(idx, args))
 
-  def reason(idx: Int, args: Seq[PrimitiveValue]): String =
+  def reason(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): String =
   {
     choices.get(args.toList) match {
       case None => {

--- a/src/main/scala/mimir/models/Model.scala
+++ b/src/main/scala/mimir/models/Model.scala
@@ -53,6 +53,10 @@ abstract class Model(val name: String) extends Serializable {
    * The list of expected arg types (may be TAny)
    */
   def argTypes       (idx: Int): Seq[Type]
+  /**
+   * The list of expected hint types (may be TAny)
+   */
+  def hintTypes      (idx: Int): Seq[Type]
 
   /**
    * Infer the type of the model from the types of the inputs
@@ -67,7 +71,7 @@ abstract class Model(val name: String) extends Serializable {
    * @param args        The skolem identifier for the specific variable to generate a best guess for
    * @return            A primitive value representing the best guess value.
    */
-  def bestGuess      (idx: Int, args: Seq[PrimitiveValue]):  PrimitiveValue
+  def bestGuess      (idx: Int, args: Seq[PrimitiveValue], hints:Seq[PrimitiveValue]):  PrimitiveValue
   /**
    * Generate a sample from the distribution of a variable represented by this model.
    * @param idx         The index of the variable family to generate a sample for
@@ -75,14 +79,14 @@ abstract class Model(val name: String) extends Serializable {
    * @param args        The skolem identifier for the specific variable to generate a sample for
    * @return            A primitive value representing the generated sample
    */
-  def sample         (idx: Int, randomness: Random, args: Seq[PrimitiveValue]):  PrimitiveValue
+  def sample         (idx: Int, randomness: Random, args: Seq[PrimitiveValue], hints:Seq[PrimitiveValue]):  PrimitiveValue
   /**
    * Generate a human-readable explanation for the uncertainty captured by this model.
    * @param idx   The index of the variable family to explain
    * @param args  The skolem identifier for the specific variable to explain
    * @return      A string reason explaining the uncertainty in this model
    */
-  def reason         (idx: Int, args: Seq[PrimitiveValue]): (String)
+  def reason         (idx: Int, args: Seq[PrimitiveValue], hints:Seq[PrimitiveValue]): (String)
   /**
    * Record feedback given as the "correct" value for a variable represented by this model
    * @param idx   The index of the variable family to record feedback for

--- a/src/main/scala/mimir/models/ModelBuildingBlocks.scala
+++ b/src/main/scala/mimir/models/ModelBuildingBlocks.scala
@@ -5,8 +5,5 @@ import mimir.algebra._
 trait NoArgModel
 {
   def argTypes(x: Int): Seq[Type] = List()
-}
-trait NoArgSingleVarModel
-{
-  def argTypes(): Seq[Type] = List()
+  def hintTypes(idx: Int) = Seq()
 }

--- a/src/main/scala/mimir/models/ModelRegistry.scala
+++ b/src/main/scala/mimir/models/ModelRegistry.scala
@@ -26,7 +26,8 @@ object ModelRegistry
    *    List[String]    -> A list of column names to impute on
    *    Operator        -> The relation to impute on
    * Outputs:
-   *    Map[...]        -> A map from column name to a Model/Idx pair 
+   *    Map[...]        -> A map from column name to a Model/Idx pair,
+   *                       along with a sequence of "hint" expressions,
    *                       defining a way to repair the attribute
    *
    * Note that although we request models for a set of columns in a
@@ -50,7 +51,7 @@ object ModelRegistry
    * operator: Select[ROWID = rowid](oper)
    */
   type ImputationConstructor = 
-    ((Database, String, List[String], Operator) => Map[String, (Model,Int)])
+    ((Database, String, List[String], Operator) => Map[String, (Model,Int,Seq[Expression])])
 
   /**
    * Factory method type for SchemaMatch model constructors

--- a/src/main/scala/mimir/models/TypeInferenceModel.scala
+++ b/src/main/scala/mimir/models/TypeInferenceModel.scala
@@ -102,12 +102,12 @@ class TypeInferenceModel(name: String, columns: IndexedSeq[String], defaultFrac:
     (x._2, TypeInferenceModel.priority(x._1) )
 
   def varType(idx: Int, argTypes: Seq[Type]) = TType()
-  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue]): PrimitiveValue = 
+  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): PrimitiveValue = 
     TypePrimitive(
       RandUtils.pickFromWeightedList(randomness, voteList(idx))
     )
 
-  def bestGuess(idx: Int, args: Seq[PrimitiveValue]): PrimitiveValue = 
+  def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): PrimitiveValue = 
   {
     choices.get(idx) match {
       case None => {
@@ -123,7 +123,7 @@ class TypeInferenceModel(name: String, columns: IndexedSeq[String], defaultFrac:
     v.isInstanceOf[TypePrimitive]
 
 
-  def reason(idx: Int, args: Seq[PrimitiveValue]): String = {
+  def reason(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): String = {
     choices.get(idx) match {
       case None => {
         val (guess, guessVotes) = voteList(idx).maxBy( rankFn _ )

--- a/src/main/scala/mimir/optimizer/InlineVGTerms.scala
+++ b/src/main/scala/mimir/optimizer/InlineVGTerms.scala
@@ -11,13 +11,13 @@ object InlineVGTerms {
 	{
 
 		e match {
-			case v @ VGTerm(model, idx, args) => 
-				val simplifiedArgs = args.map(apply(_));
+			case v @ VGTerm(model, idx, args, hints) => 
+				val simplifiedChildren = v.children.map(apply(_))
 
-				if(simplifiedArgs.forall(_.isInstanceOf[PrimitiveValue])){
-					v.get(simplifiedArgs.map(_.asInstanceOf[PrimitiveValue]))
+				if(simplifiedChildren.forall(_.isInstanceOf[PrimitiveValue])){
+					v.get(simplifiedChildren.map(_.asInstanceOf[PrimitiveValue]))
 				} else {
-					v.rebuild(simplifiedArgs)
+					v.rebuild(simplifiedChildren)
 				}
 
 			case _ => e.rebuild(e.children.map(inline(_)))
@@ -31,20 +31,7 @@ object InlineVGTerms {
 
 	def apply(o: Operator): Operator = 
 	{
-		o match {
-
-			case Project(cols, src) => 
-				Project(
-					cols.map( (col:ProjectArg) => ProjectArg(col.name, apply(col.expression)) ),
-					apply(src)
-				)
-
-			case Select(cond, src) =>
-				Select(apply(cond), apply(src))
-
-			case _ => o.rebuild(o.children.map(apply(_)))
-
-		}
+		o.recurExpressions(apply(_)).recur(apply(_))
 	}
 
 }

--- a/src/main/scala/mimir/parser/ExpressionParser.scala
+++ b/src/main/scala/mimir/parser/ExpressionParser.scala
@@ -117,12 +117,20 @@ class ExpressionParser(modelLookup: (String => Model)) extends RegexParsers {
 
 
 	def vgterm = ("\\{\\{ *".r ~> id ~ 
-					opt("[" ~> exprList <~ "]") <~ 
+					opt(("[" ~> exprList <~ "]") ~
+						opt("[" ~> exprList <~ "]")
+					) <~ 
 					" *\\}\\}".r) ^^ {
-		case v ~ args => {
+		case v ~ argsAndHints => {
+			val (args:Seq[Expression], hints:Seq[Expression]) =
+				argsAndHints match {
+					case Some(args ~ Some(hints)) => (args, hints)
+					case Some(args ~ None) => (args, Seq())
+					case None => (Seq(), Seq())
+				}
+
 			val fields = v.split("_")
-			VGTerm(modelLookup(fields(0)), fields(1).toInt,
-				   args.getOrElse(List()))
+			VGTerm(modelLookup(fields(0)), fields(1).toInt, args, hints)
 		}
 	}
 

--- a/src/main/scala/mimir/sql/sqlite/VGTermFunctions.scala
+++ b/src/main/scala/mimir/sql/sqlite/VGTermFunctions.scala
@@ -23,8 +23,12 @@ class BestGuessVGTerm(db:Database)
         model.argTypes(idx).
           zipWithIndex.
           map( arg => value_mimir(arg._2+2, arg._1) )
+      val hintList = 
+        model.hintTypes(idx).
+          zipWithIndex.
+          map( arg => value_mimir(arg._2+argList.length+2, arg._1) )
 
-      val guess = model.bestGuess(idx, argList)
+      val guess = model.bestGuess(idx, argList, hintList)
 
       logger.trace(s"$modelName;$idx: $argList -> $guess")
 
@@ -57,11 +61,12 @@ object VGTermFunctions
 
   def specialize(e: Expression): Expression = {
     e match {
-      case VGTerm(model, idx, args) => 
+      case VGTerm(model, idx, args, hints) => 
         Function(
           bestGuessVGTermFn, 
           List(StringPrimitive(model.name), IntPrimitive(idx))++
-            args.map(specialize(_))
+            args.map(specialize(_))++
+            hints.map(specialize(_))
         )
       case _ => e.recur(specialize(_))
     }

--- a/src/test/scala/mimir/algebra/ParserSpecs.scala
+++ b/src/test/scala/mimir/algebra/ParserSpecs.scala
@@ -44,24 +44,24 @@ object ParserSpecs extends Specification {
     }
     "Handle VGTerms without parameters" in {
       expr("{{ TR1INFER_0[] }}") must be equalTo
-        VGTerm( model("TR1INFER"), 0, List())
+        VGTerm( model("TR1INFER"), 0, List(), List())
     }
     "Handle fields nested in VGTerms" in {
       expr("{{ TEST_0[ 1 ] }}") must be equalTo 
-        VGTerm( model("TEST"), 0, List(IntPrimitive(1)))
+        VGTerm( model("TEST"), 0, List(IntPrimitive(1)), List())
     }
     "Handle recursively nested VGTerms" in {
       expr("{{ TEST_0[ {{ TEST_1 }} ] }}") must be equalTo
         VGTerm( model("TEST"), 0, List(
-          VGTerm( model("TEST"), 1, List())
-        ))
+          VGTerm( model("TEST"), 1, List(), List())
+        ), List())
     }
     "Handle recursively nested VGTerms mixed with others" in {
       expr("{{ TR1CAST_0[ROWID, {{ TR1INFER_0[] }}] }}") must be equalTo
         VGTerm( model("TR1CAST"), 0, List(
           RowIdVar(),
-          VGTerm( model("TR1INFER"), 0, List())
-        ))
+          VGTerm( model("TR1INFER"), 0, List(), List())
+        ), List())
     }
   }
 

--- a/src/test/scala/mimir/lenses/FeedbackSpec.scala
+++ b/src/test/scala/mimir/lenses/FeedbackSpec.scala
@@ -28,10 +28,10 @@ object FeedbackSpec
 
       // Base assumptions.  These may change, but the feedback tests 
       // below should be updated accordingly
-      model.bestGuess(0, List()) must be equalTo(str("B"))
+      model.bestGuess(0, List(), List()) must be equalTo(str("B"))
 
       model.feedback(0, List(), str("C"))
-      model.bestGuess(0, List()) must be equalTo(str("C"))
+      model.bestGuess(0, List(), List()) must be equalTo(str("C"))
     }
 
     "Support SQL Feedback" >> {
@@ -39,11 +39,11 @@ object FeedbackSpec
 
       // Base assumptions.  These may change, but the feedback tests 
       // below should be updated accordingly
-      model.bestGuess(0, List()) must be equalTo(str("C"))
+      model.bestGuess(0, List(), List()) must be equalTo(str("C"))
 
       // Test Model C
       update("FEEDBACK MATCH:EDITDISTANCE:CX 0 IS 'B'")
-      model.bestGuess(0, List()) must be equalTo(str("B"))
+      model.bestGuess(0, List(), List()) must be equalTo(str("B"))
     }
 
   }
@@ -55,13 +55,13 @@ object FeedbackSpec
 
       // Base assumptions.  These may change, but the feedback tests 
       // below should be updated accordingly
-      model.bestGuess(0, List()) must be equalTo(TypePrimitive(TInt()))
+      model.bestGuess(0, List(), List()) must be equalTo(TypePrimitive(TInt()))
       db.bestGuessSchema(table("TI")).
         find(_._1.equals("A")).get._2 must be equalTo(TInt())
 
       model.feedback(0, List(), TypePrimitive(TFloat()))
 
-      model.bestGuess(0, List()) must be equalTo(TypePrimitive(TFloat()))
+      model.bestGuess(0, List(), List()) must be equalTo(TypePrimitive(TFloat()))
       db.bestGuessSchema(table("TI")).
         find(_._1.equals("A")).get._2 must be equalTo(TFloat())
     }
@@ -73,9 +73,9 @@ object FeedbackSpec
       val model = db.models.get("MV:WEKA:B")
       val nullRow = querySingleton("SELECT ROWID() FROM R WHERE B IS NULL")
 
-      model.bestGuess(0, List(nullRow)) must not be equalTo(50)
+      model.bestGuess(0, List(nullRow), List()) must not be equalTo(50)
       model.feedback(0, List(nullRow), IntPrimitive(50))
-      model.bestGuess(0, List(nullRow)).asLong must be equalTo(50)
+      model.bestGuess(0, List(nullRow), List()).asLong must be equalTo(50)
 
     }
 
@@ -83,7 +83,7 @@ object FeedbackSpec
       val model = db.models.get("MV:WEKA:C")
       val nullRow = querySingleton("SELECT ROWID() FROM R WHERE C IS NULL")
 
-      val originalGuess = model.bestGuess(0, List(nullRow)).asLong
+      val originalGuess = model.bestGuess(0, List(nullRow), List()).asLong
       querySingleton(s"""
         SELECT C FROM MV WHERE ROWID() = ROWID($nullRow)
       """) must be equalTo(IntPrimitive(originalGuess))

--- a/src/test/scala/mimir/lenses/LensManagerSpec.scala
+++ b/src/test/scala/mimir/lenses/LensManagerSpec.scala
@@ -39,15 +39,15 @@ object LensManagerSpec extends SQLTestSpecification("LensTests") {
       coresModel must not be empty
 
       resolved2.get("CORES") must be equalTo(Some(
-        Function("CAST", List(Var("CORES"), VGTerm(coresModel, coresColumnId, List())))
+        Function("CAST", List(Var("CORES"), VGTerm(coresModel, coresColumnId, List(), List())))
       ))
 
-      coresModel.reason(coresColumnId, List()) must contain("was of type INT")
+      coresModel.reason(coresColumnId, List(), List()) must contain("was of type INT")
 
-      val coresGuess1 = coresModel.bestGuess(coresColumnId, List())
+      val coresGuess1 = coresModel.bestGuess(coresColumnId, List(), List())
       coresGuess1 must be equalTo(TypePrimitive(TInt()))
 
-      val coresGuess2 = InlineVGTerms(VGTerm(coresModel, coresColumnId, List()))
+      val coresGuess2 = InlineVGTerms(VGTerm(coresModel, coresColumnId, List(), List()))
       coresGuess2 must be equalTo(TypePrimitive(TInt()))
 
 

--- a/src/test/scala/mimir/models/EditDistanceMatchModelSpec.scala
+++ b/src/test/scala/mimir/models/EditDistanceMatchModelSpec.scala
@@ -15,10 +15,10 @@ object EditDistanceMatchModelSpec extends Specification
   }
 
   def guess(model:(Model,Int)): String = 
-    model._1.bestGuess(model._2, List[PrimitiveValue]()).asString
+    model._1.bestGuess(model._2, List(), List()).asString
   def sample(model:(Model,Int), count:Int): List[String] = {
     (0 to count).map( i => 
-      model._1.sample(model._2, new Random(), List[PrimitiveValue]()).asString
+      model._1.sample(model._2, new Random(), List(), List()).asString
     ).toList
   }
 

--- a/src/test/scala/mimir/models/TypeInferenceModelSpec.scala
+++ b/src/test/scala/mimir/models/TypeInferenceModelSpec.scala
@@ -22,7 +22,7 @@ object TypeInferenceModelSpec extends SQLTestSpecification("TypeInferenceTests")
 
   def guess(model: Model): Type =
   {
-    model.bestGuess(0, List[PrimitiveValue]()) match {
+    model.bestGuess(0, List[PrimitiveValue](), List()) match {
       case TypePrimitive(t) => t
     }
   }

--- a/src/test/scala/mimir/models/WekaModelSpec.scala
+++ b/src/test/scala/mimir/models/WekaModelSpec.scala
@@ -9,15 +9,15 @@ object WekaModelSpec extends SQLTestSpecification("WekaTest")
 {
   sequential
 
-  var models = Map[String,(Model,Int)]()
+  var models = Map[String,(Model,Int,Seq[Expression])]()
 
   def predict(col:String, row:String): PrimitiveValue = {
-    val (model, idx) = models(col)
-    model.bestGuess(idx, List(RowIdPrimitive(row)))
+    val (model, idx, hints) = models(col)
+    model.bestGuess(idx, List(RowIdPrimitive(row)), List())
   }
   def explain(col:String, row:String): String = {
-    val (model, idx) = models(col)
-    model.reason(idx, List(RowIdPrimitive(row)))
+    val (model, idx, hints) = models(col)
+    model.reason(idx, List(RowIdPrimitive(row)), List())
   }
   def trueValue(col:String, row:String): PrimitiveValue = {
     val t = db.getTableSchema("CPUSPEED").get.find(_._1.equals(col)).get._2
@@ -96,13 +96,13 @@ object WekaModelSpec extends SQLTestSpecification("WekaTest")
   "When combined with a TI Lens, the Weka Model" should {
     "Be trainable" >> {
       db.loadTable("RATINGS1", new File("test/data/ratings1.csv"))
-      val (model, idx) = WekaModel.train(db,
+      val (model, idx, hints) = WekaModel.train(db,
         "RATINGS1REPAIRED", 
         List("RATING"), 
         db.getTableOperator("RATINGS1")
       )("RATING")
       val nullRow = querySingleton("SELECT ROWID() FROM RATINGS1 WHERE RATING IS NULL")
-      model.bestGuess(idx, List(nullRow)) must beAnInstanceOf[FloatPrimitive]
+      model.bestGuess(idx, List(nullRow), List()) must beAnInstanceOf[FloatPrimitive]
 
 
     }


### PR DESCRIPTION
There are a number of cases where Models are required to run nested queries to get additional information.
For example, the WekaModel needs other attribute values from the same row.  In principle, these values are all present, but they're not accessible to the model itself.  Similarly, the KeyRepair lens needs other possible values for the same key.

The hints field is distinct from the args field, as it is not used to uniquely identify the variable being created by the VGTerm.  However, in cases where it is feasible to pass additional information to the model to accelerate it, the hints field may be used to do so.

As of right now, the hints field is not yet being used, but it is present and available.