### PR TITLE
Adaptive schemas as views

### DIFF
--- a/src/main/scala/mimir/adaptive/AdaptiveSchemaManager.scala
+++ b/src/main/scala/mimir/adaptive/AdaptiveSchemaManager.scala
@@ -128,8 +128,19 @@ class AdaptiveSchemaManager(db: Database)
 
   def viewFor(schema: String, table: String): Option[Operator] =
   {
-    get(schema).flatMap { case (lens, config) =>
-      lens.viewFor(db, config, table)
+    get(schema) match {
+      case None => None
+      case Some((lens, config)) => {
+        lens.viewFor(db, config, table) match {
+          case None => None
+          case Some(viewQuery) => 
+            Some(AdaptiveView(
+              schema,
+              table, 
+              viewQuery
+            ))
+        }
+      }
     }
   }
 }

--- a/src/main/scala/mimir/algebra/ExpressionConstructors.scala
+++ b/src/main/scala/mimir/algebra/ExpressionConstructors.scala
@@ -4,9 +4,24 @@ trait ExpressionConstructors
 {
   def toExpression: Expression
 
+  def eq(other: String): Expression =
+    eq(StringPrimitive(other))
+  def eq(other: Int): Expression =
+    eq(IntPrimitive(other))
+  def eq(other: Double): Expression =
+    eq(FloatPrimitive(other))
   def eq(other: Expression): Expression =
     Comparison(Cmp.Eq, toExpression, other)
 
+  def in(other: Seq[Expression]): Expression =
+    ExpressionUtils.makeInTest(toExpression, other)
+
+  def neq(other: String): Expression =
+    neq(StringPrimitive(other))
+  def neq(other: Int): Expression =
+    neq(IntPrimitive(other))
+  def neq(other: Double): Expression =
+    neq(FloatPrimitive(other))
   def neq(other: Expression): Expression =
     Comparison(Cmp.Neq, toExpression, other)
 

--- a/src/main/scala/mimir/algebra/Operator.scala
+++ b/src/main/scala/mimir/algebra/Operator.scala
@@ -462,14 +462,14 @@ case class View(name: String, query: Operator, annotations: Set[ViewAnnotation.T
  * an appropriate materialized form of the view ready.
  */
 @SerialVersionUID(100L)
-case class AdaptiveView(model: String, name: String, query: Operator, annotations: Set[ViewAnnotation.T] = Set())
+case class AdaptiveView(schema: String, name: String, query: Operator, annotations: Set[ViewAnnotation.T] = Set())
   extends Operator
 {
   def children: Seq[Operator] = Seq(query)
   def expressions: Seq[Expression] = Seq()
-  def rebuild(c: Seq[Operator]): Operator = AdaptiveView(model, name, c(0), annotations)
+  def rebuild(c: Seq[Operator]): Operator = AdaptiveView(schema, name, c(0), annotations)
   def rebuildExpressions(x: Seq[Expression]): Operator = this
   def toString(prefix: String): String = 
-    s"$prefix$model.$name[${annotations.mkString(", ")}] := (\n${query.toString(prefix+"   ")}\n$prefix)"
+    s"$prefix$schema.$name[${annotations.mkString(", ")}] := (\n${query.toString(prefix+"   ")}\n$prefix)"
   def columnNames = query.columnNames
 }

--- a/src/main/scala/mimir/algebra/Operator.scala
+++ b/src/main/scala/mimir/algebra/Operator.scala
@@ -431,7 +431,7 @@ case class LeftOuterJoin(left: Operator,
 }
 
 /**
- * A materialized view
+ * A (maybe materialized) view
  *
  * When initialized by RAToSql, the query field will contain the raw unmodified 
  * query that the view was instantiated with.  As the view goes through compilation,
@@ -449,5 +449,27 @@ case class View(name: String, query: Operator, annotations: Set[ViewAnnotation.T
   def rebuildExpressions(x: Seq[Expression]): Operator = this
   def toString(prefix: String): String = 
     s"$prefix$name[${annotations.mkString(", ")}] := (\n${query.toString(prefix+"   ")}\n$prefix)"
+  def columnNames = query.columnNames
+}
+
+/**
+ * A view defined by an adaptive schema
+ *
+ * When initialized by RAToSql, the query field will contain the raw unmodified 
+ * query that the view was instantiated with.  As the view goes through compilation,
+ * the nested query will be modified; The metadata field tracks which forms of 
+ * compilation have been applied to it, so that the system can decide whether it has
+ * an appropriate materialized form of the view ready.
+ */
+@SerialVersionUID(100L)
+case class AdaptiveView(model: String, name: String, query: Operator, annotations: Set[ViewAnnotation.T] = Set())
+  extends Operator
+{
+  def children: Seq[Operator] = Seq(query)
+  def expressions: Seq[Expression] = Seq()
+  def rebuild(c: Seq[Operator]): Operator = AdaptiveView(model, name, c(0), annotations)
+  def rebuildExpressions(x: Seq[Expression]): Operator = this
+  def toString(prefix: String): String = 
+    s"$prefix$model.$name[${annotations.mkString(", ")}] := (\n${query.toString(prefix+"   ")}\n$prefix)"
   def columnNames = query.columnNames
 }

--- a/src/main/scala/mimir/algebra/OperatorUtils.scala
+++ b/src/main/scala/mimir/algebra/OperatorUtils.scala
@@ -232,7 +232,7 @@ object OperatorUtils extends LazyLogging {
         findRenamingConflicts(name, lhs) ++ findRenamingConflicts(name, rhs)
       case Join(lhs, rhs) => 
         findRenamingConflicts(name, lhs) ++ findRenamingConflicts(name, rhs)
-      case EmptyTable(_) | Table(_,_,_,_) | View(_,_,_) => 
+      case EmptyTable(_) | Table(_,_,_,_) | View(_,_,_) | AdaptiveView(_,_,_,_) => 
         oper.columnNames.toSet
       case Sort(_, src) =>
         findRenamingConflicts(name, src)
@@ -328,7 +328,7 @@ object OperatorUtils extends LazyLogging {
           sch.map { col => if(col._1.equals(target)) { (replacement, col._2) } else { col } }
         )
       }
-      case View(_, _, _) => {
+      case View(_, _, _) | AdaptiveView(_, _, _, _) => {
         Project(
           oper.columnNames.map { col =>
             if(col.equals(target)){ ProjectArg(replacement, Var(target)) }

--- a/src/main/scala/mimir/algebra/QueryNamer.scala
+++ b/src/main/scala/mimir/algebra/QueryNamer.scala
@@ -9,6 +9,7 @@ object QueryNamer
 		op match { 
 			case Table(name,alias, _, _) => name
 			case View(name, _, _) => name
+			case AdaptiveView(model, name, _, _) => (model+"_"+name)
 			case Project(cols, src) => 
 				cols.length match {
 					case 1 => cols(0).name+"_FROM_"+nameQuery(src)

--- a/src/main/scala/mimir/algebra/Typechecker.scala
+++ b/src/main/scala/mimir/algebra/Typechecker.scala
@@ -251,6 +251,7 @@ class Typechecker(
 			case Table(_, _, sch, meta) => (sch ++ meta.map( x => (x._1, x._3) ))
 
 			case View(_, query, _) => schemaOf(query)
+			case AdaptiveView(_, _, query, _) => schemaOf(query)
 
 			case EmptyTable(sch) => sch
 

--- a/src/main/scala/mimir/ctables/CTExplainer.scala
+++ b/src/main/scala/mimir/ctables/CTExplainer.scala
@@ -451,14 +451,14 @@ class CTExplainer(db: Database) extends LazyLogging {
 
 				// Source 2: There might be uncertainty on the table.  Use SYS_TABLES to dig these annotations up.
 				val tableReasons = explainEverything(
-					multilens.tableCatalogFor(db, config).filter( Var("TABLE").eq(name) )
+					multilens.tableCatalogFor(db, config).filter( Var("TABLE_NAME").eq(name) )
 				)
 				// alternative: Use SYS_TABLES directly
 				//    db.table("SYS_TABLES").where( Var("SCHEMA").eq(StringPrimitive(model)).and( Var("TABLE").eq(StringPrimitive(name)) ) )
 
 				// Source 3: Check for uncertainty in one of the attributes of interest
 				val attrReasons = explainEverything(
-					multilens.attrCatalogFor(db, config).filter( Var("TABLE").eq(name).and( Var("ATTR").in( wantCol.toSeq.map { StringPrimitive(_) } ) ) )
+					multilens.attrCatalogFor(db, config).filter( Var("TABLE_NAME").eq(name).and( Var("ATTR_NAME").in( wantCol.toSeq.map { StringPrimitive(_) } ) ) )
 				)
 				// alternative: Use SYS_ATTRS directly
 				//    db.table("SYS_TABLES").where( Var("SCHEMA").eq(StringPrimitive(model)).and( Var("TABLE").eq(StringPrimitive(name)) ).and( Var("ATTR").in(wantCol.map(StringPrimitive(_))) ) )

--- a/src/main/scala/mimir/ctables/CTExplainer.scala
+++ b/src/main/scala/mimir/ctables/CTExplainer.scala
@@ -437,6 +437,35 @@ class CTExplainer(db: Database) extends LazyLogging {
 			case View(_,query,_) => 
 				explainSubsetWithoutOptimizing(query, wantCol, wantRow, wantSort)
 
+			case AdaptiveView(model, name, query, _) => {
+				// Source 1: Recur:  
+				val sourceReasons = 
+					explainSubsetWithoutOptimizing(query, wantCol, wantRow, wantSort)
+
+				// Model details
+				val (multilens, config) = 
+						db.adaptiveSchemas.get(model) match {
+							case Some(cfg) => cfg
+							case None => throw new RAException(s"Unknown adaptive schema '$model'")
+						}
+
+				// Source 2: There might be uncertainty on the table.  Use SYS_TABLES to dig these annotations up.
+				val tableReasons = explainEverything(
+					multilens.tableCatalogFor(db, config).filter( Var("TABLE").eq(name) )
+				)
+				// alternative: Use SYS_TABLES directly
+				//    db.table("SYS_TABLES").where( Var("SCHEMA").eq(StringPrimitive(model)).and( Var("TABLE").eq(StringPrimitive(name)) ) )
+
+				// Source 3: Check for uncertainty in one of the attributes of interest
+				val attrReasons = explainEverything(
+					multilens.attrCatalogFor(db, config).filter( Var("TABLE").eq(name).and( Var("ATTR").in( wantCol.toSeq.map { StringPrimitive(_) } ) ) )
+				)
+				// alternative: Use SYS_ATTRS directly
+				//    db.table("SYS_TABLES").where( Var("SCHEMA").eq(StringPrimitive(model)).and( Var("TABLE").eq(StringPrimitive(name)) ).and( Var("ATTR").in(wantCol.map(StringPrimitive(_))) ) )
+				sourceReasons ++ tableReasons ++ attrReasons
+			}
+
+
 			case EmptyTable(_) => Seq()
 
 			case Project(args, child) => {

--- a/src/main/scala/mimir/ctables/CTPercolator.scala
+++ b/src/main/scala/mimir/ctables/CTPercolator.scala
@@ -531,6 +531,18 @@ object CTPercolator
         )
       }
       case v @ AdaptiveView(model, name, query, metadata) => { 
+        // Oliver:
+        //   I'm on the fence about whether we want to treat this case as being different from default views.
+        //   In principle, we want to decide whether any of the attributes or the table itself are NonDet and
+        //   to tag the relevant columns/rows here.  However, this has the side effect of tagging *every* row 
+        //   with non-determinsm.  However, as described in issue #165
+        //    > https://github.com/UBOdin/mimir/issues/165
+        //   this may not be the interface that we're looking for.  Table-wide annotations should *really* 
+        //   be added through some other vector (e.g., labeling column headers or somesuch)
+        //
+        //   For now, I'm just going to leave adaptive views to operate like they would otherwise operate.
+        //   As soon as it becomes appropriate to start tagging things... then see 
+        //   CTExplainer.explainSubsetWithoutOptimizing for an idea of how to implement this correctly.
         val (newQuery, colDeterminism, rowDeterminism) = percolateLite(query, models)
         val columns = query.columnNames
 
@@ -547,6 +559,7 @@ object CTPercolator
           Var(mimirRowDeterministicColumnName)
         )
       }
+
       case EmptyTable(sch) => {
         return (oper, 
           // All columns are deterministic

--- a/src/main/scala/mimir/exec/mode/TupleBundle.scala
+++ b/src/main/scala/mimir/exec/mode/TupleBundle.scala
@@ -403,6 +403,7 @@ class TupleBundle(seeds: Seq[Long] = (0l until 10l).toSeq)
       // We don't handle materialized tuple bundles (at the moment)
       // so give up and drop the view.
       case View(_, query, _) =>  compileFlat(query, models)
+      case AdaptiveView(_, _, query, _) =>  compileFlat(query, models)
 
       case ( Sort(_,_) | Limit(_,_,_) | LeftOuterJoin(_,_,_) | Annotate(_, _) | ProvenanceOf(_) | Recover(_, _) ) =>
         throw new RAException("Tuple-Bundler presently doesn't support LeftOuterJoin, Sort, or Limit (probably need to resort to 'Long' evaluation)")

--- a/src/main/scala/mimir/gprom/algebra/OperatorTranslation.scala
+++ b/src/main/scala/mimir/gprom/algebra/OperatorTranslation.scala
@@ -1248,9 +1248,12 @@ object OperatorTranslation {
 			  list.length += 1 
 			  list
 			}
-			case View(name, query, meta) => {
+			case View(_, query, _) => {
 			  mimirOperatorToGProMList(query)
 			}
+      case AdaptiveView(_, _, query, _) => {
+        mimirOperatorToGProMList(query)
+      }
 			case EmptyTable(sch)=> {
 			   throw new Exception("Operator Translation not implemented '"+mimirOperator+"'")
 			}

--- a/src/main/scala/mimir/lenses/CommentLens.scala
+++ b/src/main/scala/mimir/lenses/CommentLens.scala
@@ -32,7 +32,7 @@ object CommentLens {
         + Math.abs(colComments.mkString("_").hashCode())
   
     val resultCols = args.flatMap {
-      case Function("RESULT_COLUMNS", cols:Seq[Var]) => Some( cols.map(_.name) )
+      case Function("RESULT_COLUMNS", cols:(Seq[Var] @unchecked)) => Some( cols.map(_.name) )
       case _ => None
     }.flatten
     

--- a/src/main/scala/mimir/lenses/GeocodingLens.scala
+++ b/src/main/scala/mimir/lenses/GeocodingLens.scala
@@ -97,12 +97,12 @@ object GeocodingLens {
     
     
     val resultCols = args.flatMap {
-      case Function("RESULT_COLUMNS", cols:Seq[Var]) => Some( cols.map(_.name) )
+      case Function("RESULT_COLUMNS", cols:Seq[Var] @unchecked) => Some( cols.map(_.name) )
       case _ => None
     }.flatten
     
     val projectedOutAddrCols = args.flatMap {
-      case Function("HIDE_ADDR_COLUMNS", cols:Seq[Var]) => Some( cols.map(_.name) )
+      case Function("HIDE_ADDR_COLUMNS", cols:Seq[Var] @unchecked) => Some( cols.map(_.name) )
       case _ => None
     }.flatten
     

--- a/src/main/scala/mimir/optimizer/operator/ProjectRedundantColumns.scala
+++ b/src/main/scala/mimir/optimizer/operator/ProjectRedundantColumns.scala
@@ -128,6 +128,7 @@ object ProjectRedundantColumns extends OperatorOptimization {
       }
 
       case view: View => view
+      case view: AdaptiveView => view
       case table: Table => table
       case table: EmptyTable => table
 

--- a/src/main/scala/mimir/optimizer/operator/PushdownSelections.scala
+++ b/src/main/scala/mimir/optimizer/operator/PushdownSelections.scala
@@ -53,10 +53,10 @@ object PushdownSelections extends OperatorOptimization {
 				val dualSchema = lhsSchema ++ rhsSchema
 
 				if(! (lhsSchema & rhsSchema).isEmpty ){
-					throw new SQLException("Pushdown into overlapping schema ("+(lhsSchema&rhsSchema)+"): "+o)
+					throw new SQLException(s"Pushdown into overlapping schema (${lhsSchema&rhsSchema}): $o")
 				}
 				if(! (ExpressionUtils.getColumns(cond) &~ dualSchema).isEmpty ){
-					throw new SQLException("Pushdown into unsafe schema")
+					throw new SQLException(s"Pushdown into unsafe schema: ${ExpressionUtils.getColumns(cond)} -> ${lhsSchema union rhsSchema}:\n $o")
 				}
 
 				// Generic clauses have no variable references.  In principle, 

--- a/src/main/scala/mimir/provenance/Provenance.scala
+++ b/src/main/scala/mimir/provenance/Provenance.scala
@@ -142,6 +142,10 @@ object Provenance extends LazyLogging {
         val (newQuery, rowIds) = compile(query)
         ( View(name, newQuery, meta + ViewAnnotation.PROVENANCE), rowIds)
 
+      case AdaptiveView(model, name, query, meta) => 
+        val (newQuery, rowIds) = compile(query)
+        ( AdaptiveView(model, name, newQuery, meta + ViewAnnotation.PROVENANCE), rowIds)
+
       case Table(name, alias, schema, meta) =>
         (
           Table(name, alias, schema, meta ++ List((rowidColnameBase, Var("ROWID"), TRowId()))),
@@ -302,6 +306,8 @@ object Provenance extends LazyLogging {
       // We don't handle materializing the entire history of a given value
       // for now... drop the view and focus on the query itself.
       case View(_, query, _) => 
+        doFilterForToken(query, rowIds, db)
+      case AdaptiveView(_, _, query, _) => 
         doFilterForToken(query, rowIds, db)
 
       case Table(_,_, _, meta) =>

--- a/src/main/scala/mimir/provenance/Tracer.scala
+++ b/src/main/scala/mimir/provenance/Tracer.scala
@@ -109,6 +109,8 @@ object Tracer {
 
       case View(_, query, _) => 
         trace(query, targetRowId)
+      case AdaptiveView(_, _, query, _) => 
+        trace(query, targetRowId)
 
       case Table(name, alias, schema, meta) =>
         val targetFilter = 

--- a/src/main/scala/mimir/serialization/Json.scala
+++ b/src/main/scala/mimir/serialization/Json.scala
@@ -100,6 +100,15 @@ object Json
           "annotations" -> JsArray(annotations.toSeq.map { _.toString }.map { JsString(_) })
         ))
 
+      case AdaptiveView(model, name, query, annotations) => 
+        JsObject(Map[String,JsValue](
+          "type" -> JsString("table_adaptive"),
+          "model" -> JsString(model),
+          "name" -> JsString(name),
+          "query" -> ofOperator(query),
+          "annotations" -> JsArray(annotations.toSeq.map { _.toString }.map { JsString(_) })
+        ))
+
       case Limit(offset, count, source) => 
         JsObject(Map[String, JsValue](
           "type" -> JsString("limit"),
@@ -262,6 +271,15 @@ object Json
         )
       case "table_view" =>
         View(
+          elems("name").as[JsString].value,
+          toOperator(elems("query")),
+          elems("annotations").as[JsArray].value.map { annot =>
+            ViewAnnotation.withName(annot.as[JsString].value)
+          }.toSet
+        )
+      case "table_adaptive" =>
+        AdaptiveView(
+          elems("model").as[JsString].value,
           elems("name").as[JsString].value,
           toOperator(elems("query")),
           elems("annotations").as[JsArray].value.map { annot =>

--- a/src/main/scala/mimir/sql/JDBCBackend.scala
+++ b/src/main/scala/mimir/sql/JDBCBackend.scala
@@ -308,6 +308,10 @@ class JDBCBackend(val backend: String, val filename: String)
             case _ =>
               stmt.setTimestamp(i, JDBCUtils.convertTimestamp(t))
           }
+        case t:IntervalPrimitive  => 
+          backend match {
+            case _ => throw new SQLException(s"$backend does not support intervals in prepared statements")
+          }
         case r:RowIdPrimitive     => stmt.setString(i,r.v)
         case t:TypePrimitive      => stmt.setString(i, t.t.toString) 
         case BoolPrimitive(true)  => stmt.setInt(i, 1)

--- a/src/main/scala/mimir/sql/RAToSql.scala
+++ b/src/main/scala/mimir/sql/RAToSql.scala
@@ -426,6 +426,10 @@ class RAToSql(db: Database)
         logger.warn("Inlined view when constructing SQL: RAToSQL will not use materialized views")
         extractSelectsAndJoins(query)
 
+      case AdaptiveView(schema, name, query, annotations) => 
+        logger.warn("Inlined view when constructing SQL: RAToSQL will not use materialized views")
+        extractSelectsAndJoins(query)
+
       case _ => (BoolPrimitive(true), Seq(makeSubSelect(oper)))
     }
   }

--- a/src/test/scala/mimir/adaptive/DiscalaAbadiSpec.scala
+++ b/src/test/scala/mimir/adaptive/DiscalaAbadiSpec.scala
@@ -216,6 +216,14 @@ object DiscalaAbadiSpec
       ){ _.toSeq must contain(StringPrimitive("1")) }
     }
 
+    "Generate legitimate explanations on query results" >> {
+      explainEverything("""
+        SELECT QUANTITY FROM SHIPPING.BILL_OF_LADING_NBR
+      """).flatMap(_.all(db)).map(_.reason) must contain(
+        "QUANTITY could be organized under any of BILL_OF_LADING_NBR (19), ROOT (-1); I chose BILL_OF_LADING_NBR"
+      )
+    }
+
   }
 
 


### PR DESCRIPTION
Added AdaptiveView operator type (closes #200) (closes #213)

* Added AdaptiveView operator.  Overall, this operator behaves like View, but references an adaptive schema instead.
* AdaptiveSchemaManager.viewFor now wraps the returned view in an AdaptiveSchema operator.
* CTExplainer now returns explanations related to adaptive schemas involved in the view being queried
   * CTPercolator behavior has *not* changed.  (see #165 for discussion)
