### PR TITLE
Date cmp fix

### DIFF
--- a/src/main/scala/mimir/algebra/Eval.scala
+++ b/src/main/scala/mimir/algebra/Eval.scala
@@ -6,6 +6,7 @@ import mimir.Database
 import mimir.algebra.function._
 import mimir.provenance.Provenance
 import mimir.ctables.CTables
+import org.joda.time.Period
 
 class EvalTypeException(msg: String, e: Expression, v: PrimitiveValue) extends Exception
 
@@ -194,71 +195,78 @@ object Eval
   def applyArith(op: Arith.Op, 
             a: PrimitiveValue, b: PrimitiveValue
   ): PrimitiveValue = {
-    (op, Typechecker.escalate(
-      a.getType, b.getType, op, "Evaluate Arithmetic", Arithmetic(op, a, b)
+    val aRoot = Type.rootType(a.getType)
+    val bRoot = Type.rootType(b.getType)
+
+    (op, aRoot, bRoot,
+      Typechecker.escalate(
+      aRoot, bRoot, op, "Evaluate Arithmetic", Arithmetic(op, a, b)
     )) match { 
-      case (Arith.Add, TInt()) => 
+      case (Arith.Add, _, _, TInt()) => 
         IntPrimitive(a.asLong + b.asLong)
-      case (Arith.Add, TFloat()) => 
+      case (Arith.Add, _, _, TFloat()) => 
         FloatPrimitive(a.asDouble + b.asDouble)
-      case (Arith.Sub, TInt()) => 
+      case (Arith.Sub, _, _, TInt()) => 
         IntPrimitive(a.asLong - b.asLong)
-      case (Arith.Sub, TFloat()) => 
+      case (Arith.Sub, _, _, TFloat()) => 
         FloatPrimitive(a.asDouble - b.asDouble)
-      case (Arith.Mult, TInt()) => 
+      case (Arith.Mult, _, _, TInt()) => 
         IntPrimitive(a.asLong * b.asLong)
-      case (Arith.Mult, TFloat()) => 
+      case (Arith.Mult, _, _, TFloat()) => 
         FloatPrimitive(a.asDouble * b.asDouble)
-      case (Arith.Div, (TInt()|TInt())) => 
+      case (Arith.Div, _, _, TInt()) => 
         IntPrimitive(a.asLong / b.asLong)
-      case (Arith.Div, (TFloat()|TInt())) => 
+      case (Arith.Div, _, _, TFloat()) => 
         FloatPrimitive(a.asDouble / b.asDouble)
-      case (Arith.BitAnd, TInt()) =>
+      case (Arith.BitAnd, _, _, TInt()) =>
         IntPrimitive(a.asLong & b.asLong)
-      case (Arith.BitOr, TInt()) =>
+      case (Arith.BitOr, _, _, TInt()) =>
         IntPrimitive(a.asLong | b.asLong)
-      case (Arith.ShiftLeft, TInt()) =>
+      case (Arith.ShiftLeft, _, _, TInt()) =>
         IntPrimitive(a.asLong << b.asLong)
-      case (Arith.ShiftRight, TInt()) =>
+      case (Arith.ShiftRight, _, _, TInt()) =>
         IntPrimitive(a.asLong >> b.asLong)
-      case (Arith.And, TBool()) =>
+      case (Arith.And, _, _, TBool()) =>
         BoolPrimitive(a.asBool && b.asBool)
-      case (Arith.Or, TBool()) =>
+      case (Arith.Or, _, _, TBool()) =>
         BoolPrimitive(a.asBool || b.asBool)
 
-      case (Arith.Add, TInterval()) =>
-      	IntervalPrimitive(a.asInterval.plus(b.asInterval))
+      case (Arith.Add, TInterval(), TInterval(), _) =>
+        IntervalPrimitive(a.asInterval.plus(b.asInterval))
+      case (Arith.Sub, TInterval(), TInterval(), _) =>
+        IntervalPrimitive(a.asInterval.minus(b.asInterval))
+      case (Arith.Sub, TDate() | TTimestamp(), TDate() | TTimestamp(), _) =>
+        IntervalPrimitive(new Period(b.asDateTime, a.asDateTime))
 
-      case (Arith.Sub, TInterval()) =>
-      	(a.getType, b.getType) match {
-      		case (TInterval(),TInterval()) =>
-      			IntervalPrimitive(a.asInterval.minus(b.asInterval))
-      		case (TDate() | TTimestamp(),TDate() | TTimestamp()) =>
-      			IntervalPrimitive(new org.joda.time.Period(b.asDateTime, a.asDateTime))
-      		case (_, _) =>
-      			throw new RAException(s"Invalid Arithmetic $a $op $b")
-      	}
+      case (Arith.Add, TDate(), TInterval(), _) =>
+        val d = a.asDateTime.plus(b.asInterval)
+        DatePrimitive(d.getYear,d.getMonthOfYear,d.getDayOfMonth)
+      case (Arith.Add, TInterval(), TDate(), _) =>
+        val d = b.asDateTime.plus(a.asInterval)
+        DatePrimitive(d.getYear,d.getMonthOfYear,d.getDayOfMonth)
+      case (Arith.Sub, TDate(), TInterval(), _) =>
+        val d = a.asDateTime.minus(b.asInterval)
+        DatePrimitive(d.getYear,d.getMonthOfYear,d.getDayOfMonth)
 
-      case (Arith.Mult, TInterval()) =>
-        (a.getType, b.getType) match {
-          case (TInt(), TInterval()) =>
-            IntervalPrimitive(b.asInterval.multipliedBy(a.asInt))
-          case (TInterval(), TInt()) =>
-            IntervalPrimitive(a.asInterval.multipliedBy(b.asInt))
-          case (_, _) =>
-            throw new RAException(s"Invalid Arithmetic $a $op $b")
-        }
+      case (Arith.Add, TTimestamp(), TInterval(), _) =>
+        val d = a.asDateTime.plus(b.asInterval)
+        TimestampPrimitive(d.getYear,d.getMonthOfYear,d.getDayOfMonth,d.getHourOfDay,d.getMinuteOfHour,d.getSecondOfMinute,d. getMillisOfSecond)
+      case (Arith.Add, TInterval(), TTimestamp(), _) =>
+        val d = b.asDateTime.plus(a.asInterval)
+        TimestampPrimitive(d.getYear,d.getMonthOfYear,d.getDayOfMonth,d.getHourOfDay,d.getMinuteOfHour,d.getSecondOfMinute,d. getMillisOfSecond)
+      case (Arith.Sub, TTimestamp(), TInterval(), _) =>
+        val d = a.asDateTime.minus(b.asInterval)
+        TimestampPrimitive(d.getYear,d.getMonthOfYear,d.getDayOfMonth,d.getHourOfDay,d.getMinuteOfHour,d.getSecondOfMinute,d. getMillisOfSecond)
 
-      case (Arith.Add, TTimestamp()) =>
-      	val d = a.asDateTime.plus(b.asInterval)
-      	TimestampPrimitive(d.getYear,d.getMonthOfYear,d.getDayOfMonth,d.getHourOfDay,d.getMinuteOfHour,d.getSecondOfMinute,d. getMillisOfSecond)
+      case (Arith.Mult, TInterval(), TInt() | TFloat(), _) =>
+        IntervalPrimitive(a.asInterval.multipliedBy(b.asInt))
+      case (Arith.Mult, TInt() | TFloat(), TInterval(), _) =>
+        IntervalPrimitive(b.asInterval.multipliedBy(a.asInt))
+      case (Arith.Div, TInterval(), TInt() | TFloat(), _) => 
+        throw new RAException("Division not quite yet supported")
 
-      case (Arith.Sub, TTimestamp()) =>
-      	val d = a.asDateTime.minus(b.asInterval)
-      	TimestampPrimitive(d.getYear,d.getMonthOfYear,d.getDayOfMonth,d.getHourOfDay,d.getMinuteOfHour,d.getSecondOfMinute,d. getMillisOfSecond)	
-
-      case (_, _) => 
-        throw new RAException(s"Invalid Arithmetic $a $op $b")
+      case _ => 
+        throw new RAException(s"Invalid Arithmetic $a ${Arith.opString(op)} $b")
     }
   }
 

--- a/src/main/scala/mimir/algebra/Expression.scala
+++ b/src/main/scala/mimir/algebra/Expression.scala
@@ -100,7 +100,8 @@ object Arith extends Enumeration {
   /**
    * Convert from the operator's Arith.Op representation to a string
    */
-  def opString(v: Op): String = {
+  def opString(v: Op): String = 
+  {
     v match {
       case Add => "+"
       case Sub => "-"
@@ -117,7 +118,8 @@ object Arith extends Enumeration {
   /**
    * Is this binary operation a boolean operator (AND/OR)
    */
-  def isBool(v: Op): Boolean = {
+  def isBool(v: Op): Boolean = 
+  {
     v match {
       case And | Or => true
       case _ => false
@@ -138,7 +140,8 @@ object Cmp extends Enumeration {
   type Op = Value
   val Eq, Neq, Gt, Lt, Gte, Lte, Like, NotLike = Value
   
-  def negate(v: Op): Op = {
+  def negate(v: Op): Op = 
+  {
     v match {
       case Eq => Neq
       case Neq => Eq
@@ -150,8 +153,23 @@ object Cmp extends Enumeration {
       case NotLike => Like
     }
   }
+
+  def flip(v: Op): Option[Op] = 
+  {
+    v match {
+      case Eq      => Some(Eq)
+      case Neq     => Some(Neq)
+      case Gt      => Some(Lt)
+      case Gte     => Some(Lte)
+      case Lt      => Some(Gt)
+      case Lte     => Some(Gte)
+      case Like    => None
+      case NotLike => None
+    }
+  }
   
-  def opString(v: Op): String = {
+  def opString(v: Op): String = 
+  {
     v match {
       case Eq => "="
       case Neq => "<>"
@@ -445,7 +463,7 @@ case class FloatPrimitive(v: Double)
  */
 @SerialVersionUID(100L)
 case class DatePrimitive(y: Int, m: Int, d: Int)
-  extends PrimitiveValue(TDate())
+  extends PrimitiveValue(TDate()) with Comparable[DatePrimitive]
 {
   override def toString() = s"DATE '${asString}'"
   def asLong: Long = throw new TypeException(TDate(), TInt(), "Hard Cast");
@@ -454,7 +472,7 @@ case class DatePrimitive(y: Int, m: Int, d: Int)
   def asString: String = f"$y%04d-$m%02d-$d%02d"
   def asInterval: Period = throw new TypeException(TDate(), TInterval(), "Hard Cast")
   def payload: Object = (y, m, d).asInstanceOf[Object];
-  final def compare(c: DatePrimitive): Integer = {
+  final def compareTo(c: DatePrimitive): Int = {
     if(c.y < y){ -1 }
     else if(c.y > y) { 1 }
     else if(c.m < m) { -1 }
@@ -464,10 +482,10 @@ case class DatePrimitive(y: Int, m: Int, d: Int)
     else { 0 }
   }
 
-  def >(c:DatePrimitive): Boolean = compare(c) > 0
-  def >=(c:DatePrimitive): Boolean = compare(c) >= 0
-  def <(c:DatePrimitive): Boolean = compare(c) < 0
-  def <=(c:DatePrimitive): Boolean = compare(c) <= 0
+  def >(c:DatePrimitive): Boolean = compareTo(c) > 0
+  def >=(c:DatePrimitive): Boolean = compareTo(c) >= 0
+  def <(c:DatePrimitive): Boolean = compareTo(c) < 0
+  def <=(c:DatePrimitive): Boolean = compareTo(c) <= 0
 
   def asDateTime: DateTime = new DateTime(y, m, d, 0, 0)
 }
@@ -478,7 +496,7 @@ case class DatePrimitive(y: Int, m: Int, d: Int)
   */
 @SerialVersionUID(100L)
 case class TimestampPrimitive(y: Int, m: Int, d: Int, hh: Int, mm: Int, ss: Int, ms: Int)
-  extends PrimitiveValue(TTimestamp())
+  extends PrimitiveValue(TTimestamp()) with Comparable[TimestampPrimitive]
 {
   override def toString() = s"DATE '${asString}'"
   def asLong: Long = throw new TypeException(TDate(), TInt(), "Hard Cast");
@@ -487,7 +505,7 @@ case class TimestampPrimitive(y: Int, m: Int, d: Int, hh: Int, mm: Int, ss: Int,
   def asString: String = f"$y%04d-$m%02d-$d%02d $hh%02d:$mm%02d:$ss%02d.$ms%04d"
   def asInterval: Period = throw new TypeException(TDate(), TInterval(), "Hard Cast")
   def payload: Object = (y, m, d).asInstanceOf[Object];
-  final def compare(c: TimestampPrimitive): Integer = {
+  final def compareTo(c: TimestampPrimitive): Int = {
     if(c.y < y){ -1 }
     else if(c.y > y) { 1 }
     else if(c.m < m) { -1 }
@@ -503,10 +521,10 @@ case class TimestampPrimitive(y: Int, m: Int, d: Int, hh: Int, mm: Int, ss: Int,
     else { 0 }
   }
 
-  def >(c:TimestampPrimitive): Boolean = compare(c) > 0
-  def >=(c:TimestampPrimitive): Boolean = compare(c) >= 0
-  def <(c:TimestampPrimitive): Boolean = compare(c) < 0
-  def <=(c:TimestampPrimitive): Boolean = compare(c) <= 0
+  def >(c:TimestampPrimitive): Boolean = compareTo(c) > 0
+  def >=(c:TimestampPrimitive): Boolean = compareTo(c) >= 0
+  def <(c:TimestampPrimitive): Boolean = compareTo(c) < 0
+  def <=(c:TimestampPrimitive): Boolean = compareTo(c) <= 0
 
   def asDateTime: DateTime = new DateTime(y, m, d, hh, mm, ss, ms)
 }

--- a/src/main/scala/mimir/algebra/Type.scala
+++ b/src/main/scala/mimir/algebra/Type.scala
@@ -104,10 +104,11 @@ object Type {
       case t2 => t2
     }
 
-  def isNumeric(t: Type): Boolean =
+  def isNumeric(t: Type, treatTAnyAsNumeric: Boolean = false): Boolean =
   {
     rootType(t) match {
       case TInt() | TFloat() => true
+      case TAny() => treatTAnyAsNumeric
       case _ => false
     }
   }

--- a/src/main/scala/mimir/algebra/Typechecker.scala
+++ b/src/main/scala/mimir/algebra/Typechecker.scala
@@ -58,7 +58,8 @@ class Typechecker(
 	/* Assert that the expressions claimed type is its type */
 	def assert(e: Expression, t: Type, scope: (String => Type), context: Option[Operator] = None, msg: String = "Typechecker"): Unit = {
 		val eType = typeOf(e, scope);
-		if(Typechecker.escalate(eType, t, msg, e) != t){
+		if(!Typechecker.canCoerce(eType, t)){
+			logger.trace(s"LUB: ${Typechecker.leastUpperBound(eType, t)}")
 			throw new TypeException(eType, t, msg, Some(e))
 		}
 	}
@@ -80,24 +81,23 @@ class Typechecker(
 			case p: PrimitiveValue => p.getType;
 			case Not(child) => assert(child, TBool(), scope, context, "NOT"); TBool()
 			case p: Proc => p.getType(p.children.map(recur(_)))
-			case Arithmetic(op, lhs, rhs) => {
-				op match {
-					case (Add | Sub | Mult | Div | BitAnd | BitOr | ShiftLeft | ShiftRight) => 
-					  Typechecker.assertNumeric(Typechecker.escalate(recur(lhs), recur(rhs), op.toString, e), e);
-					case (And | Or) => 
-						assert(lhs, TBool(), scope, context, "BoolOp");
-						assert(rhs, TBool(), scope, context, "BoolOp");
-						TBool()
-				}
-			}
+			case Arithmetic(op, lhs, rhs) => 
+				Typechecker.escalate(recur(lhs), recur(rhs), op, "Arithmetic", e)
 			case Comparison(op, lhs, rhs) => {
 				op match {
 					case (Eq | Neq) => 
-						Typechecker.escalate(recur(lhs), recur(rhs), "Comparison", e);
+						Typechecker.assertLeastUpperBound(recur(lhs), recur(rhs), "Comparison", e)
 					case (Gt | Gte | Lt | Lte) => 
-						if(recur(lhs) != TDate() && recur(rhs) != TDate()) {
-							Typechecker.assertNumeric(Typechecker.escalate(recur(lhs), recur(rhs), "Comparison", e), e)
-						}
+						Typechecker.assertOneOf(
+							Typechecker.assertLeastUpperBound(
+								recur(lhs), 
+								recur(rhs), 
+								"Comparison", 
+								e
+							),
+							Set(TDate(), TInterval(), TTimestamp(), TInt(), TFloat()),
+							e
+						)
 					case (Like | NotLike) =>
 						assert(lhs, TString(), scope, context, "LIKE")
 						assert(rhs, TString(), scope, context, "LIKE")
@@ -120,7 +120,7 @@ class Typechecker(
 					case p:PrimitiveValue => { p match {
               case StringPrimitive(s) => Type.toSQLiteType(Integer.parseInt(s))
               case IntPrimitive(i)  =>  Type.toSQLiteType(i.toInt)
-      	      case _ => throw new SQLException("Invalid CAST to '"+p+"' of type: "+recur(p))
+      	      case _ => throw new RAException("Invalid CAST to '"+p+"' of type: "+recur(p))
             }
 					}
 					case _ => TAny()
@@ -130,10 +130,11 @@ class Typechecker(
 
 			case Conditional(condition, thenClause, elseClause) => 
 				assert(condition, TBool(), scope, context, "WHEN")
-				Typechecker.escalate(
+				Typechecker.assertLeastUpperBound(
 					recur(elseClause),
 					recur(thenClause),
-					"IF, ELSE CLAUSE", e
+					"CASE-WHEN",
+					e
 				)
 			case IsNullExpression(child) =>
 				recur(child);
@@ -231,7 +232,7 @@ class Typechecker(
 
 				val overlap = lSchema.map(_._1).toSet & rSchema.map(_._1).toSet
 				if(!(overlap.isEmpty)){
-					throw new SQLException("Ambiguous Keys ('"+overlap+"') in Cross Product\n"+o);
+					throw new RAException("Ambiguous Keys ('"+overlap+"') in Cross Product\n"+o);
 				}
 				lSchema ++ rSchema
 
@@ -243,7 +244,7 @@ class Typechecker(
 				val rSchema = schemaOf(rhs);
 
 				if(!(lSchema.map(_._1).toSet.equals(rSchema.map(_._1).toSet))){
-					throw new SQLException("Schema Mismatch in Union\n"+o);
+					throw new RAException("Schema Mismatch in Union\n"+o);
 				}
 				lSchema
 
@@ -261,6 +262,7 @@ class Typechecker(
 }
 
 object Typechecker 
+  extends LazyLogging
 {
 
 
@@ -272,53 +274,119 @@ object Typechecker
  		t;
  	}
 
- 	def escalateLeft(a: Type, b: Type): Option[Type] =
+ 	def canCoerce(from: Type, to: Type): Boolean =
  	{
-		(a,b) match {
-			case (TDate() | TTimestamp(), TDate() | TTimestamp())  => Some(TInterval())
-			case (TDate() | TTimestamp(), TInterval())  => Some(TTimestamp())
-			case (TInt(), TInterval()) | (TInterval(), TInt())  => Some(TInterval())
-			case _ if a.equals(b)         => Some(a)
-			case (TUser(name),_)          => escalateLeft(TypeRegistry.baseType(name),b)
-			case (TAny(),_)               => Some(b)
-			case (_,TAny())               => Some(a)
-			case (TInt(),TFloat())        => Some(TFloat())
-			case (TRowId(),TString())     => Some(b)
-			case _                        => None
+ 		logger.debug("Coerce from $from to $to")
+ 		leastUpperBound(from, to) match {
+ 			case Some(lub) => lub.equals(to)
+ 			case None => false
 		}
  	}
 
-	def escalate(a: Type, b: Type, msg: String, e: Expression): Type = 
-		escalate(a, b, msg, Some(e))
-	def escalate(a: Type, b: Type, msg: String, e: Option[Expression]): Type = 
-	{
-		escalate(a, b) match {
+ 	def leastUpperBound(a: Type, b: Type): Option[Type] =
+ 	{
+ 		if(a.equals(b)){ return Some(a); }
+ 		(a, b) match {
+ 			case (TAny(), _) => Some(b)
+			case (_, TAny()) => Some(a)
+			case (TInt(), TFloat()) => Some(TFloat())
+			case (TFloat(), TInt()) => Some(TFloat())
+			case (TDate(), TTimestamp()) => Some(TTimestamp())
+			case (TTimestamp(), TDate()) => Some(TTimestamp())
+			case (TUser(name), _) => leastUpperBound(TypeRegistry.baseType(name), b)
+			case (_, TUser(name)) => leastUpperBound(a, TypeRegistry.baseType(name))
+			case _ => return None
+ 		}
+ 	}
+
+ 	def leastUpperBound(tl: TraversableOnce[Type]): Option[Type] =
+ 	{
+ 		tl.map { Some(_) }.fold(Some(TAny()):Option[Type]) { case (Some(a), Some(b)) => leastUpperBound(a, b) case _ => None }
+ 	}
+
+ 	def assertLeastUpperBound(a: Type, b: Type, msg: String, e: Expression): Type =
+ 	{
+ 		leastUpperBound(a, b) match {
+ 			case Some(t) => t
+ 			case None => throw new TypeException(a, b, msg, Some(e))
+ 		}
+ 	}
+ 	def assertLeastUpperBound(tl: TraversableOnce[Type], msg: String, e: Expression): Type =
+ 	{
+ 		tl.fold(TAny()) { assertLeastUpperBound(_, _, msg, e) }
+ 	}
+
+ 	def assertOneOf(a: Type, candidates: TraversableOnce[Type], e: Expression): Type =
+ 	{
+		candidates.flatMap { leastUpperBound(a, _) }.collectFirst { case x => x } match {
 			case Some(t) => t
-			case None => throw new TypeException(a, b, msg, e);
+			case None => 
+				throw new TypeException(a, TAny(), s"Not one of $candidates", Some(e))
 		}
-	}
-	def escalate(a: Type, b: Type): Option[Type] = 
+ 	}
+
+	def escalate(a: Type, b: Type, op: Arith.Op, msg: String, e: Expression): Type = 
 	{
-		escalateLeft(a, b) match {
-			case s@Some(_) => s
-			case None   => escalateLeft(b, a)
+		escalate(a, b, op) match {
+			case Some(t) => t
+			case None => throw new TypeException(a, b, msg, Some(e));
 		}
 	}
-	def escalate(a: Option[Type], b: Option[Type]): Option[Type] =
+	def escalate(a: Type, b: Type, op: Arith.Op): Option[Type] = 
+	{
+
+		// Start with special case overrides
+		(a, b, op) match {
+			case (TDate() | TTimestamp(), 
+						TDate() | TTimestamp(), 
+						Arith.Sub)                => return Some(TInterval())
+			case (TDate() | TTimestamp(), 
+						TInterval(), 
+						Arith.Sub | Arith.Add)    => return Some(a)
+			case (TInt(), TInterval(), Arith.Mult) | 
+					 (TInterval(), TInt(), Arith.Mult | Arith.Div)  
+					                            => return Some(TInterval())
+			case _ => ()
+		}
+
+		(op) match {
+			case (Arith.Add | Arith.Sub | Arith.Mult | Arith.Div) => 
+				if(Type.isNumeric(a) && Type.isNumeric(b)){
+					leastUpperBound(a, b)
+				} else {
+					throw new RAException(s"Invalid Arithmetic: $a ${Arith.opString(op)} $b (Not Numeric)")
+				}
+
+      case (Arith.BitAnd | Arith.BitOr | Arith.ShiftLeft | Arith.ShiftRight) =>
+      	if(Type.rootType(a) == TInt() && Type.rootType(a) == TInt()){
+	      	Some(TInt())
+      	} else {
+					throw new RAException(s"Invalid Arithmetic: $a ${Arith.opString(op)} $b (Not Integer)")
+      	}
+
+      case (Arith.And | Arith.Or) =>
+      	if(Type.rootType(a) == TBool() && Type.rootType(a) == TBool()){
+	      	Some(TBool())
+      	} else {
+					throw new RAException(s"Invalid Arithmetic: $a ${Arith.opString(op)} $b (Not Boolean)")
+      	}
+		}
+	}
+	def escalate(a: Option[Type], b: Option[Type], op: Arith.Op): Option[Type] =
 	{
 		(a, b) match {
 			case (None,_) => b
 			case (_,None) => a
-			case (Some(at), Some(bt)) => escalate(at, bt)
+			case (Some(at), Some(bt)) => escalate(at, bt, op)
 		}
 	}
 
-	def escalate(l: TraversableOnce[Type]): Option[Type] =
+	def escalate(l: TraversableOnce[Type], op: Arith.Op): Option[Type] =
 	{
-		l.map(Some(_)).fold(None)(escalate(_,_))
+		l.map(Some(_)).fold(None)(escalate(_,_,op))
 	}
-	def escalate(l: TraversableOnce[Type], msg: String, e: Expression): Type =
+	def escalate(l: TraversableOnce[Type], op: Arith.Op, msg: String, e: Expression): Type =
 	{
-		l.fold(TAny())(escalate(_,_,msg,e))
+		l.fold(TAny())(escalate(_,_,op,msg,e))
 	}
 }

--- a/src/main/scala/mimir/algebra/function/AggregateRegistry.scala
+++ b/src/main/scala/mimir/algebra/function/AggregateRegistry.scala
@@ -62,7 +62,7 @@ class AggregateRegistry
           throw new RAException("Invalid arg list ["+aggName+"]: "+argTypes.mkString(", "))
         }
         if(
-          t.zip(argTypes).exists { t => Typechecker.escalate(t._1, t._2) == None }
+          t.zip(argTypes).exists { t => Typechecker.leastUpperBound(t._1, t._2) == None }
         ){ 
           throw new RAException("Invalid arg list ["+aggName+"]: "+argTypes.mkString(", "))
         }

--- a/src/main/scala/mimir/algebra/function/SampleFunctions.scala
+++ b/src/main/scala/mimir/algebra/function/SampleFunctions.scala
@@ -25,7 +25,7 @@ object SampleFunctions
         val debugExpr = Function("BEST_SAMPLE", types.map(TypePrimitive(_)))
 
         Typechecker.assertNumeric(types.head, debugExpr)
-        Typechecker.escalate(
+        Typechecker.assertLeastUpperBound(
           types.tail.grouped(2).
             map { t => 
               Typechecker.assertNumeric(t(0),debugExpr)

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -18,6 +18,7 @@
   <logger name="mimir.algebra.ExpressionChecker"                   level="WARN"/>
   <logger name="mimir.algebra.OperatorUtils"                       level="WARN"/>
   <logger name="mimir.algebra.Typechecker"                         level="WARN"/>
+  <logger name="mimir.algebra.Typechecker$"                        level="WARN"/>
 
   <!--+++++++++++++++++++++++  CTables  +++++++++++++++++++++++-->
   <logger name="mimir.ctables.CTPercolator"                        level="WARN"/>

--- a/src/test/scala/mimir/algebra/IntervalSpec.scala
+++ b/src/test/scala/mimir/algebra/IntervalSpec.scala
@@ -28,11 +28,11 @@ object IntervalSpec extends Specification with RASimplify {
       }
 
       "Date + Interval" >> {
-        simplify("DATE('2017-01-01')+INTERVAL('P0Y1M1W1DT0H0M0S')") must be equalTo(TimestampPrimitive(2017,2,9,0,0,0,0))
+        simplify("DATE('2017-01-01')+INTERVAL('P0Y1M1W1DT0H0M0S')") must be equalTo(DatePrimitive(2017,2,9))
       }
 
       "Date - Interval" >> {
-        simplify("DATE('2017-02-09')-INTERVAL('P0Y1M1W1DT0H0M0S')") must be equalTo(TimestampPrimitive(2017,1,1,0,0,0,0))
+        simplify("DATE('2017-02-09')-INTERVAL('P0Y1M1W1DT0H0M0S')") must be equalTo(DatePrimitive(2017,1,1))
       }
 
       "Date - Date" >> {


### PR DESCRIPTION
Cleaning up Typechecker escalation and fixing a few related bugs in Eval. (closes #259)

Typechecker.escalate is now three independent methods:
 - Typechecker.escalate (Compute the type of an arithmetic op)
 - Typechecker.leastUpperBound (Compute the least upper bound of two types)
 - Typechecker.canCoerce (Evaluate whether a CAST operation --- explicit or implicit --- is permissible)

Eval.applyArith and Eval.applyCmp are both now a little more robust to variations in input types.  In particular applyCmp now works correctly for TDate (closes #259)