### PR TITLE
Inline eval

### DIFF
--- a/src/main/scala/mimir/algebra/Cast.scala
+++ b/src/main/scala/mimir/algebra/Cast.scala
@@ -11,7 +11,11 @@ object Cast
         case TInt()             => IntPrimitive(x.asLong)
         case TFloat()           => FloatPrimitive(x.asDouble)
         case TString()          => StringPrimitive(x.asString)
-        case TDate()            => TextUtils.parseDate(x.asString)
+        case TDate()            => 
+          x match { 
+            case _:DatePrimitive => x
+            case _ => TextUtils.parseDate(x.asString)
+          }
         case TTimeStamp()       => TextUtils.parseTimeStamp(x.asString)
         case TRowId()           => RowIdPrimitive(x.asString)
         case TAny()             => x

--- a/src/main/scala/mimir/algebra/FunctionRegistry.scala
+++ b/src/main/scala/mimir/algebra/FunctionRegistry.scala
@@ -18,7 +18,7 @@ class RegisteredFunction(
   def unfold(args: Seq[Expression]): Option[Expression] = None
 }
 
-class ExpressionFunction(name: String, args:Seq[String], expr: Expression)
+class ExpressionFunction(name: String, val args:Seq[String], val expr: Expression)
   extends RegisteredFunction(name, 
     (argVal) => Eval.eval(expr, args.zip(argVal).toMap),
     (argT) => Typechecker.typeOf(expr, args.zip(argT).toMap)

--- a/src/main/scala/mimir/algebra/FunctionRegistry.scala
+++ b/src/main/scala/mimir/algebra/FunctionRegistry.scala
@@ -7,6 +7,8 @@ import mimir.ctables._
 import mimir.util._
 import mimir.exec.{TupleBundler,WorldBits}
 import mimir.parser.SimpleExpressionParser
+import org.geotools.referencing.datum.DefaultEllipsoid
+import org.joda.time.DateTime
 
 class RegisteredFunction(
 	val name: String, 
@@ -71,7 +73,7 @@ object FunctionRegistry {
 		  (params: Seq[PrimitiveValue]) => 
           { TextUtils.parseDate(params.head.asString) },
 		  _ match {
-		    case TString() :: Nil => TDate()
+		    case _ :: Nil => TDate()
 		    case _ => throw new SQLException("Invalid parameters to DATE()")
 		  }
 		)
@@ -103,12 +105,34 @@ object FunctionRegistry {
 
     registerNative(
       "DST",
-      (args) => ???,
-      (_) => TFloat()
+      (args) => {
+        FloatPrimitive(DefaultEllipsoid.WGS84.orthodromicDistance(
+          args(0).asDouble, //lon1
+          args(1).asDouble, //lat1
+          args(2).asDouble, //lon2
+          args(3).asDouble  //lat2
+        ))
+      },
+      (args) => {
+        (0 until 4).foreach { i => Typechecker.assertNumeric(args(i), Function("DST", List())) }; 
+        TFloat()
+      }
     )
     registerNative(
       "SPEED",
-      (args) => ???,
+      (args) => {
+        val distance: Double = args(0).asDouble
+        val startingDate: DateTime = args(1).asDateTime
+        val endingDate: DateTime =
+          args(2) match {
+            case NullPrimitive() => new DateTime()
+            case x => x.asDateTime
+          }
+
+        val numberOfHours: Long = Math.abs(endingDate.getMillis - startingDate.getMillis) / 1000 / 60 / 60
+
+        FloatPrimitive(distance / 1000 / numberOfHours) // kmph
+      },
       (_) => TFloat()
     )
     registerNative(

--- a/src/main/scala/mimir/algebra/Primitives.scala
+++ b/src/main/scala/mimir/algebra/Primitives.scala
@@ -1,6 +1,7 @@
 package mimir.algebra;
 
 import mimir.algebra.Type._;
+import org.joda.time.DateTime;
 
 /////////////// Primitive Values ///////////////
 
@@ -39,6 +40,11 @@ abstract class PrimitiveValue(t: Type)
    */
   def asBool: Boolean;
   /**
+   * Convert the current object into a DateTime or throw a TypeException if
+   * not possible
+   */
+  def asDateTime: DateTime;
+  /**
    * Convert the current object into a string or throw a TypeException if 
    * not possible.  Note the difference between this and toString.
    * asString returns the content, while toString returns a representation
@@ -69,7 +75,8 @@ case class IntPrimitive(v: Long)
   override def toString() = v.toString
   def asLong: Long = v;
   def asDouble: Double = v.toDouble;
-  def asBool: Boolean = throw new TypeException(TInt(), TBool(), "Cast")
+  def asBool: Boolean = throw new TypeException(TInt(), TBool(), "Hard Cast")
+  def asDateTime: DateTime = throw new TypeException(TInt(), TDate(), "Hard Cast")
   def asString: String = v.toString;
   def payload: Object = v.asInstanceOf[Object];
 }
@@ -83,7 +90,8 @@ case class StringPrimitive(v: String)
   override def toString() = "'"+v.toString+"'"
   def asLong: Long = java.lang.Long.parseLong(v)
   def asDouble: Double = java.lang.Double.parseDouble(v)
-  def asBool: Boolean = throw new TypeException(TString(), TBool(), "Cast")
+  def asBool: Boolean = throw new TypeException(TString(), TBool(), "Hard Cast")
+  def asDateTime: DateTime = throw new TypeException(TString(), TDate(), "Hard Cast")
   def asString: String = v;
   def payload: Object = v.asInstanceOf[Object];
 }
@@ -95,9 +103,10 @@ case class TypePrimitive(t: Type)
   extends PrimitiveValue(TType())
 {
   override def toString() = t.toString
-  def asLong: Long = throw new TypeException(TType(), TInt(), "Cast")
-  def asDouble: Double = throw new TypeException(TType(), TFloat(), "Cast")
-  def asBool: Boolean = throw new TypeException(TType(), TBool(), "Cast")
+  def asLong: Long = throw new TypeException(TType(), TInt(), "Hard Cast")
+  def asDouble: Double = throw new TypeException(TType(), TFloat(), "Hard Cast")
+  def asBool: Boolean = throw new TypeException(TType(), TBool(), "Hard Cast")
+  def asDateTime: DateTime = throw new TypeException(TType(), TDate(), "Hard Cast")
   def asString: String = t.toString;
   def payload: Object = t.asInstanceOf[Object];
 }
@@ -111,7 +120,8 @@ case class RowIdPrimitive(v: String)
   override def toString() = "'"+v.toString+"'"
   def asLong: Long = java.lang.Long.parseLong(v)
   def asDouble: Double = java.lang.Double.parseDouble(v)
-  def asBool: Boolean = throw new TypeException(TRowId(), TBool(), "Cast")
+  def asBool: Boolean = throw new TypeException(TRowId(), TBool(), "Hard Cast")
+  def asDateTime: DateTime = throw new TypeException(TRowId(), TDate(), "Hard Cast")
   def asString: String = v;
   def payload: Object = v.asInstanceOf[Object];
 }
@@ -123,9 +133,10 @@ case class FloatPrimitive(v: Double)
   extends NumericPrimitive(TFloat())
 {
   override def toString() = v.toString
-  def asLong: Long = throw new TypeException(TFloat(), TInt(), "Cast");
+  def asLong: Long = throw new TypeException(TFloat(), TInt(), "Hard Cast");
   def asDouble: Double = v
-  def asBool: Boolean = throw new TypeException(TFloat(), TBool(), "Cast")
+  def asBool: Boolean = throw new TypeException(TFloat(), TBool(), "Hard Cast")
+  def asDateTime: DateTime = throw new TypeException(TFloat(), TDate(), "Hard Cast")
   def asString: String = v.toString;
   def payload: Object = v.asInstanceOf[Object];
 }
@@ -138,9 +149,9 @@ case class DatePrimitive(y: Int, m: Int, d: Int)
   extends PrimitiveValue(TDate())
 {
   override def toString() = s"DATE '${asString}'"
-  def asLong: Long = throw new TypeException(TDate(), TInt(), "Cast");
-  def asDouble: Double = throw new TypeException(TDate(), TFloat(), "Cast");
-  def asBool: Boolean = throw new TypeException(TDate(), TBool(), "Cast")
+  def asLong: Long = throw new TypeException(TDate(), TInt(), "Hard Cast");
+  def asDouble: Double = throw new TypeException(TDate(), TFloat(), "Hard Cast");
+  def asBool: Boolean = throw new TypeException(TDate(), TBool(), "Hard Cast")
   def asString: String = f"$y%04d-$m%02d-$d%02d"
   def payload: Object = (y, m, d).asInstanceOf[Object];
   final def compare(c: DatePrimitive): Integer = {
@@ -157,6 +168,8 @@ case class DatePrimitive(y: Int, m: Int, d: Int)
   def >=(c:DatePrimitive): Boolean = compare(c) >= 0
   def <(c:DatePrimitive): Boolean = compare(c) < 0
   def <=(c:DatePrimitive): Boolean = compare(c) <= 0
+
+  def asDateTime: DateTime = new DateTime(y, m, d, 0, 0)
 }
 
 /**
@@ -168,9 +181,9 @@ case class TimestampPrimitive(y: Int, m: Int, d: Int, hh: Int, mm: Int, ss: Int)
   extends PrimitiveValue(TTimeStamp())
 {
   override def toString() = s"DATE '${asString}'"
-  def asLong: Long = throw new TypeException(TDate(), TInt(), "Cast");
-  def asDouble: Double = throw new TypeException(TDate(), TFloat(), "Cast");
-  def asBool: Boolean = throw new TypeException(TDate(), TBool(), "Cast")
+  def asLong: Long = throw new TypeException(TDate(), TInt(), "Hard Cast");
+  def asDouble: Double = throw new TypeException(TDate(), TFloat(), "Hard Cast");
+  def asBool: Boolean = throw new TypeException(TDate(), TBool(), "Hard Cast")
   def asString: String = f"$y%04d-$m%02d-$d%02d $hh%02d:$mm%02d:$ss%02d"
   def payload: Object = (y, m, d).asInstanceOf[Object];
   final def compare(c: TimestampPrimitive): Integer = {
@@ -193,6 +206,8 @@ case class TimestampPrimitive(y: Int, m: Int, d: Int, hh: Int, mm: Int, ss: Int)
   def >=(c:TimestampPrimitive): Boolean = compare(c) >= 0
   def <(c:TimestampPrimitive): Boolean = compare(c) < 0
   def <=(c:TimestampPrimitive): Boolean = compare(c) <= 0
+
+  def asDateTime: DateTime = new DateTime(y, m, d, hh, mm, ss)
 }
 /**
  * Boxed representation of a boolean
@@ -202,8 +217,9 @@ case class BoolPrimitive(v: Boolean)
   extends PrimitiveValue(TBool())
 {
   override def toString() = if(v) {"TRUE"} else {"FALSE"}
-  def asLong: Long = throw new TypeException(TBool(), TInt(), "Cast");
-  def asDouble: Double = throw new TypeException(TBool(), TFloat(), "Cast");
+  def asLong: Long = throw new TypeException(TBool(), TInt(), "Hard Cast");
+  def asDouble: Double = throw new TypeException(TBool(), TFloat(), "Hard Cast");
+  def asDateTime: DateTime = throw new TypeException(TBool(), TDate(), "Hard Cast")
   def asBool: Boolean = v
   def asString: String = toString;
   def payload: Object = v.asInstanceOf[Object];
@@ -216,9 +232,10 @@ case class NullPrimitive()
   extends PrimitiveValue(TAny())
 {
   override def toString() = "NULL"
-  def asLong: Long = throw new TypeException(TAny(), TInt(), "Cast Null");
-  def asDouble: Double = throw new TypeException(TAny(), TFloat(), "Cast Null");
-  def asString: String = throw new TypeException(TAny(), TString(), "Cast Null");
-  def asBool: Boolean = throw new TypeException(TAny(), TBool(), "Cast Null")
+  def asLong: Long = throw new TypeException(TAny(), TInt(), "Hard Cast Null");
+  def asDouble: Double = throw new TypeException(TAny(), TFloat(), "Hard Cast Null");
+  def asString: String = throw new TypeException(TAny(), TString(), "Hard Cast Null");
+  def asBool: Boolean = throw new TypeException(TAny(), TBool(), "Hard Cast Null")
+  def asDateTime: DateTime = throw new TypeException(TAny(), TDate(), "Hard Cast")
   def payload: Object = null
 }

--- a/src/main/scala/mimir/algebra/Primitives.scala
+++ b/src/main/scala/mimir/algebra/Primitives.scala
@@ -143,7 +143,7 @@ case class DatePrimitive(y: Int, m: Int, d: Int)
   def asBool: Boolean = throw new TypeException(TDate(), TBool(), "Cast")
   def asString: String = f"$y%04d-$m%02d-$d%02d"
   def payload: Object = (y, m, d).asInstanceOf[Object];
-  def compare(c: DatePrimitive): Integer = {
+  final def compare(c: DatePrimitive): Integer = {
     if(c.y < y){ -1 }
     else if(c.y > y) { 1 }
     else if(c.m < m) { -1 }
@@ -152,6 +152,11 @@ case class DatePrimitive(y: Int, m: Int, d: Int)
     else if(c.d > d) { 1 }
     else { 0 }
   }
+
+  def >(c:DatePrimitive): Boolean = compare(c) > 0
+  def >=(c:DatePrimitive): Boolean = compare(c) >= 0
+  def <(c:DatePrimitive): Boolean = compare(c) < 0
+  def <=(c:DatePrimitive): Boolean = compare(c) <= 0
 }
 
 /**
@@ -168,7 +173,7 @@ case class TimestampPrimitive(y: Int, m: Int, d: Int, hh: Int, mm: Int, ss: Int)
   def asBool: Boolean = throw new TypeException(TDate(), TBool(), "Cast")
   def asString: String = f"$y%04d-$m%02d-$d%02d $hh%02d:$mm%02d:$ss%02d"
   def payload: Object = (y, m, d).asInstanceOf[Object];
-  def compare(c: TimestampPrimitive): Integer = {
+  final def compare(c: TimestampPrimitive): Integer = {
     if(c.y < y){ -1 }
     else if(c.y > y) { 1 }
     else if(c.m < m) { -1 }
@@ -183,6 +188,11 @@ case class TimestampPrimitive(y: Int, m: Int, d: Int, hh: Int, mm: Int, ss: Int)
     else if(c.ss > ss) { 1 }
     else { 0 }
   }
+
+  def >(c:TimestampPrimitive): Boolean = compare(c) > 0
+  def >=(c:TimestampPrimitive): Boolean = compare(c) >= 0
+  def <(c:TimestampPrimitive): Boolean = compare(c) < 0
+  def <=(c:TimestampPrimitive): Boolean = compare(c) <= 0
 }
 /**
  * Boxed representation of a boolean

--- a/src/main/scala/mimir/exec/EvalInlined.scala
+++ b/src/main/scala/mimir/exec/EvalInlined.scala
@@ -1,0 +1,314 @@
+package mimir.exec;
+
+import mimir.algebra._
+import scala.util.matching._
+
+class EvalInlined[T](scope: Map[String, (Type, (T => PrimitiveValue))])
+{
+  val typechecker = new ExpressionChecker(scope.mapValues(_._1))
+
+  type Compiled[R] = (T => R)
+
+  def typeOf(e: Expression): Type = typechecker.typeOf(e)
+
+  def compile(e: Expression): Compiled[PrimitiveValue] = 
+    compile(e, typeOf(e))
+
+  def compile(e: Expression, t:Type): Compiled[PrimitiveValue] =
+  {
+    t match {
+      case TAny()       => throw new RAException("Can not compile untyped expression")
+      case TInt()       => val v = compileForLong(e);   (t:T) => { try { IntPrimitive(v(t))    } catch { case _:NullPointerException => NullPrimitive() } }
+      case TFloat()     => val v = compileForDouble(e); (t:T) => { try { FloatPrimitive(v(t))  } catch { case _:NullPointerException => NullPrimitive() } }
+      case TBool()      => val v = compileForBool(e);   (t:T) => { try { BoolPrimitive(v(t))   } catch { case _:NullPointerException => NullPrimitive() } }
+      case TString()    => val v = compileForString(e); (t:T) => { try { StringPrimitive(v(t)) } catch { case _:NullPointerException => NullPrimitive() } }
+      case TType()      => val v = compileForType(e);   (t:T) => { try { TypePrimitive(v(t))   } catch { case _:NullPointerException => NullPrimitive() } }
+      case TDate()      => compileForDate(e); 
+      case TTimeStamp() => compileForTimestamp(e); 
+      case TRowId()     => compileForRowId(e); 
+      case TUser(ut)    => compile(e, TypeRegistry.baseType(ut));
+    }
+  }
+
+  def compileProc(p: Proc): Compiled[PrimitiveValue] =
+  {
+    val args = p.getArgs.map { compile(_) }
+    (t) => { p.get(args.map { _(t) }) }
+  }
+
+  def compileFunction(func: RegisteredFunction, argExprs: Seq[Expression]): Compiled[PrimitiveValue] =
+  {
+    val args = argExprs.map { compile(_) }
+    (t) => { func.eval(args.map { _(t) }) }
+  }
+  def compileConditional[R](c: Expression, t: Expression, e: Expression, rcr: Expression => Compiled[R]): Compiled[R]=
+  {
+    val cv = compileForBool(c)
+    val tv = rcr(t)
+    val ev = rcr(e)
+    (t) => { if(cv(t)){ tv(t) } else { ev(t) } }
+  }
+
+  final def compileBinary[RA,RB](a: Expression, b: Expression, rcr: Expression => (T=>RA))(op:(RA,RA)=>RB): T => RB =
+  {
+    val la = rcr(a)
+    val lb = rcr(b)
+    (t) => { op(la(t), lb(t)) }
+  }
+
+
+  def compileForLong(e: Expression): Compiled[Long] = 
+  {
+    e match {
+      case pv:PrimitiveValue            => (t:T) => pv.asLong
+      case Var(vname)                   => val l = scope(vname)._2; { l(_).asLong }
+      case p:Proc                       => val l = compileProc(p); { l(_).asLong }
+      case Arithmetic(op, lhs, rhs)     => {
+        val lv = compileForLong(lhs)
+        val rv = compileForLong(rhs)
+        op match {
+          case Arith.Add        => (t:T) => { lv(t) + rv(t) }
+          case Arith.Mult       => (t:T) => { lv(t) * rv(t) }
+          case Arith.Sub        => (t:T) => { lv(t) - rv(t) }
+          case Arith.Div        => (t:T) => { lv(t) / rv(t) }
+          case Arith.BitAnd     => (t:T) => { lv(t) & rv(t) }
+          case Arith.BitOr      => (t:T) => { lv(t) | rv(t) }
+          case Arith.ShiftLeft  => (t:T) => { lv(t) << rv(t) }
+          case Arith.ShiftRight => (t:T) => { lv(t) >> rv(t) }
+        }
+      }
+      case Function(name, args) => {
+        val func = FunctionRegistry.functionPrototypes(name)
+        func.unfold(args) match {
+          case Some(fExpr) => compileForLong(fExpr)
+          case None => val l = compileFunction(func, args); { l(_).asLong }
+        }
+      }
+      case Conditional(c, t, e) => compileConditional(c, t, e, compileForLong)
+      case _ => throw new RAException(s"Invalid Expression on Int: $e")
+    }
+  }
+  def compileForDouble(e: Expression): Compiled[Double] = 
+  {
+    e match {
+      case pv:PrimitiveValue            => (t:T) => pv.asDouble
+      case Var(vname)                   => val l = scope(vname)._2; { l(_).asDouble }
+      case p:Proc                       => val l = compileProc(p); { l(_).asDouble }
+      case Arithmetic(op, lhs, rhs)     => {
+        val lv = compileForDouble(lhs)
+        val rv = compileForDouble(rhs)
+        op match {
+          case Arith.Add        => (t:T) => { lv(t) + rv(t) }
+          case Arith.Mult       => (t:T) => { lv(t) * rv(t) }
+          case Arith.Sub        => (t:T) => { lv(t) - rv(t) }
+          case Arith.Div        => (t:T) => { lv(t) / rv(t) }
+          case _                => throw new RAException(s"Invalid Arithmetic on Float: $op")
+        }
+      }
+      case Function(name, args) => {
+        val func = FunctionRegistry.functionPrototypes(name)
+        func.unfold(args) match {
+          case Some(fExpr) => compileForDouble(fExpr)
+          case None => val l = compileFunction(func, args); { l(_).asDouble }
+        }
+      }
+      case Conditional(c, t, e) => compileConditional(c, t, e, compileForDouble)
+      case _ => throw new RAException(s"Invalid Expression on Float: $e")
+    }
+  }
+
+  final def likeToRE(s: String): Regex = 
+    s.replaceAll("[.()\\[\\]]", "\\\\.").replaceAll("%", ".*").replaceAll("\\?", ".").r
+
+
+  def compileForBool(e: Expression): Compiled[Boolean] = 
+  {
+    e match {
+      case pv:PrimitiveValue            => (t:T) => pv.asBool
+      case Var(vname)                   => val l = scope(vname)._2; { l(_).asBool }
+      case p:Proc                       => val l = compileProc(p); { l(_).asBool }
+      case Arithmetic(op, lhs, rhs)     => {
+        val lv = compileForBool(lhs)
+        val rv = compileForBool(rhs)
+        op match {
+          case Arith.And  => (t:T) => { lv(t) && rv(t) }
+          case Arith.Or   => (t:T) => { lv(t) || rv(t) }
+          case _                => throw new RAException(s"Invalid Arithmetic on Float: $op")
+        }
+      }
+      case Comparison(op, lhs, rhs)     => {
+        (op, Type.rootType(typeOf(lhs)), Type.rootType(typeOf(rhs))) match {
+          case (_, TAny(), _) => throw new RAException(s"Invalid comparison on TAny: $e")
+          case (_, _, TAny()) => throw new RAException(s"Invalid comparison on TAny: $e")
+          case (_, TUser(n), _) => throw new RAException(s"Internal error in Type.rootType($n): $e")
+          case (_, _, TUser(n)) => throw new RAException(s"Internal error in Type.rootType($n): $e")
+          case (Cmp.Eq, TBool(), TBool())           => compileBinary(lhs, rhs, compileForBool) { _ == _ }
+          case (Cmp.Eq, TInt(), TInt())             => compileBinary(lhs, rhs, compileForLong) { _ == _ }
+          case (Cmp.Eq, ( TInt() | TFloat() ), ( TInt() | TFloat() ) ) 
+                                                    => compileBinary(lhs, rhs, compileForDouble) { _ == _ }
+          case (Cmp.Eq, TString(), TString())       => compileBinary(lhs, rhs, compileForString) { _.equals(_) }
+          case (Cmp.Eq, TType(), TType())           => compileBinary(lhs, rhs, compileForType) { _.equals(_) }
+          case (Cmp.Eq, TDate(), TDate())           => compileBinary(lhs, rhs, compileForDate) { _.equals(_) }
+          case (Cmp.Eq, TTimeStamp(), TTimeStamp()) => compileBinary(lhs, rhs, compileForTimestamp) { _.equals(_) }
+          case (Cmp.Eq, TRowId(), TRowId())         => compileBinary(lhs, rhs, compileForRowId) { _.equals(_) }
+          case (Cmp.Eq, _, _) 
+              => throw new RAException(s"Invalid comparison: $e")
+          case (Cmp.Neq, _, _)                      => compileForBool(ExpressionUtils.makeNot(Comparison(Cmp.Eq, lhs, rhs)))
+          case (Cmp.Gt, TInt(), TInt())             => compileBinary(lhs, rhs, compileForLong) { _ > _ }
+          case (Cmp.Gte, TInt(), TInt())            => compileBinary(lhs, rhs, compileForLong) { _ >= _ }
+          case (Cmp.Lt, TInt(), TInt())             => compileBinary(lhs, rhs, compileForLong) { _ < _ }
+          case (Cmp.Lte, TInt(), TInt())            => compileBinary(lhs, rhs, compileForLong) { _ <= _ }
+          case (Cmp.Gt, ( TInt() | TFloat() ), ( TInt() | TFloat() ))
+                                                    => compileBinary(lhs, rhs, compileForDouble) { _ > _ }
+          case (Cmp.Gte, ( TInt() | TFloat() ), ( TInt() | TFloat() ))
+                                                    => compileBinary(lhs, rhs, compileForDouble) { _ >= _ }
+          case (Cmp.Lt, ( TInt() | TFloat() ), ( TInt() | TFloat() ))
+                                                    => compileBinary(lhs, rhs, compileForDouble) { _ < _ }
+          case (Cmp.Lte, ( TInt() | TFloat() ), ( TInt() | TFloat() ))
+                                                    => compileBinary(lhs, rhs, compileForDouble) { _ <= _ }
+          case (Cmp.Gt, TDate(), TDate())           => compileBinary(lhs, rhs, compileForDate) { _ > _ }
+          case (Cmp.Gte, TDate(), TDate())          => compileBinary(lhs, rhs, compileForDate) { _ >= _ }
+          case (Cmp.Lt, TDate(), TDate())           => compileBinary(lhs, rhs, compileForDate) { _ < _ }
+          case (Cmp.Lte, TDate(), TDate())          => compileBinary(lhs, rhs, compileForDate) { _ <= _ }
+          case (Cmp.Gt, TTimeStamp(), TTimeStamp()) => compileBinary(lhs, rhs, compileForTimestamp) { _ > _ }
+          case (Cmp.Gte, TTimeStamp(), TTimeStamp())=> compileBinary(lhs, rhs, compileForTimestamp) { _ >= _ }
+          case (Cmp.Lt, TTimeStamp(), TTimeStamp()) => compileBinary(lhs, rhs, compileForTimestamp) { _ < _ }
+          case (Cmp.Lte, TTimeStamp(), TTimeStamp())=> compileBinary(lhs, rhs, compileForTimestamp) { _ <= _ }
+          case (Cmp.Like, TString(), TString()) => {
+            val lv = compileForString(rhs)
+            rhs match {
+              case StringPrimitive(s) => 
+                val re = likeToRE(s)
+                (t) => { re.findFirstIn(lv(t)) != None }
+              case _ => 
+                val rv = compileForString(rhs)
+                (t) => { likeToRE(rv(t)).findFirstIn(lv(t)) != None }
+            }
+          }
+          case (Cmp.Like, _, _) => throw new RAException(s"Invalid comparison: LIKE: $e")
+          case (Cmp.NotLike, TString(), TString()) => compileForBool(ExpressionUtils.makeNot(Comparison(Cmp.Like, lhs, rhs)))
+          case (Cmp.NotLike, _, _) => throw new RAException(s"Invalid comparison: NOT LIKE: $e")
+          case (_, a, b) => throw new RAException(s"Invalid comparison: $a $op $b")
+
+        }
+      }
+      case Not(e)                       => val l = compileForBool(e); { !l(_) }
+      case IsNullExpression(e)          => compileForIsNull(e) match { case Left(x) => {(t) => x}; case Right(x) => x}
+      case Function(name, args) => {
+        val func = FunctionRegistry.functionPrototypes(name)
+        func.unfold(args) match {
+          case Some(fExpr) => compileForBool(fExpr)
+          case None => val l = compileFunction(func, args); { l(_).asBool }
+        }
+      }
+      case Conditional(c, t, e) => compileConditional(c, t, e, compileForBool)
+      case _ => throw new RAException(s"Invalid Expression on Bool: $e")
+    }
+  }
+
+  final def compilePassthrough[R](e: Expression, rcr: Expression => Compiled[R], prim: PrimitiveValue => R): Compiled[R] =
+  {
+    e match {
+      case pv:PrimitiveValue            => (t:T) => prim(pv)
+      case Var(vname)                   => val l = scope(vname)._2; (t) => prim(l(t))
+      case p:Proc                       => val l = compileProc(p); (t) => prim(l(t))
+      case Function(name, args) => {
+        val func = FunctionRegistry.functionPrototypes(name)
+        func.unfold(args) match {
+          case Some(fExpr) => rcr(fExpr)
+          case None => val l = compileFunction(func, args); (t) => prim(l(t))
+        }
+      }
+      case Conditional(c, t, e) => compileConditional(c, t, e, rcr)
+      case _ => throw new RAException(s"Invalid Passthrough Expression: $e")
+    }
+  }
+
+  def compileForString(e: Expression): Compiled[String] = 
+    compilePassthrough(e, compileForString, _.asString)
+  def compileForType(e: Expression): Compiled[Type] = 
+    compilePassthrough(e, compileForType, _.asInstanceOf[TypePrimitive].t)
+  def compileForDate(e: Expression): Compiled[DatePrimitive] = 
+    compilePassthrough(e, compileForDate, _.asInstanceOf[DatePrimitive])    
+  def compileForTimestamp(e: Expression): Compiled[TimestampPrimitive] = 
+    compilePassthrough(e, compileForTimestamp, _.asInstanceOf[TimestampPrimitive])    
+  def compileForRowId(e: Expression): Compiled[RowIdPrimitive] = 
+    compilePassthrough(e, compileForRowId, _.asInstanceOf[RowIdPrimitive])    
+  def and(a: Compiled[Boolean], b: Compiled[Boolean]): Compiled[Boolean] =
+    { (t) => a(t) && b(t) }
+  def or(a: Compiled[Boolean], b: Compiled[Boolean]): Compiled[Boolean] =
+    { (t) => a(t) || b(t) }
+  def compileForIsNull(e: Expression): Either[Boolean, Compiled[Boolean]] = 
+  {
+    e match {
+      case _:NullPrimitive => Left(true)
+      case _:PrimitiveValue => Left(false)
+      case Var(vname) => {
+        val v = scope(vname)._2
+        Right( { v(_) match { case NullPrimitive() => true; case _ => false } } )
+      }
+      case Arithmetic(Arith.And, lhs, rhs) => {
+        (compileForIsNull(lhs), compileForIsNull(rhs)) match {
+          case (Left(true), Left(true)) => Left(true)
+          case (Left(false), Left(false)) => Left(false)
+          case (Left(true), Left(false)) => Right(compileForBool(ExpressionUtils.makeNot(rhs)))
+          case (Left(false), Left(true)) => Right(compileForBool(ExpressionUtils.makeNot(lhs)))
+          case (Left(true), Right(rv)) => Right(or(rv, compileForBool(rhs)))
+          case (Right(lv), Left(true)) => Right(or(lv, compileForBool(lhs)))
+          case (Left(false), Right(rv)) => Right(and(rv, compileForBool(rhs)))
+          case (Right(lv), Left(false)) => Right(and(lv, compileForBool(lhs)))
+          case (Right(lv), Right(rv)) => 
+            Right(or(or(
+              and(lv, rv),
+              and(lv, compileForBool(rhs))
+            ), and(rv, compileForBool(lhs))))
+        }
+      }
+      case Arithmetic(Arith.Or, lhs, rhs) => {
+        (compileForIsNull(lhs), compileForIsNull(rhs)) match {
+          case (Left(true), Left(true)) => Left(true)
+          case (Left(false), Left(false)) => Left(false)
+          case (Left(true), Left(false)) => Right(compileForBool(rhs))
+          case (Left(false), Left(true)) => Right(compileForBool(lhs))
+          case (Left(true), Right(rv)) => Right(or(rv, compileForBool(ExpressionUtils.makeNot(rhs))))
+          case (Right(lv), Left(true)) => Right(or(lv, compileForBool(ExpressionUtils.makeNot(lhs))))
+          case (Left(false), Right(rv)) => Right(and(rv, compileForBool(ExpressionUtils.makeNot(rhs))))
+          case (Right(lv), Left(false)) => Right(and(lv, compileForBool(ExpressionUtils.makeNot(lhs))))
+          case (Right(lv), Right(rv)) => 
+            Right(or(or(
+              and(lv, rv),
+              and(lv, compileForBool(ExpressionUtils.makeNot(rhs)))
+            ), and(rv, compileForBool(ExpressionUtils.makeNot(lhs)))))
+        }
+      }
+      case Arithmetic(_, lhs, rhs) => {
+        (compileForIsNull(lhs), compileForIsNull(rhs)) match {
+          case (Left(true), _) => Left(true)
+          case (_, Left(true)) => Left(true)
+          case (l, Left(false)) => l
+          case (Left(false), r) => r
+          case (Right(l), Right(r)) => Right( (t) => { l(t) && r(t) } )
+        }
+      }
+      case Comparison(_, lhs, rhs) => {
+        (compileForIsNull(lhs), compileForIsNull(rhs)) match {
+          case (Left(true), _) => Left(true)
+          case (_, Left(true)) => Left(true)
+          case (l, Left(false)) => l
+          case (Left(false), r) => r
+          case (Right(l), Right(r)) => Right( {(t) => { l(t) && r(t) } } )
+        }
+      }
+      case Not(ne) => compileForIsNull(ne)
+      case Conditional(c, t, e) => {
+        compileForIsNull(
+          Arithmetic(Arith.Or, 
+            Arithmetic(Arith.And, c, t),
+            Arithmetic(Arith.And, ExpressionUtils.makeNot(c), e)
+          )
+        )
+      }
+    }
+  }
+
+}

--- a/src/main/scala/mimir/exec/stream/ProjectionResultIterator.scala
+++ b/src/main/scala/mimir/exec/stream/ProjectionResultIterator.scala
@@ -4,6 +4,7 @@ import java.sql._
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import mimir.algebra._
 import mimir.util._
+import mimir.exec._
 
 class ProjectionResultIterator(
   tupleDefinition: Seq[ProjectArg],
@@ -35,43 +36,16 @@ class ProjectionResultIterator(
   // and the result is the columnOutput, annotationOutput 
   // elements defined below.
   // 
-  private val inputProcs: Map[String,Proc] =
-  {
-    inputSchema.zipWithIndex.map { case ((name, t), idx) =>
-      (name -> new Proc(Seq()) {
-        def getType(argTypes: Seq[Type]): Type = t
-        def get(v: Seq[PrimitiveValue]): PrimitiveValue =
-          JDBCUtils.convertField(t, source, idx+1)
-        def rebuild(x: Seq[Expression]) = this
-      })
+  private val evalScope: Map[String,(Type, Seq[PrimitiveValue] => PrimitiveValue)] =
+    inputSchema.zipWithIndex.map { 
+      case ((name, t), idx) => (name, (t, (_:Seq[PrimitiveValue])(idx))) 
     }.toMap
-  }  
-  private def inlineProcs(expr: Expression): Expression =
-  {
-    expr match {
-      case Var(name) => inputProcs(name)
-      case _ => expr.recur(inlineProcs(_))
-    }
-  }
-  private def compile(arg: ProjectArg): (() => PrimitiveValue) =
-  {
-    Eval.simplify(arg.expression) match {
-      case pv: PrimitiveValue => {
-        return { () => pv }
-      }
-      case Var(name) => {
-        val idx = inputSchema.indexWhere(_._1.equals(name))
-        return { () => JDBCUtils.convertField(inputSchema(idx)._2, source, idx+1) }
-      }
-      case expr => {
-        val inlined = inlineProcs(expr)
-        return { () => Eval.eval(inlined) }
-      }
-    }
-  }
+  private val eval = new EvalInlined[Seq[PrimitiveValue]](evalScope)
 
-  val columnOutputs: Seq[() => PrimitiveValue] = tupleDefinition.map( compile(_) )
-  val annotationOutputs: Seq[() => PrimitiveValue] = annotationDefinition.map( compile(_) )
+  lazy val columnOutputs: Seq[Seq[PrimitiveValue] => PrimitiveValue] = 
+    tupleDefinition.map { _.expression }.map { eval.compile(_) }
+  lazy val annotationOutputs: Seq[Seq[PrimitiveValue] => PrimitiveValue] = 
+    annotationDefinition.map { _.expression }.map { eval.compile(_) }
   val extractInputs: Seq[() => (String, PrimitiveValue)] =
     inputSchema.
       zipWithIndex.
@@ -82,6 +56,14 @@ class ProjectionResultIterator(
           (name, fn(source))
         }
       }
+  val extractInputsRaw: Seq[() => PrimitiveValue] = 
+    inputSchema.
+      zipWithIndex.
+      map { case ((name, t), idx) => 
+        logger.debug(s"Extracting Raw: $name (@$idx) -> $t")
+        val fn = JDBCUtils.convertFunction(t, idx+1, rowIdType = rowIdAndDateType._1, dateType = rowIdAndDateType._2)
+        () => { fn(source) }
+      }
 
   var closed = false
   def close(): Unit = {
@@ -91,13 +73,13 @@ class ProjectionResultIterator(
 
   var currentRow: Option[Row] = None;
 
-
   val makeRow =
     if(ExperimentalOptions.isEnabled("AGGRESSIVE-ROW-COMPUTE")) {
       () => {
+        val tuple = extractInputsRaw.map { _() }
         new ExplicitRow(
-          columnOutputs.map(_()), 
-          annotationOutputs.map(_()),
+          columnOutputs.map(_(tuple)), 
+          annotationOutputs.map(_(tuple)),
           this
         )
       }

--- a/src/main/scala/mimir/exec/stream/ProjectionResultIterator.scala
+++ b/src/main/scala/mimir/exec/stream/ProjectionResultIterator.scala
@@ -74,22 +74,22 @@ class ProjectionResultIterator(
   var currentRow: Option[Row] = None;
 
   val makeRow =
-    if(ExperimentalOptions.isEnabled("AGGRESSIVE-ROW-COMPUTE")) {
-      () => {
-        val tuple = extractInputsRaw.map { _() }
-        new ExplicitRow(
-          columnOutputs.map(_(tuple)), 
-          annotationOutputs.map(_(tuple)),
-          this
-        )
-      }
-    } else {
+    if(ExperimentalOptions.isEnabled("LAZY-ROW-COMPUTE")) {
       () => {
         new LazyRow(
           extractInputs.map { x => x() }.toMap,
           tupleDefinition,
           annotationDefinition,
           schema
+        )
+      }
+    } else {
+      () => {
+        val tuple = extractInputsRaw.map { _() }
+        new ExplicitRow(
+          columnOutputs.map(_(tuple)), 
+          annotationOutputs.map(_(tuple)),
+          this
         )
       }
     }

--- a/src/test/scala/mimir/demo/CureScenario.scala
+++ b/src/test/scala/mimir/demo/CureScenario.scala
@@ -97,9 +97,9 @@ object CureScenario
                    PORTS.LON              AS "PORT_LON",
                    DATE(SRC.DATE)          AS "SRC_DATE",
                    DST(LOC.LAT, LOC.LON, PORTS.LAT, PORTS.LON) AS "DISTANCE",  SPEED(DST(LOC.LAT, LOC.LON, PORTS.LAT, PORTS.LON), SRC.DATE, NULL) AS "SPEED"
-                 FROM CURESOURCE_RAW AS SRC
-                  JOIN CURELOCATIONS_RAW AS LOC ON SRC.IMO_CODE = LOC.IMO_CODE
-                   LEFT OUTER JOIN CUREPORTS_RAW AS PORTS ON SRC.PORT_OF_ARRIVAL = PORTS.PORT
+                 FROM CURESOURCE AS SRC
+                  JOIN CURELOCATIONS AS LOC ON SRC.IMO_CODE = LOC.IMO_CODE
+                   LEFT OUTER JOIN CUREPORTS AS PORTS ON SRC.PORT_OF_ARRIVAL = PORTS.PORT
                  ;
          """){ _.foreach { row => {} } }
        }


### PR DESCRIPTION
It's not ready for primetime, but for your consideration...
EvalInlined is a complied analog to the interpreted Eval.  EvalInlined uses scala lambdas as
a sort of ghetto bytecode: Expressions are reduced to a function T => PrimitiveValue, where T
is an arbitrary, opaque type that defines a scope for the expression to evaluate in.

This has the potential to significantly boost performance on the CureTests, though I really don't have a good sense for by how much.
