### PR TITLE
Fixing date parsing and a few QOL tweaks (closes #256)

### DIFF
--- a/src/main/scala/mimir/algebra/Cast.scala
+++ b/src/main/scala/mimir/algebra/Cast.scala
@@ -16,8 +16,16 @@ object Cast
             case _:DatePrimitive => x
             case _ => TextUtils.parseDate(x.asString)
           }
-        case TTimestamp()       => TextUtils.parseTimestamp(x.asString)
-	case TInterval()	=> TextUtils.parseInterval(x.asString)
+        case TTimestamp()       => 
+          x match { 
+            case _:TimestampPrimitive => x
+            case _ => TextUtils.parseTimestamp(x.asString)
+          }
+      	case TInterval()	=> 
+          x match { 
+            case _:IntervalPrimitive => x
+            case _ => TextUtils.parseInterval(x.asString)
+          }
         case TRowId()           => RowIdPrimitive(x.asString)
         case TAny()             => x
         case TBool()            => BoolPrimitive(x.asLong != 0)

--- a/src/main/scala/mimir/exec/result/ResultIterator.scala
+++ b/src/main/scala/mimir/exec/result/ResultIterator.scala
@@ -28,4 +28,6 @@ trait ResultIterator
     new ResultSeq(super.toIndexedSeq, tupleSchema, annotationSchema)
   override def toList: List[Row] = 
     this.toIndexedSeq.toList
+
+  def tuples = map { _.tuple }.toIndexedSeq
 }

--- a/src/main/scala/mimir/exec/result/ResultSeq.scala
+++ b/src/main/scala/mimir/exec/result/ResultSeq.scala
@@ -30,4 +30,5 @@ class ResultSeq(
   def column(idx: Int): Seq[PrimitiveValue] =
     data.map { _(idx) }
 
+  def tuples = map { _.tuple }
 }

