### PR TITLE
December demo

### DIFF
--- a/src/main/scala/mimir/Database.scala
+++ b/src/main/scala/mimir/Database.scala
@@ -416,7 +416,7 @@ case class Database(backend: Backend)
            case x => x.toUpperCase
      }) match {
       case "CSV" => {
-        val (delim, typeinference, adaptive) =
+        val (delim, typeinference, detectHeaders) =
           format._2 match {
             case Seq(StringPrimitive(delim_)) => (delim_, true, true)
             case Seq(StringPrimitive(delim_),BoolPrimitive(typeinference_)) => (delim_, typeinference_, true)
@@ -433,24 +433,24 @@ case class Database(backend: Backend)
             LoadCSV.handleLoadTableRaw(this, targetRaw, sourceFile, 
               Map("DELIMITER" -> delim)
             )
-            val oper = table(targetRaw)
-            //detect headers and create adaptive schema
-            if(adaptive)
-              adaptiveSchemas.create( targetTable.toUpperCase+"_DH", "DETECT_HEADER", oper, Seq())
-            //create TI adaptive schema - also create a view with the target name 
+            var oper = table(targetRaw)
+            //detect headers 
+            if(detectHeaders) {
+              val dhSchemaName = targetTable.toUpperCase+"_DH"
+              adaptiveSchemas.create(dhSchemaName, "DETECT_HEADER", oper, Seq())
+              oper = adaptiveSchemas.viewFor(dhSchemaName, "DATA").get
+            }
+            //type inference
             if(typeinference){
-              adaptiveSchemas.create( targetTable.toUpperCase+"_TI", "TYPE_INFERENCE", adaptiveSchemas.viewFor(targetTable.toUpperCase+ "_DH", targetRaw).getOrElse(oper), Seq(FloatPrimitive(.5))) 
-              views.create(targetTable.toUpperCase, adaptiveSchemas.viewFor(targetTable.toUpperCase+ "_TI", targetRaw).get)
+              val tiSchemaName = targetTable.toUpperCase+"_TI"
+              adaptiveSchemas.create(tiSchemaName, "TYPE_INFERENCE", oper, Seq(FloatPrimitive(.5))) 
+              oper = adaptiveSchemas.viewFor(tiSchemaName, "DATA").get
             }
-            else if(adaptive){
-              //if there is no ti then make a view with the target name of the detect header adaptive schema view 
-              views.create(targetTable.toUpperCase, adaptiveSchemas.viewFor(targetTable.toUpperCase+ "_DH", targetRaw).getOrElse(oper))
-            }
-            else {
-              //if there is no ti or detect headers then make a view with the target name of the raw table
-              views.create(targetTable.toUpperCase, oper)
-            }
-          } else LoadCSV.handleLoadTableRaw(this, targetTable.toUpperCase, sourceFile,  Map("DELIMITER" -> delim) )
+            //finally create a view for the data
+            views.create(targetTable.toUpperCase, oper)
+          } else {
+            LoadCSV.handleLoadTableRaw(this, targetTable.toUpperCase, sourceFile,  Map("DELIMITER" -> delim) )
+          }
         }
       case fmt =>
         throw new SQLException(s"Unknown load format '$fmt'")