--- a/src/main/scala/mimir/sql/sqlite/SQLiteCompat.scala
+++ b/src/main/scala/mimir/sql/sqlite/SQLiteCompat.scala
@@ -222,12 +222,10 @@ object MimirCast extends org.sqlite.Function with LazyLogging {
 
 
     @Override
-    def xFunc(): Unit = { // 1 is int, double is 2, 3 is string, 5 is null
+    def xFunc(): Unit = { 
       if (args != 2) { throw new java.sql.SQLDataException("NOT THE RIGHT NUMBER OF ARGS FOR MIMIRCAST, EXPECTED 2 IN FORM OF MIMIRCAST(COLUMN,TYPE)") }
       try {
-//        println("Input: " + value_text(0) + " : " + value_text(1))
         val t = Type.toSQLiteType(value_int(1))
-//        println("TYPE CASTED: "+t)
         val v = value_text(0)
         logger.trace(s"Casting $v as $t")
         t match {

--- a/src/main/scala/mimir/util/JDBCUtils.scala
+++ b/src/main/scala/mimir/util/JDBCUtils.scala
@@ -37,6 +37,7 @@ object JDBCUtils {
       case TAny()       => java.sql.Types.VARCHAR
       case TBool()      => java.sql.Types.INTEGER
       case TType()      => java.sql.Types.VARCHAR
+      case TInterval()  => java.sql.Types.VARCHAR
       case TUser(t)     => convertMimirType(TypeRegistry.baseType(t))
     }
   }
@@ -66,13 +67,7 @@ object JDBCUtils {
           case TString() => (r) => { 
               val d = r.getString(field)
               if(d == null){ NullPrimitive() } 
-              else { 
-                try {
-                  convertDate(Date.valueOf(d))
-                } catch { 
-                  case _:IllegalArgumentException => NullPrimitive()
-                }
-              }
+              else { TextUtils.parseDate(d) }
             }
           case _ =>         throw new SQLException(s"Can't extract TDate as $dateType")
         }
@@ -86,17 +81,12 @@ object JDBCUtils {
           case TString() => (r) => {
               val t = r.getString(field)
               if(t == null){ NullPrimitive() }
-              else {
-                try {
-                  convertTimestamp(Timestamp.valueOf(t))
-                } catch { 
-                  case _:IllegalArgumentException => NullPrimitive()
-                }
-              }
+              else { TextUtils.parseTimestamp(t) }
             }
           case _ =>         throw new SQLException(s"Can't extract TTimestamp as $dateType")
 
         }
+      case TInterval() => (r) => { TextUtils.parseInterval(r.getString(field)) }
       case TUser(t) => convertFunction(TypeRegistry.baseType(t), field, dateType)
     }
   }

--- a/src/main/scala/mimir/util/TextUtils.scala
+++ b/src/main/scala/mimir/util/TextUtils.scala
@@ -1,8 +1,9 @@
 package mimir.util
 
+import com.typesafe.scalalogging.slf4j.LazyLogging
 import mimir.algebra._
 
-object TextUtils {
+object TextUtils extends LazyLogging {
 
   def parsePrimitive(t: Type, s: String): PrimitiveValue = 
   {
@@ -31,8 +32,10 @@ object TextUtils {
 
   def parseDate(s: String): PrimitiveValue =
   {
+    logger.trace(s"Parse Date: '$s'")
     s match {
       case dateRegexp(y, m, d) => 
+        logger.trace(s"   -> $y-$m-$d  -> ${DatePrimitive(y.toInt, m.toInt, d.toInt)}")
         DatePrimitive(y.toInt, m.toInt, d.toInt)
       case _ => NullPrimitive()
     }
@@ -40,6 +43,7 @@ object TextUtils {
 
   def parseTimestamp(s: String): PrimitiveValue =
   {
+    logger.trace(s"Parse Timestamp: '$s'")
     s match {
       case timestampRegexp(yr, mo, da, hr, mi, se) => 
         val seconds = se.toDouble
@@ -50,6 +54,7 @@ object TextUtils {
 
   def parseInterval(s: String): PrimitiveValue =
   {
+    logger.trace(s"Parse Interval: '$s'")
     s match {
       case intervalRegexp(y, m, w, d, hh, mm, se) => 
         val seconds = se.toDouble

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -51,7 +51,7 @@
   <logger name="mimir.optimizer.operator.InlineProjections$"       level="WARN"/>
 
   <!--+++++++++++++++++++++++  PLOT  ++++++++++++++++++++++++++-->
-  <logger name="mimir.plot.Plot$"                               level="WARN"/>
+  <logger name="mimir.plot.Plot$"                                  level="WARN"/>
 
   <!--+++++++++++++++++++++  Provenance  ++++++++++++++++++++++-->
   <logger name="mimir.provenance.Provenance$"                      level="WARN"/>
@@ -70,14 +70,15 @@
   <logger name="mimir.statistics.SystemCatalog"                    level="WARN"/>
 
   <!--+++++++++++++++++++++++  Util  ++++++++++++++++++++++++++-->
-  <logger name="mimir.util.LoadCSV$"                            level="INFO"/> <!-- Use INFO to track stats -->
-  <logger name="mimir.util.NonStrictCSVParser"                  level="INFO"/> <!-- Use INFO to track stats -->
-  <logger name="mimir.util.LineReaderInputSource"               level="WARN"/>
-  <logger name="mimir.util.PythonProcess$"                      level="WARN"/>
+  <logger name="mimir.util.LoadCSV$"                               level="INFO"/> <!-- Use INFO to track stats -->
+  <logger name="mimir.util.NonStrictCSVParser"                     level="INFO"/> <!-- Use INFO to track stats -->
+  <logger name="mimir.util.LineReaderInputSource"                  level="WARN"/>
+  <logger name="mimir.util.PythonProcess$"                         level="WARN"/>
+  <logger name="mimir.util.TextUtils$"                             level="WARN"/>
 
 
   <!--+++++++++++++++++++++++  Views  +++++++++++++++++++++++++-->
-  <logger name="mimir.views.ViewManager"                        level="WARN"/>
+  <logger name="mimir.views.ViewManager"                           level="WARN"/>
 
  
   <root level="TRACE">

--- a/src/test/scala/mimir/algebra/DateSpec.scala
+++ b/src/test/scala/mimir/algebra/DateSpec.scala
@@ -1,0 +1,35 @@
+package mimir.algebra
+
+import org.specs2.mutable._
+import org.specs2.specification._
+import mimir.parser._
+import mimir.algebra._
+import mimir.algebra.function.FunctionRegistry
+import mimir.optimizer._
+import mimir.optimizer.expression._
+import mimir.test._
+
+object DateSpec 
+  extends SQLTestSpecification("Dates") 
+  with BeforeAll
+{
+
+  def beforeAll() {
+    db.loadTable("test/data/DetectSeriesTest2.csv")
+  }
+
+  "Dates on SQLite" should {
+
+    "Not be messed up by order-by" >> {
+
+      val noOrderBy = 
+        db.query("SELECT DOB FROM DetectSeriesTest2 WHERE Rank = 1;") { _.tuples }
+      val withOrderBy = 
+        db.query("SELECT DOB FROM DetectSeriesTest2 WHERE Rank = 1 ORDER BY DOB;") { _.tuples }
+
+      withOrderBy must be equalTo(noOrderBy)
+    }
+
+  }
+}
+


### PR DESCRIPTION
- Added a bunch of logging to date-related branches of the CAST code
- JDBCUtils.convertFunction now works with Timestamps and Intervals
- Added a .tuples convenience function to get a sequence of raw tuples out of a resultseq or resultiterator
- JDBCUtils.convertFunction now uses the canonical TextUtils methods for date/timestamp/interval string conversion (closes #256)