--- a/src/main/scala/mimir/Mimir.scala
+++ b/src/main/scala/mimir/Mimir.scala
@@ -203,14 +203,22 @@ object Mimir extends LazyLogging {
 
     if(rowId == null){
       output.print("==== Explain Table ====")
+      logger.debug("Starting to Explain Table")
       val reasonSets = db.explainer.explainEverything(query)
+      logger.debug("Done Explaining Table")
       for(reasonSet <- reasonSets){
         logger.debug(s"Expanding $reasonSet")
-        val count = reasonSet.size(db);
-        val reasons = reasonSet.take(db, 5);
-        printReasons(reasons);
-        if(count > reasons.size){
-          output.print(s"... and ${count - reasons.size} more like the last")
+        // Workaround for a bug: SQLite crashes if a UDA is run on an empty input
+        if(!reasonSet.isEmpty(db)){
+          logger.debug(s"Not Empty")
+          val count = reasonSet.size(db);
+          logger.debug(s"Size = $count")
+          val reasons = reasonSet.take(db, 5);
+          logger.debug(s"Got ${reasons.size} reasons")
+          printReasons(reasons);
+          if(count > reasons.size){
+            output.print(s"... and ${count - reasons.size} more like the last")
+          }
         }
       }
       if(assign == true) {

--- a/src/main/scala/mimir/Mimir.scala
+++ b/src/main/scala/mimir/Mimir.scala
@@ -205,6 +205,7 @@ object Mimir extends LazyLogging {
       output.print("==== Explain Table ====")
       val reasonSets = db.explainer.explainEverything(query)
       for(reasonSet <- reasonSets){
+        logger.debug(s"Expanding $reasonSet")
         val count = reasonSet.size(db);
         val reasons = reasonSet.take(db, 5);
         printReasons(reasons);

--- a/src/main/scala/mimir/Mimir.scala
+++ b/src/main/scala/mimir/Mimir.scala
@@ -210,7 +210,7 @@ object Mimir extends LazyLogging {
         logger.debug(s"Expanding $reasonSet")
         // Workaround for a bug: SQLite crashes if a UDA is run on an empty input
         if(!reasonSet.isEmpty(db)){
-          logger.debug(s"Not Empty")
+          logger.debug(s"Not Empty: \n${reasonSet.argLookup}")
           val count = reasonSet.size(db);
           logger.debug(s"Size = $count")
           val reasons = reasonSet.take(db, 5);

--- a/src/main/scala/mimir/adaptive/CheckHeader.scala
+++ b/src/main/scala/mimir/adaptive/CheckHeader.scala
@@ -38,7 +38,7 @@ object CheckHeader
       ),
       Seq(
         Seq(
-          StringPrimitive(config.schema)
+          StringPrimitive("DATA")
         )
       )
     )
@@ -55,7 +55,7 @@ object CheckHeader
       ),
       (0 until config.query.columnNames.size).map { col =>
         Seq(
-          StringPrimitive(config.schema),
+          StringPrimitive("DATA"),
           TypePrimitive(TString()),
           BoolPrimitive(false),
           IntPrimitive(col)
@@ -68,13 +68,15 @@ object CheckHeader
   
   def viewFor(db: Database, config: MultilensConfig, table: String): Option[Operator] =
   {
-    val model = db.models.get("MIMIR_CH_" + config.schema).asInstanceOf[DetectHeaderModel]
-    Some(
-        Project( model.query.columnNames.zipWithIndex.map( col => 
-          ProjectArg(model.bestGuess(0, Seq(IntPrimitive(col._2)), Seq()).asString,Var(col._1)) )
-          , config.query) match {
-          case proj if model.headerDetected => proj.limit(-1, 1)
-          case proj => proj
-        })
+    if(table.equals("DATA")){
+      val model = db.models.get("MIMIR_CH_" + config.schema).asInstanceOf[DetectHeaderModel]
+      Some(
+          Project( model.query.columnNames.zipWithIndex.map( col => 
+            ProjectArg(model.bestGuess(0, Seq(IntPrimitive(col._2)), Seq()).asString,Var(col._1)) )
+            , config.query) match {
+            case proj if model.headerDetected => proj.limit(-1, 1)
+            case proj => proj
+          })
+    } else { None }
   }
 }

--- a/src/main/scala/mimir/adaptive/TypeInference.scala
+++ b/src/main/scala/mimir/adaptive/TypeInference.scala
@@ -65,7 +65,7 @@ object TypeInference
       ),
       Seq(
         Seq(
-          StringPrimitive(config.schema)
+          StringPrimitive("DATA")
         )
       )
     )
@@ -86,7 +86,7 @@ object TypeInference
       ),
       config.query.columnNames.map(col => 
         Seq(
-          StringPrimitive(config.schema), 
+          StringPrimitive("DATA"), 
           StringPrimitive(col), 
           BoolPrimitive(false),
           IntPrimitive(columnIndexes.getOrElse(col, -1).toLong),
@@ -108,22 +108,24 @@ object TypeInference
         
   def viewFor(db: Database, config: MultilensConfig, table: String): Option[Operator] =
   {
-    val model = db.models.get(s"MIMIR_TI_ATTR_${config.schema}").asInstanceOf[TypeInferenceModel]
-    val columnIndexes = model.columns.zipWithIndex.toMap
-    Some(Project(
-      config.query.columnNames.map { colName =>
-        ProjectArg(colName, 
-          if(columnIndexes contains colName){ 
-            Function("CAST", Seq(
-              Var(colName),
-              model.bestGuess(0, Seq(IntPrimitive(columnIndexes(colName))), Seq())
-            ))
-          } else {
-            Var(colName)
-          }
-        )
-      }, config.query
-    ))  
+    if(table.equals("DATA")){
+      val model = db.models.get(s"MIMIR_TI_ATTR_${config.schema}").asInstanceOf[TypeInferenceModel]
+      val columnIndexes = model.columns.zipWithIndex.toMap
+      Some(Project(
+        config.query.columnNames.map { colName =>
+          ProjectArg(colName, 
+            if(columnIndexes contains colName){ 
+              Function("CAST", Seq(
+                Var(colName),
+                model.bestGuess(0, Seq(IntPrimitive(columnIndexes(colName))), Seq())
+              ))
+            } else {
+              Var(colName)
+            }
+          )
+        }, config.query
+      ))  
+    } else { None }
   }
 
   

--- a/src/main/scala/mimir/adaptive/TypeInference.scala
+++ b/src/main/scala/mimir/adaptive/TypeInference.scala
@@ -82,7 +82,7 @@ object TypeInference
         ("ATTR_NAME" , TString()),
         ("IS_KEY", TBool()), 
         ("IDX", TInt()),
-        ("DEFAULT_TYPE", TType())
+        ("HARD_TYPE", TType())
       ),
       config.query.columnNames.map(col => 
         Seq(
@@ -96,14 +96,14 @@ object TypeInference
       )
     ).addColumn(
       "ATTR_TYPE" -> 
-        Var("IDX")
-          .gte(IntPrimitive(0))
+        Var("HARD_TYPE")
+          .isNull
           .thenElse {
             VGTerm(s"MIMIR_TI_ATTR_${config.schema}", 0, Seq(Var("IDX")), Seq())
           } {
-            Var("DEFAULT_TYPE")
+            Var("HARD_TYPE")
           }
-    ).removeColumns("IDX", "DEFAULT_TYPE")
+    ).removeColumns("IDX", "HARD_TYPE")
   }
         
   def viewFor(db: Database, config: MultilensConfig, table: String): Option[Operator] =

--- a/src/main/scala/mimir/adaptive/TypeInference.scala
+++ b/src/main/scala/mimir/adaptive/TypeInference.scala
@@ -59,43 +59,71 @@ object TypeInference
 
   def tableCatalogFor(db: Database, config: MultilensConfig): Operator =
   {
-    HardTable(Seq(("TABLE_NAME",TString()),("SCHEMA_NAME",TString())),Seq(Seq(StringPrimitive(config.schema),StringPrimitive("MIMIR"))))
+    HardTable(
+      Seq(
+        ("TABLE_NAME",TString())
+      ),
+      Seq(
+        Seq(
+          StringPrimitive(config.schema)
+        )
+      )
+    )
   }
   
   def attrCatalogFor(db: Database, config: MultilensConfig): Operator =
   {
-   val model = db.models.get(s"MIMIR_TI_ATTR_${config.schema}").asInstanceOf[TypeInferenceModel]
-   val table = HardTable(
-      Seq(("TABLE_NAME" , TString()), ("ATTR_NAME" , TString()),("ATTR_TYPE", TType()),("IS_KEY", TBool()), ("SCHEMA_NAME", TString()), ("IDX", TInt())),
-      model.columns.zipWithIndex.map(col => 
-        Seq(StringPrimitive(config.schema), StringPrimitive(col._1), model.bestGuess(col._2, Seq(), Seq()) ,BoolPrimitive(false),StringPrimitive("MIMIR"),IntPrimitive(col._2))
-     )) 
-   val oper = Project( table.schema.map {
-     case ("ATTR_TYPE", _) => ProjectArg("ATTR_TYPE", VGTerm(model.name, 0, Seq(Var("IDX")), Seq(Var("ATTR_TYPE"))))
-     case (col, _) => ProjectArg(col, Var(col))
-   }, table)
-   oper
+    val model = db.models.get(s"MIMIR_TI_ATTR_${config.schema}").asInstanceOf[TypeInferenceModel]
+    val columnIndexes = model.columns.zipWithIndex.toMap
+    lazy val qSchema = db.typechecker.schemaOf(config.query).toMap
+    HardTable(
+      Seq(
+        ("TABLE_NAME" , TString()), 
+        ("ATTR_NAME" , TString()),
+        ("IS_KEY", TBool()), 
+        ("IDX", TInt()),
+        ("DEFAULT_TYPE", TType())
+      ),
+      config.query.columnNames.map(col => 
+        Seq(
+          StringPrimitive(config.schema), 
+          StringPrimitive(col), 
+          BoolPrimitive(false),
+          IntPrimitive(columnIndexes.getOrElse(col, -1).toLong),
+          if(columnIndexes contains col){ NullPrimitive() } 
+            else { TypePrimitive(qSchema(col)) }
+        )
+      )
+    ).addColumn(
+      "ATTR_TYPE" -> 
+        Var("IDX")
+          .gte(IntPrimitive(0))
+          .thenElse {
+            VGTerm(s"MIMIR_TI_ATTR_${config.schema}", 0, Seq(Var("IDX")), Seq())
+          } {
+            Var("DEFAULT_TYPE")
+          }
+    ).removeColumns("IDX", "DEFAULT_TYPE")
   }
         
   def viewFor(db: Database, config: MultilensConfig, table: String): Option[Operator] =
   {
     val model = db.models.get(s"MIMIR_TI_ATTR_${config.schema}").asInstanceOf[TypeInferenceModel]
+    val columnIndexes = model.columns.zipWithIndex.toMap
     Some(Project(
-        db.query(
-          attrCatalogFor(db, config)
-        ) { results => {
-            val cols = model.columns
-            results.toSeq.map { row =>
-              val colIdx = row(5).asInt
-              val colName = cols(colIdx)
-              val colType = row(2).asString
-              val schemaTupStr = s"($colName, $colType)"
-              ProjectArg(
-                colName,
-                Function("CAST", Seq(Var(colName), TypePrimitive(Type.fromString(colType))))
-              )
-            }.toIndexedSeq}
-    }, config.query))  
+      config.query.columnNames.map { colName =>
+        ProjectArg(colName, 
+          if(columnIndexes contains colName){ 
+            Function("CAST", Seq(
+              Var(colName),
+              model.bestGuess(0, Seq(IntPrimitive(columnIndexes(colName))), Seq())
+            ))
+          } else {
+            Var(colName)
+          }
+        )
+      }, config.query
+    ))  
   }
 
   

--- a/src/main/scala/mimir/algebra/Eval.scala
+++ b/src/main/scala/mimir/algebra/Eval.scala
@@ -77,7 +77,7 @@ class Eval(
     e match {
       case p : PrimitiveValue => p
       case Var(v) => bindings(v) match {
-        case None => throw new RAException("Variable Out Of Scope: "+v+" (in "+bindings+")");
+        case None => throw new RAException("Variable Out Of Scope: "+v);
         case Some(s) => s
       }
       case RowIdVar() => throw new RAException("Evaluating RowIds in the Interpreter Unsupported")

--- a/src/main/scala/mimir/algebra/Operator.scala
+++ b/src/main/scala/mimir/algebra/Operator.scala
@@ -340,7 +340,8 @@ case class HardTable(schema: Seq[(String, Type)], data: Seq[Seq[PrimitiveValue]]
   extends Operator
 {
   def toString(prefix: String) =
-    prefix + "< " + ( schema.map { case (name, v) => name+": "+v.toString }.mkString(", ") ) + " >"
+    prefix + "< " + ( schema.map { case (name, v) => name+": "+v.toString }.mkString(", ") ) + " >" +
+    data.take(3).map { "\n"+prefix+"< "+_.mkString(", ")+" >"}.mkString("")
   def children: Seq[Operator] = Seq()
   def rebuild(x: Seq[Operator]) = this
   def expressions = List()

--- a/src/main/scala/mimir/algebra/Operator.scala
+++ b/src/main/scala/mimir/algebra/Operator.scala
@@ -138,7 +138,7 @@ case class AggFunction(function: String, distinct: Boolean, args: Seq[Expression
 case class Aggregate(groupby: Seq[Var], aggregates: Seq[AggFunction], source: Operator) extends Operator
 {
   def toString(prefix: String) =
-    prefix + "AGGREGATE[" + 
+    prefix + (if(aggregates.isEmpty){ "DISTINCT" } else { "AGGREGATE" })+"[" + 
       (groupby ++ aggregates).mkString(", ") + 
       "](\n" +
       source.toString(prefix + "  ") + "\n" + prefix + ")"

--- a/src/main/scala/mimir/algebra/OperatorConstructors.scala
+++ b/src/main/scala/mimir/algebra/OperatorConstructors.scala
@@ -71,6 +71,8 @@ trait OperatorConstructors
     }:_*)
   }
 
+  def removeColumns(targets: String*): Operator =
+    removeColumn(targets:_*)
   def removeColumn(targets: String*): Operator =
   {
     val isTarget = targets.toSet

--- a/src/main/scala/mimir/ctables/ReasonSet.scala
+++ b/src/main/scala/mimir/ctables/ReasonSet.scala
@@ -16,7 +16,7 @@ class ReasonSet(val model: Model, val idx: Int, val argLookup: Option[(Operator,
         db.query(
           query.count( alias = "COUNT" ), 
           UnannotatedBestGuess
-        ) { _.next.tuple(0).asLong > 0 }
+        ) { _.next.tuple(0).asLong <= 0 }
       case None => 
         false
     }    

--- a/src/main/scala/mimir/ctables/ReasonSet.scala
+++ b/src/main/scala/mimir/ctables/ReasonSet.scala
@@ -5,9 +5,22 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
 import mimir.Database
 import mimir.algebra._
 import mimir.models._
+import mimir.exec.mode.UnannotatedBestGuess
 
 class ReasonSet(val model: Model, val idx: Int, val argLookup: Option[(Operator, Seq[Expression], Seq[Expression])])
 {
+  def isEmpty(db: Database): Boolean =
+  {
+    argLookup match {
+      case Some((query, argExprs, hintExprs)) => 
+        db.query(
+          query.count( alias = "COUNT" ), 
+          UnannotatedBestGuess
+        ) { _.next.tuple(0).asLong > 0 }
+      case None => 
+        false
+    }    
+  }
   def size(db: Database): Long =
   {
     argLookup match {

--- a/src/main/scala/mimir/ctables/Repair.scala
+++ b/src/main/scala/mimir/ctables/Repair.scala
@@ -56,9 +56,10 @@ case class RepairByType(t: Type)
     val tString =
       t match {
         case TUser(ut) => ut
+        case TString() => "any string"
         case _ => t.toString
       }
-    s"< ${tString} >"
+    s"<${tString}>"
   }
 }
 

--- a/src/main/scala/mimir/ctables/vgterm/BestGuess.scala
+++ b/src/main/scala/mimir/ctables/vgterm/BestGuess.scala
@@ -10,7 +10,7 @@ case class BestGuess(
   vgArgs: Seq[Expression],
   vgHints: Seq[Expression]
 ) extends Proc(vgArgs++vgHints) {
-  override def toString() = "{{ "+model.name+";"+idx+"["+vgArgs.mkString(", ")+"]["+vgHints.mkString(", ")+"] }}"
+  override def toString() = "{{ BEST GUESS: "+model.name+";"+idx+"["+vgArgs.mkString(", ")+"]["+vgHints.mkString(", ")+"] }}"
   override def getType(bindings: Seq[Type]):Type = model.varType(idx, bindings)
   override def children: Seq[Expression] = vgArgs ++ vgHints
   override def rebuild(x: Seq[Expression]) = {

--- a/src/main/scala/mimir/exec/Compiler.scala
+++ b/src/main/scala/mimir/exec/Compiler.scala
@@ -26,6 +26,7 @@ class Compiler(db: Database) extends LazyLogging {
 
   def operatorOptimizations: Seq[OperatorOptimization] =
     Seq(
+      new EvaluateHardTables(db.typechecker, db.interpreter),
       ProjectRedundantColumns,
       InlineProjections,
       PushdownSelections,

--- a/src/main/scala/mimir/exec/mode/BestGuess.scala
+++ b/src/main/scala/mimir/exec/mode/BestGuess.scala
@@ -90,16 +90,17 @@ object BestGuess
 
     logger.debug(s"INLINED: $oper")
 
-    // Clean things up a little... make the query prettier, tighter, and 
-    // faster
-    oper = db.compiler.optimize(oper)
-
-    logger.debug(s"OPTIMIZED: $oper")
 
     // Replace VG-Terms with their "Best Guess values"
     oper = bestGuessQuery(db, oper)
 
     logger.debug(s"GUESSED: $oper")
+
+    // Clean things up a little... make the query prettier, tighter, and 
+    // faster
+    oper = db.compiler.optimize(oper)
+
+    logger.debug(s"OPTIMIZED: $oper")
 
     return (
       oper, 

--- a/src/main/scala/mimir/exec/mode/UnannotatedBestGuess.scala
+++ b/src/main/scala/mimir/exec/mode/UnannotatedBestGuess.scala
@@ -1,0 +1,35 @@
+package mimir.exec.mode
+
+import com.typesafe.scalalogging.slf4j.LazyLogging
+import mimir.Database
+import mimir.algebra._
+import mimir.exec._
+import mimir.exec.result._
+
+object UnannotatedBestGuess
+  extends CompileMode[ResultIterator]
+  with LazyLogging
+{
+  type MetadataT = Seq[String]
+
+  /**
+   * Rewrite the specified operator
+   */
+  def rewrite(db: Database, oper: Operator): (Operator, Seq[String], MetadataT) =
+  {
+    (
+      BestGuess.bestGuessQuery(db, oper),
+      oper.columnNames,
+      Seq()
+    )
+  }
+
+  /**
+   * Wrap a resultset generated for the specified operator with a 
+   * specific type of resultIterator.
+   */
+  def wrap(db: Database, results: ResultIterator, query: Operator, meta: MetadataT): ResultIterator =
+  { 
+    return results;
+  }
+}

--- a/src/main/scala/mimir/models/DetectHeaderModel.scala
+++ b/src/main/scala/mimir/models/DetectHeaderModel.scala
@@ -109,22 +109,25 @@ with NeedsDatabase
 
   
   def argTypes(idx: Int) = {
-    Seq()
+    Seq(TInt())
   }
   def varType(idx: Int, args: Seq[Type]) = {
     TString()
   }
   def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]  ) = {
-    getFeedback(idx, args).getOrElse(StringPrimitive(initialHeaders(idx)))
+    getFeedback(idx, args).getOrElse(StringPrimitive(initialHeaders(args(0).asInt)))
   }
   def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]) = {
     bestGuess(idx, args, hints)
   }
   def reason(idx: Int, args: Seq[PrimitiveValue],hints: Seq[PrimitiveValue]): String = {
     getFeedback(idx, args) match {
-      case Some(colName) => s"${getReasonWho(idx, args)} told me that $colName is a valid column header for column with index: $idx"
-      case None if headerDetected => s"I used an analysis on the first several rows and there appears to be column headers in the first row.  For column with index: $idx, the detected header is ${initialHeaders(idx)}"
-      case None =>s"I used an analysis on the first several rows and there appears NOT to be column headers in the first row.  For the column with index: $idx, I used the default value of ${initialHeaders(idx)}"
+      case Some(colName) => 
+        s"${getReasonWho(idx, args)} told me that $targetName.$colName is a valid column name for column number ${args(0)}"
+      case None if headerDetected => 
+        s"I analyzed the first several rows of $targetName and there appear to be column headers in the first row.  For column with index: ${args(0)}, the detected header is ${initialHeaders(args(0).asInt)}"
+      case None =>
+        s"I analyzed the first several rows of $targetName and there do NOT appear to be column headers in the first row.  For the column with index: ${args(0)}, I used the default value of ${initialHeaders(args(0).asInt)}"
     }
   }
   def feedback(idx: Int, args: Seq[PrimitiveValue], v: PrimitiveValue): Unit = {
@@ -137,7 +140,7 @@ with NeedsDatabase
     Seq()
   }
   def getFeedbackKey(idx: Int, args: Seq[PrimitiveValue]) = {
-    s"$idx"
+    s"${args(0)}"
   }
   def confidence (idx: Int, args: Seq[PrimitiveValue], hints:Seq[PrimitiveValue]) : Double = {
     getFeedback(idx, args) match {

--- a/src/main/scala/mimir/models/TypeInferenceModel.scala
+++ b/src/main/scala/mimir/models/TypeInferenceModel.scala
@@ -177,7 +177,7 @@ class TypeInferenceModel(name: String, val columns: IndexedSeq[String], defaultF
       case Seq(IntPrimitive(i)) => i.toInt
       case _ => idxi
     }
-    super.isAcknowledged(idx, args) || isPerfectGuess(idx)
+    super.isAcknowledged(idx, args) //|| isPerfectGuess(idx)
   }
 
   def confidence (idx: Int, args: Seq[PrimitiveValue], hints:Seq[PrimitiveValue]) : Double = {

--- a/src/main/scala/mimir/optimizer/operator/EvaluateHardTables.scala
+++ b/src/main/scala/mimir/optimizer/operator/EvaluateHardTables.scala
@@ -1,0 +1,63 @@
+package mimir.optimizer.operator
+
+import mimir.optimizer.OperatorOptimization
+import mimir.algebra._
+import mimir.algebra.function._
+
+class EvaluateHardTables(typechecker: Typechecker, interpreter: Eval) extends OperatorOptimization
+{
+  def safeToEval(expr: Expression): Boolean =
+  {
+    expr match {
+      case _:VGTerm => false
+      case _        => expr.children.map { safeToEval(_) }.fold(true) { _ && _ }
+    }
+  }
+
+
+  def apply(o: Operator): Operator =
+  {
+
+    o.recur(apply(_)) match { 
+      case Union(
+        HardTable(sch,lhs),
+        HardTable(_,rhs)
+      ) => HardTable(sch, lhs++rhs)
+
+      case Join(
+        HardTable(lhsSch,lhsData), 
+        HardTable(rhsSch,rhsData)
+      ) => HardTable(lhsSch++rhsSch, lhsData.flatMap { lhsRow => rhsData.map { lhsRow ++ _ }})
+
+      case Select(cond, HardTable(sch,data)) 
+        if safeToEval(cond) => 
+      {
+        val colNames = sch.map{ _._1 }
+        HardTable(
+          sch,
+          data.filter { row => 
+            interpreter.evalBool(cond, colNames.zip(row).toMap)
+          }
+        )
+      }
+
+      case Project(exprs, HardTable(sch, data)) 
+        if exprs.forall { col => safeToEval(col.expression) } =>
+      {
+        val colNames = sch.map{ _._1 }
+        val schMap = sch.toMap
+        HardTable(
+          exprs.map { col => (col.name, typechecker.typeOf(col.expression, schMap, Some(o))) },
+          data.map { row => 
+            val bindings = colNames.zip(row).toMap
+            exprs.map { col =>
+              interpreter.eval(col.expression, bindings)
+            }
+          }
+        )
+      }
+
+      case somethingElse => somethingElse
+    }
+  }
+}

--- a/src/main/scala/mimir/optimizer/operator/ProjectRedundantColumns.scala
+++ b/src/main/scala/mimir/optimizer/operator/ProjectRedundantColumns.scala
@@ -137,11 +137,23 @@ object ProjectRedundantColumns extends OperatorOptimization {
           groupby.flatMap( ExpressionUtils.getColumns(_) ).
             toSet
 
+        val allDownwardDependencies = computedDependencies ++ groupbyDependencies
+
+        // It is possible for an Aggregate column to want to project away ALL columns
+        // While this isn't a problem for us, it makes it VERY difficult to convert the resulting
+        // expression to SQL.  Preseve a single (arbitrary) column for safety in this case.
+        val safeDownwardDependencies =
+          if(allDownwardDependencies.isEmpty){
+            Set(source.columnNames.head)
+          } else {
+            allDownwardDependencies
+          }
+
         val aggregate = 
           Aggregate(
             groupby,
             computed.filter( (column) => dependencies contains column.alias ),
-            apply(source, computedDependencies ++ groupbyDependencies)
+            apply(source, safeDownwardDependencies)
           )
 
         projectIfNeeded(aggregate, dependencies)

--- a/src/main/scala/mimir/sql/JDBCBackend.scala
+++ b/src/main/scala/mimir/sql/JDBCBackend.scala
@@ -341,13 +341,23 @@ class JDBCBackend(val backend: String, val filename: String)
   {
     backend match {
       case "sqlite" => {
-        logger.warn("SQLITE has no programatic way to access attributes in SQL")
         HardTable(Seq(
-          ("TABLE_NAME", TString()), 
-          ("ATTR_NAME", TString()),
-          ("ATTR_TYPE", TString()),
-          ("IS_KEY", TBool())
-        ),Seq());
+            ("TABLE_NAME", TString()), 
+            ("ATTR_NAME", TString()),
+            ("ATTR_TYPE", TString()),
+            ("IS_KEY", TBool())
+          ),
+          getAllTables().flatMap { table =>
+            getTableSchema(table).get.map { case (col, t) =>
+              Seq(
+                StringPrimitive(table),
+                StringPrimitive(col),
+                TypePrimitive(t),
+                BoolPrimitive(false)
+              )
+            }
+          }
+        )
       }
 
       case "oracle" => ???

--- a/src/main/scala/mimir/statistics/SystemCatalog.scala
+++ b/src/main/scala/mimir/statistics/SystemCatalog.scala
@@ -65,15 +65,15 @@ object SystemCatalog
 {
   val tableCatalogSchema = 
     Seq( 
-      ("TABLE_NAME", TString()),
-      ("SCHEMA_NAME", TString()) 
+      ("SCHEMA_NAME", TString()),
+      ("TABLE_NAME", TString())
     )
   val attrCatalogSchema =
     Seq( 
+      ("SCHEMA_NAME", TString()),
       ("TABLE_NAME", TString()), 
       ("ATTR_NAME", TString()),
       ("ATTR_TYPE", TString()),
-      ("IS_KEY", TBool()),
-      ("SCHEMA_NAME", TString()) 
+      ("IS_KEY", TBool())
     )
 }

--- a/src/main/scala/mimir/views/ViewManager.scala
+++ b/src/main/scala/mimir/views/ViewManager.scala
@@ -238,11 +238,23 @@ class ViewManager(db:Database) extends LazyLogging {
   {
     logger.warn("Constructing lens attribute list not implemented yet")
     HardTable(Seq(
-      ("TABLE_NAME", TString()), 
-      ("ATTR_NAME", TString()),
-      ("ATTR_TYPE", TString()),
-      ("IS_KEY", TBool())
-    ),Seq())
+        ("TABLE_NAME", TString()), 
+        ("ATTR_NAME", TString()),
+        ("ATTR_TYPE", TString()),
+        ("IS_KEY", TBool())
+      ),
+      list().flatMap { view => 
+        db.typechecker.schemaOf(get(view).get.query).map { case (col, t) =>
+          Seq(
+            StringPrimitive(view),
+            StringPrimitive(col),
+            TypePrimitive(t),
+            BoolPrimitive(false)
+          )
+        }
+
+      }
+    )
   }
 
   /**
@@ -282,6 +294,9 @@ class ViewManager(db:Database) extends LazyLogging {
           },
           metadata.table
         )
+      }
+      case AdaptiveView(schema, name, query, wantAnnotations) => {
+        return resolve(query)
       }
 
       case _ =>


### PR DESCRIPTION
A ton of bugfixes and cleanup

* Standardized how TI and CH adaptive schemas interact with the world.  In particular, both now use VGTerms in a way that shows up in SYS_ATTRS and SYS_TABLES, and both now expose a single designated table with a standard name ("DATA")
* Cleaned up the code flow of Mimir.loadTable using a var rather than a branching tree of possible configurations.  Also standardized use of the "DATA" table.
* A number of bugfixes pertaining to HardTable's interactions with the optimizer.  
    * Notably, there were a few cases where the schema and data fields could fall out of sync
    * In addition, added a new EvaluateHardTable optimization stage that simplifies hardcoded tables where possible.
     * Another odd case, it was possible to have a HardTable with an empty schema (As a result of ProjectRedundantColumns and SELECT DISTINCT or SELECT COUNT(*) queries).  The optimizer has been modified to avoid this case, since there's no real way to implement a non-attributed tuple in a SQL SELECT.
* A number of bugfixes pertaining to CTExplainer
     * Notably, standardizing on the "DATA" table name for TI and CH was enough to make CTExplainer work correctly with adaptive schemas
