### PR TITLE
Extra validators

### DIFF
--- a/src/main/scala/mimir/Mimir.scala
+++ b/src/main/scala/mimir/Mimir.scala
@@ -58,9 +58,9 @@ object Mimir extends LazyLogging {
     if(!conf.quiet()){
       output.print("Connecting to " + conf.backend() + "://" + conf.dbname() + "...")
     }
+    sback.sparkTranslator = db.sparkTranslator
     db.metadataBackend.open()
     db.backend.open()
-    OperatorTranslation.db = db
     sback.registerSparkFunctions(db.functions.functionPrototypes.map(el => el._1).toSeq, db.functions)
     sback.registerSparkAggregates(db.aggregates.prototypes.map(el => el._1).toSeq, db.aggregates)
       

--- a/src/main/scala/mimir/MimirVizier.scala
+++ b/src/main/scala/mimir/MimirVizier.scala
@@ -68,6 +68,7 @@ object MimirVizier extends LazyLogging {
       val database = Mimir.conf.dbname().split("[\\\\/]").last.replaceAll("\\..*", "")
       val sback = new SparkBackend(database)
       db = new Database(sback, new JDBCMetadataBackend(Mimir.conf.backend(), Mimir.conf.dbname()))
+      sback.sparkTranslator = db.sparkTranslator
       db.metadataBackend.open()
       db.backend.open()
       val otherExcludeFuncs = Seq("NOT","!","%","&","*","+","-","/","<","<=","<=>","=","==",">",">=","^")
@@ -445,11 +446,15 @@ object MimirVizier extends LazyLogging {
     val timeRes = logTime("createLens") {
       logger.debug("createView: From Vistrails: [" + input + "] [" + query + "]"  ) ;
       val (viewNameSuffix, inputSubstitutionQuery) = input match {
-        case aliases:JMapWrapper[String,String] => {
+        case rawAliases:JMapWrapper[_,_] => {
+          // The following line needed to suppress compiler type erasure warning
+          val aliases = rawAliases.asInstanceOf[JMapWrapper[String,String]]
           aliases.map{ case (vizierName, mimirName) => db.sql.registerVizierNameMapping(vizierName.toUpperCase(), mimirName) } 
           (aliases.unzip._2.mkString(""), query)
         }
-        case inputs:Seq[String] => {
+        case rawInputs:Seq[_] => {
+          // The following line needed to suppress compiler type erasure warning
+          val inputs = rawInputs.asInstanceOf[Seq[String]]
           (inputs.mkString(""),inputs.zipWithIndex.foldLeft(query)((init, curr) => {
             init.replaceAll(s"\\{\\{\\s*input_${curr._2}\\s*\\}\\}", curr._1) 
           })) 
@@ -556,11 +561,15 @@ object MimirVizier extends LazyLogging {
   
 def vistrailsQueryMimirJson(input:Any, query : String, includeUncertainty:Boolean, includeReasons:Boolean) : String = {
     val inputSubstitutionQuery = input match {
-        case aliases:JMapWrapper[String,String] => {
+        case rawAliases:JMapWrapper[_,_] => {
+          // The following line needed to suppress compiler type erasure warning
+          val aliases = rawAliases.asInstanceOf[JMapWrapper[String,String]]
           aliases.map{ case (vizierName, mimirName) => db.sql.registerVizierNameMapping(vizierName.toUpperCase(), mimirName) } 
           query
         }
-        case inputs:Seq[String] => {
+        case rawInputs:Seq[_] => {
+          // The following line needed to suppress compiler type erasure warning
+          val inputs = rawInputs.asInstanceOf[Seq[String]]
           inputs.zipWithIndex.foldLeft(query)((init, curr) => {
             init.replaceAll(s"\\{\\{\\s*input_${curr._2}\\s*\\}\\}", curr._1) 
           })
@@ -718,7 +727,7 @@ def vistrailsQueryMimirJson(query : String, includeUncertainty:Boolean, includeR
       try{
         logger.debug("getSchema: From Vistrails: [" + query + "]"  ) ;
         val oper = totallyOptimize(db.sql.convert(db.parse(query).head.asInstanceOf[Select]))
-        JSONBuilder.list( db.typechecker.schemaOf(oper).map( schel =>  Map( "name" -> schel._1, "type" -> schel._2.toString(), "base_type" -> Type.rootType(schel._2).toString())))
+        JSONBuilder.list( db.typechecker.schemaOf(oper).map( schel =>  Map( "name" -> schel._1, "type" -> schel._2.toString(), "base_type" -> db.types.rootType(schel._2).toString())))
       } catch {
         case t: Throwable => {
           logger.error("Error Getting Schema: [" + query + "]", t)
@@ -1077,7 +1086,7 @@ def vistrailsQueryMimirJson(query : String, includeUncertainty:Boolean, includeR
       val resultList = results.toList 
       val (resultsStrs, prov) = resultList.map(row => (row.tuple.map(cell => cell), row.provenance.asString)).unzip
       JSONBuilder.dict(Map(
-        "schema" -> results.schema.map( schel =>  Map( "name" -> schel._1, "type" ->schel._2.toString(), "base_type" -> Type.rootType(schel._2).toString())),
+        "schema" -> results.schema.map( schel =>  Map( "name" -> schel._1, "type" ->schel._2.toString(), "base_type" -> db.types.rootType(schel._2).toString())),
         "data" -> resultsStrs,
         "prov" -> prov
       ))
@@ -1092,7 +1101,7 @@ def vistrailsQueryMimirJson(query : String, includeUncertainty:Boolean, includeR
       val (resultsStrs, colTaint) = resultsStrsColTaint.unzip
       val (prov, rowTaint) = provRowTaint.unzip
       JSONBuilder.dict(Map(
-        "schema" -> results.schema.map( schel =>  Map( "name" -> schel._1, "type" ->schel._2.toString(), "base_type" -> Type.rootType(schel._2).toString())),
+        "schema" -> results.schema.map( schel =>  Map( "name" -> schel._1, "type" ->schel._2.toString(), "base_type" -> db.types.rootType(schel._2).toString())),
         "data" -> resultsStrs,
         "prov" -> prov,
         "col_taint" -> colTaint,
@@ -1110,7 +1119,7 @@ def vistrailsQueryMimirJson(query : String, includeUncertainty:Boolean, includeR
       val (prov, rowTaint) = provRowTaint.unzip
       val reasons = explainEverything(oper).map(reasonSet => reasonSet.all(db).toSeq.map(_.toJSONWithFeedback))
       JSONBuilder.dict(Map(
-        "schema" -> results.schema.map( schel =>  Map( "name" -> schel._1, "type" ->schel._2.toString(), "base_type" -> Type.rootType(schel._2).toString())),
+        "schema" -> results.schema.map( schel =>  Map( "name" -> schel._1, "type" ->schel._2.toString(), "base_type" -> db.types.rootType(schel._2).toString())),
         "data" -> resultsStrs,
         "prov" -> prov,
         "col_taint" -> colTaint,

--- a/src/main/scala/mimir/adaptive/AdaptiveSchemaManager.scala
+++ b/src/main/scala/mimir/adaptive/AdaptiveSchemaManager.scala
@@ -63,9 +63,9 @@ class AdaptiveSchemaManager(db: Database)
     ){ _.map { row => 
       val name = row(0).asString
       val mlensType = row(1).asString
-      val query = Json.toOperator(Json.parse(row(2).asString))
+      val query = Json.toOperator(Json.parse(row(2).asString), db.types)
       val args:Seq[Expression] = 
-        Json.toExpressionList(Json.parse(row(3).asString))
+        Json.toExpressionList(Json.parse(row(3).asString), db.types)
  
       ( 
         MultilensRegistry.multilenses(mlensType), 
@@ -87,9 +87,9 @@ class AdaptiveSchemaManager(db: Database)
     ){ _.map { row => 
       val name = row(0).asString
       val mlensType = row(1).asString
-      val query = Json.toOperator(Json.parse(row(2).asString))
+      val query = Json.toOperator(Json.parse(row(2).asString), db.types)
       val args:Seq[Expression] = 
-        Json.toExpressionList(Json.parse(row(3).asString))
+        Json.toExpressionList(Json.parse(row(3).asString), db.types)
  
       ( 
         MultilensRegistry.multilenses(mlensType), 
@@ -166,9 +166,9 @@ class AdaptiveSchemaManager(db: Database)
         val row = result.next
         val name = row(0).asString
         val mlensType = row(1).asString
-        val query = Json.toOperator(Json.parse(row(2).asString))
+        val query = Json.toOperator(Json.parse(row(2).asString), db.types)
         val args:Seq[Expression] = 
-          Json.toExpressionList(Json.parse(row(3).asString))
+          Json.toExpressionList(Json.parse(row(3).asString), db.types)
    
         Some(( 
           MultilensRegistry.multilenses(mlensType), 

--- a/src/main/scala/mimir/adaptive/DiscalaAbadiNormalizer.scala
+++ b/src/main/scala/mimir/adaptive/DiscalaAbadiNormalizer.scala
@@ -74,8 +74,8 @@ object DiscalaAbadiNormalizer
         fullSchema.map { x => (x._2.toLong -> x._1._1) }.toMap
       )
     groupingModel.trainDomain(db)//.reconnectToDatabase(db)
-    val schemaLookup =
-      fullSchema.map( x => (x._2 -> x._1) ).toMap
+    val schemaLookup:Map[Int,(String,BaseType)] =
+      fullSchema.map( x => (x._2 -> (x._1._1, db.types.rootType(x._1._2))) ).toMap
 
     // for every possible parent/child relationship except for ROOT
     val parentKeyRepairs = 
@@ -261,9 +261,9 @@ class DAFDRepairModel(
   name: String, 
   context: String, 
   source: Operator, 
-  keys: Seq[(String, Type)], 
+  keys: Seq[(String, BaseType)], 
   target: String,
-  targetType: Type,
+  targetType: BaseType,
   scoreCol: Option[String],
   attrLookup: Map[Long,String]
 ) extends RepairKeyModel(name, context, source, keys, target, targetType, scoreCol)

--- a/src/main/scala/mimir/adaptive/SchemaMatching.scala
+++ b/src/main/scala/mimir/adaptive/SchemaMatching.scala
@@ -27,7 +27,7 @@ object SchemaMatching
           val typeName = split(1)
           (
             varName.toString.toUpperCase -> 
-              Type.fromString(typeName.toString)
+              db.types.rootType(db.types.fromString(typeName.toString))
           )
         }).
         toList
@@ -118,7 +118,7 @@ object SchemaMatching
           val typeName = split(1)
           (
             varName.toString.toUpperCase -> 
-              Type.fromString(typeName.toString)
+              db.types.fromString(typeName.toString)
           )
         }).toList
     targetSchema.tail.foldLeft(
@@ -149,16 +149,16 @@ object SchemaMatching
   {
     if(table.equals("DATA")){
       val targetSchema =
-      config.args.
-        map(field => {
-          val split = db.interpreter.evalString(field).split(" +")
-          val varName  = split(0).toUpperCase
-          val typeName = split(1)
-          (
-            varName.toString.toUpperCase -> 
-              Type.fromString(typeName.toString)
-          )
-        }).toList
+        config.args.
+          map(field => {
+            val split = db.interpreter.evalString(field).split(" +")
+            val varName  = split(0).toUpperCase
+            val typeName = split(1)
+            (
+              varName.toString.toUpperCase -> 
+                db.types.fromString(typeName.toString)
+            )
+          }).toList
       Some(Project(
         targetSchema.map { case (colName, colType)  => { 
           val metaModel = db.models.get(s"${config.schema}:META:$colName")

--- a/src/main/scala/mimir/adaptive/TypeInference.scala
+++ b/src/main/scala/mimir/adaptive/TypeInference.scala
@@ -15,14 +15,14 @@ object TypeInference
 {
 
   
-  def detectType(v: String): Iterable[Type] = {
-    Type.tests.flatMap({ case (t, regexp) =>
-      regexp.findFirstMatchIn(v).map(_ => t)
-    })++
-      TypeRegistry.matchers.flatMap({ case (regexp, name) =>
-        regexp.findFirstMatchIn(v).map(_ => TUser(name))
-      })
-  }
+  // def detectType(v: String, types:TypeRegistry): Iterable[Type] = {
+  //   Type.tests.flatMap({ case (t, regexp) =>
+  //     regexp.findFirstMatchIn(v).map(_ => t)
+  //   })++
+  //     TypeRegistry.matchers.flatMap({ case (regexp, name) =>
+  //       regexp.findFirstMatchIn(v).map(_ => TUser(name))
+  //     })
+  // }
 
   def initSchema(db: Database, config: MultilensConfig): TraversableOnce[Model] =
   {
@@ -49,7 +49,8 @@ object TypeInference
         modelColumns,
         stringDefaultScore,
         db.backend.asInstanceOf[BackendWithSparkContext].getSparkContext(),
-        Some(db.backend.execute(config.query.limit(TypeInferenceModel.sampleLimit, 0)))
+        Some(db.backend.execute(config.query.limit(TypeInferenceModel.sampleLimit, 0))),
+        db.types.getSerializable
       )
 
     val columnIndexes = 

--- a/src/main/scala/mimir/algebra/Cast.scala
+++ b/src/main/scala/mimir/algebra/Cast.scala
@@ -4,7 +4,7 @@ import mimir.util._
 
 object Cast 
 {
-  def apply(t: Type, x: PrimitiveValue): PrimitiveValue =
+  def apply(t: BaseType, x: PrimitiveValue): PrimitiveValue =
   {
     try {
       t match {
@@ -27,18 +27,12 @@ object Cast
             case _ => TextUtils.parseInterval(x.asString)
           }
         case TRowId()           => RowIdPrimitive(x.asString)
-        case TAny()             => x
         case TBool()            => BoolPrimitive(x.asLong != 0)
-        case TType()            => TypePrimitive(Type.fromString(x.asString))
-        case TUser(name) => {
-          val (typeRegexp, baseT) = TypeRegistry.registeredTypes(name)
-          val base = apply(baseT, x) 
-          if(typeRegexp.findFirstMatchIn(base.asString).isEmpty){
-            NullPrimitive()
-          } else {
-            base
-          }
-        }
+        case TType()            => TypePrimitive(
+                                      BaseType.fromString(x.asString)
+                                              .getOrElse{ TUser(x.asString) } 
+                                   )
+        case TAny()             => x
       }
     } catch {
       case _:TypeException=> NullPrimitive();
@@ -46,6 +40,6 @@ object Cast
     }
   }
 
-  def apply(t: Type, x: String): PrimitiveValue =
+  def apply(t: BaseType, x: String): PrimitiveValue =
     apply(t, StringPrimitive(x))
 }

--- a/src/main/scala/mimir/algebra/Eval.scala
+++ b/src/main/scala/mimir/algebra/Eval.scala
@@ -213,12 +213,12 @@ object Eval
   ): PrimitiveValue = {
     if(a.equals(NullPrimitive()) || b.equals(NullPrimitive())) { return NullPrimitive() }
 
-    val aRoot = Type.rootType(a.getType)
-    val bRoot = Type.rootType(b.getType)
+    val typeOfA = a.getType
+    val typeOfB = b.getType
 
-    (op, aRoot, bRoot,
+    (op, typeOfA, typeOfB,
       Typechecker.escalate(
-      aRoot, bRoot, op, "Evaluate Arithmetic", Arithmetic(op, a, b)
+      typeOfA, typeOfB, op, "Evaluate Arithmetic", Arithmetic(op, a, b)
     )) match { 
       case (Arith.Add, _, _, TInt()) => 
         IntPrimitive(a.asLong + b.asLong)

--- a/src/main/scala/mimir/algebra/Expression.scala
+++ b/src/main/scala/mimir/algebra/Expression.scala
@@ -1,6 +1,5 @@
 package mimir.algebra;
 
-import mimir.algebra.Type._;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
 
@@ -318,7 +317,7 @@ case class IsNullExpression(child: Expression) extends Expression {
  * Slightly more specific base type for constant terms.  PrimitiveValue
  * also acts as a boxing type for constants in Mimir.
  */
-abstract sealed class PrimitiveValue(t: Type)
+abstract sealed class PrimitiveValue(t: BaseType)
   extends LeafExpression with Serializable
 {
   def getType = t
@@ -375,7 +374,7 @@ abstract sealed class PrimitiveValue(t: Type)
   def payload: Object;
 }
 
-abstract sealed class NumericPrimitive(t: Type) extends PrimitiveValue(t)
+abstract sealed class NumericPrimitive(t: BaseType) extends PrimitiveValue(t)
 
 /**
  * Boxed representation of a long integer
@@ -590,7 +589,7 @@ case class IntervalPrimitive(p: Period)
  */
 abstract class Proc(val args: Seq[Expression]) extends Expression
 {
-  def getType(argTypes: Seq[Type]): Type
+  def getType(argTypes: Seq[BaseType]): BaseType
   def getArgs = args
   def children = args
   def get(v: Seq[PrimitiveValue]): PrimitiveValue

--- a/src/main/scala/mimir/algebra/Type.scala
+++ b/src/main/scala/mimir/algebra/Type.scala
@@ -2,143 +2,101 @@ package mimir.algebra;
 
 import scala.collection.mutable.ListBuffer
 import scala.util.matching.Regex
+import mimir.util.SealedSubclassEnumeration
 
 /**
  * An enum class defining the type of primitive-valued expressions
  * (e.g., integers, floats, strings, etc...)
  */
 sealed trait Type
-{
-  override def toString(): String = {
-    Type.toString(this)
-  }
-}
 
-object Type {
-  val rootTypes = Seq(TInt(), TFloat(), TDate(), TTimestamp(), TString(), TBool(), TInterval())
-  
-  def toString(t:Type) = t match {
-    case TInt() => "int"
-    case TFloat() => "real"
-    case TDate() => "date"
-    case TTimestamp() => "datetime"
-    case TString() => "varchar"
-    case TBool() => "bool"
-    case TRowId() => "rowid"
-    case TType() => "type"
-    case TAny() => "any"
-    case TUser(name) => name.toLowerCase
-    case TInterval() => "interval"
-  }
-  def fromString(t: String) = t.toLowerCase match {
-    case "int"       => TInt()
-    case "integer"   => TInt()
-    case "float"     => TFloat()
-    case "double"    => TFloat()
-    case "decimal"   => TFloat()
-    case "real"      => TFloat() 
-    case "num"       => TFloat()
-    case "date"      => TDate()
-    case "datetime"  => TTimestamp()
-    case "timestamp" => TTimestamp()
-    case "interval"  => TInterval()
-    case "varchar"   => TString()
-    case "nvarchar"  => TString()
-    case "char"      => TString()
-    case "string"    => TString()
-    case "text"      => TString()
-    case "bool"      => TBool()
-    case "rowid"     => TRowId()
-    case "type"      => TType()
-    case "any"       => TAny()
-    case ""          => TAny() // SQLite doesn't do types sometimes
-    case x if TypeRegistry.registeredTypes contains x => TUser(x)
-    case _ => 
-      throw new RAException("Invalid Type '" + t + "'");
-  }
-  def toSQLiteType(i:Int) = i match {
-    case 0 => TInt()
-    case 1 => TFloat()
-    case 2 => TDate()
-    case 3 => TString()
-    case 4 => TBool()
-    case 5 => TRowId()
-    case 6 => TType()
-    case 7 => TAny()
-    case 8 => TTimestamp()
-    case 9 => TInterval()
-    case _ => {
-      // 9 because this is the number of native types, if more are added then this number needs to increase
-      TUser(TypeRegistry.idxType(i-10))
+object BaseType {
+
+  def toString(t:BaseType) = 
+    t match {
+      case TInt()       => "int"
+      case TFloat()     => "real"
+      case TDate()      => "date"
+      case TTimestamp() => "datetime"
+      case TString()    => "varchar"
+      case TBool()      => "bool"
+      case TRowId()     => "rowid"
+      case TType()      => "type"
+      case TInterval()  => "interval"
+      case TAny()       => "any"
     }
-  }
-  def id(t:Type) = t match {
-    case TInt() => 0
-    case TFloat() => 1
-    case TDate() => 2
-    case TString() => 3
-    case TBool() => 4
-    case TRowId() => 5
-    case TType() => 6
-    case TAny() => 7
-    case TTimestamp() => 8
-    case TInterval() => 9
-    case TUser(name)  => TypeRegistry.typeIdx(name.toLowerCase)+10
-      // 9 because this is the number of native types, if more are added then this number needs to increase
-  }
 
-  val tests = Map[Type,Regex](
+  def fromString(t: String):Option[BaseType] = 
+    t.toLowerCase match {
+      case "int"       => Some(TInt())
+      case "integer"   => Some(TInt())
+      case "float"     => Some(TFloat())
+      case "double"    => Some(TFloat())
+      case "decimal"   => Some(TFloat())
+      case "real"      => Some(TFloat() )
+      case "num"       => Some(TFloat())
+      case "date"      => Some(TDate())
+      case "datetime"  => Some(TTimestamp())
+      case "timestamp" => Some(TTimestamp())
+      case "interval"  => Some(TInterval())
+      case "varchar"   => Some(TString())
+      case "nvarchar"  => Some(TString())
+      case "char"      => Some(TString())
+      case "string"    => Some(TString())
+      case "text"      => Some(TString())
+      case "bool"      => Some(TBool())
+      case "rowid"     => Some(TRowId())
+      case "type"      => Some(TType())
+      case ""          => Some(TAny())
+      case "any"       => Some(TAny())
+      case _           => None
+    }
+
+  val tests = Seq[(BaseType,Regex)](
     TInt()   -> "^(\\+|-)?([0-9]+)$".r,
     TFloat() -> "^(\\+|-)?([0-9]*(\\.[0-9]+)?)$".r,
-    //TDate()  -> "^[0-9]{4}[\\/\\\\-][0-9]{1,2}[\\/\\\\-][0-9]{1,2}$".r,
-    //TTimestamp() -> """^[0-9]{4}[\/\\-][0-9]{1,2}[\/\\-][0-9]{1,2}\s+[0-9]{1,2}:[0-9]{1,2}:(?:[0-9]{0,2}(?:\.[0-9]*)?)$""".r,
     TDate()  -> "^[0-9]{4}\\-[0-9]{1,2}\\-[0-9]{1,2}$".r,
     TTimestamp() -> "^[0-9]{4}\\-[0-9]{1,2}\\-[0-9]{1,2}\\s+[0-9]{1,2}:[0-9]{1,2}:([0-9]{1,2}|[0-9]{0,2}\\.[0-9]*)$".r,
     TBool()  -> "^(?i:true|false)$".r
   )
-  def matches(t: Type, v: String): Boolean =
-    tests.get(t) match {
-      case Some(test) => !test.findFirstIn(v).isEmpty
-      case None => true
-    }
 
-  def rootType(t: Type): Type =
-    t match {
-      case TUser(t2) => rootType(TypeRegistry.baseType(t2))
-      case t2 => t2
-    }
-
-  def isNumeric(t: Type, treatTAnyAsNumeric: Boolean = false): Boolean =
-  {
-    rootType(t) match {
-      case TInt() | TFloat() => true
-      case TAny() => treatTAnyAsNumeric
-      case _ => false
-    }
+  def guessBaseType(s:String): BaseType = {
+    tests.find { case (_,regex) => (regex findFirstIn s) != None }
+         .map { case (t,_) => t }
+         .getOrElse(TString())
   }
 
-  def getType(s:String): Type = {
-    var t: Type = TString() // default
-
-    if(s.matches("^(\\+|-)?([0-9]*(\\.[0-9]+)?)$")) // float
-      t = TFloat()
-    else if(s.matches("^(\\+|-)?([0-9]+)$")) // Int
-      t = TInt()
-    else if(s.matches("^(?i:true|false)$")) // Bool
-      t = TBool()
-    else if(s.matches("^[0-9]{4}\\-[0-9]{2}\\-[0-9]{2}$"))
-      t = TDate()
-    else if(s.matches("^[0-9]{4}\\-[0-9]{2}\\-[0-9]{2}\\ \\[0-9]{2}\\:[0-9]{2}\\:[0-9]{2}"))
-      t = TTimestamp()
-    t
-  }
-
+  val idTypeOrder = Seq[BaseType](
+    TInt(),
+    TFloat(),
+    TDate(),
+    TString(),
+    TBool(),
+    TRowId(),
+    TType(),
+    TAny(),
+    TTimestamp(),
+    TInterval()
+  )
 }
 
 sealed trait BaseType extends Type
+{
+  override def toString(): String = {
+    BaseType.toString(this)
+  }
+  val isNumeric = false
+}
 
 case class TInt() extends BaseType
+{ 
+  override val isNumeric = true
+}
 case class TFloat() extends BaseType
+{ 
+  override val isNumeric = true
+}
+
 case class TDate() extends BaseType
 case class TString() extends BaseType
 case class TBool() extends BaseType
@@ -146,9 +104,12 @@ case class TRowId() extends BaseType
 case class TType() extends BaseType
 case class TTimestamp() extends BaseType
 case class TInterval() extends BaseType
+case class TAny() extends BaseType
 
-case class TAny() extends Type
 case class TUser(name:String) extends Type
+{ 
+  override def toString() = name
+}
 
 
 
@@ -173,29 +134,29 @@ These are the files that need to change to extend the TUser
     - change sealed trait Type so that all the instances of TUser match the new parameters
   - mimir.sql.sqlite.SQLiteCompat:
     - update TUser type parameters
- */
-object TypeRegistry {
-  val registeredTypes = Map[String,(Regex,Type)](
-    "tuser"         -> ("USER".r,                              TString()),
-    "tweight"       -> ("KG*".r,                               TString()),
-    "productid"     -> ("^P\\d+$".r,                           TString()),
-    "firecompany"   -> ("^[a-zA-Z]\\d{3}$".r,                  TString()),
-    "zipcode"       -> ("^\\d{5}(?:[-\\s]\\d{4})?$".r,         TString()),
-    "container"     -> ("^[A-Z]{4}[0-9]{7}$".r,                TString()),
-    "carriercode"   -> ("^[A-Z]{4}$".r,                        TString()),
-    "mmsi"          -> ("^MID\\d{6}|0MID\\d{5}|00MID\\{4}$".r, TString()),
-    "billoflanding" -> ("^[A-Z]{8}[0-9]{8}$".r,                TString()),
-    "imo_code"      -> ("^\\d{7}$".r,                          TInt())
-  )
-  val idxType = registeredTypes.keys.toIndexedSeq
-  val typeIdx = idxType.zipWithIndex.toMap
+  */
+// object TypeRegistry {
+//   val registeredTypes = Map[String,(Regex,Type)](
+//     "tuser"         -> ("USER".r,                              TString()),
+//     "tweight"       -> ("KG*".r,                               TString()),
+//     "productid"     -> ("^P\\d+$".r,                           TString()),
+//     "firecompany"   -> ("^[a-zA-Z]\\d{3}$".r,                  TString()),
+//     "zipcode"       -> ("^\\d{5}(?:[-\\s]\\d{4})?$".r,         TString()),
+//     "container"     -> ("^[A-Z]{4}[0-9]{7}$".r,                TString()),
+//     "carriercode"   -> ("^[A-Z]{4}$".r,                        TString()),
+//     "mmsi"          -> ("^MID\\d{6}|0MID\\d{5}|00MID\\{4}$".r, TString()),
+//     "billoflanding" -> ("^[A-Z]{8}[0-9]{8}$".r,                TString()),
+//     "imo_code"      -> ("^\\d{7}$".r,                          TInt())
+//   )
+//   val idxType = registeredTypes.keys.toIndexedSeq
+//   val typeIdx = idxType.zipWithIndex.toMap
 
-  val matchers = registeredTypes.toSeq.map( t => (t._2._1, t._1) )
+//   val matchers = registeredTypes.toSeq.map( t => (t._2._1, t._1) )
 
-  def baseType(t: String): Type = registeredTypes(t)._2
+//   def baseType(t: String): Type = registeredTypes(t)._2
 
-  def matcher(t: String): Regex = registeredTypes(t)._1
+//   def matcher(t: String): Regex = registeredTypes(t)._1
 
-  def matches(t: String, v: String): Boolean =
-    !matcher(t).findFirstIn(v).isEmpty
-}
+//   def matches(t: String, v: String): Boolean =
+//     !matcher(t).findFirstIn(v).isEmpty
+// }

--- a/src/main/scala/mimir/algebra/Type.scala
+++ b/src/main/scala/mimir/algebra/Type.scala
@@ -135,17 +135,20 @@ object Type {
 
 }
 
-case class TInt() extends Type
-case class TFloat() extends Type
-case class TDate() extends Type
-case class TString() extends Type
-case class TBool() extends Type
-case class TRowId() extends Type
-case class TType() extends Type
+sealed trait BaseType extends Type
+
+case class TInt() extends BaseType
+case class TFloat() extends BaseType
+case class TDate() extends BaseType
+case class TString() extends BaseType
+case class TBool() extends BaseType
+case class TRowId() extends BaseType
+case class TType() extends BaseType
+case class TTimestamp() extends BaseType
+case class TInterval() extends BaseType
+
 case class TAny() extends Type
 case class TUser(name:String) extends Type
-case class TTimestamp() extends Type
-case class TInterval() extends Type
 
 
 

--- a/src/main/scala/mimir/algebra/Typechecker.scala
+++ b/src/main/scala/mimir/algebra/Typechecker.scala
@@ -6,32 +6,33 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
 
 import mimir.Database
 import mimir.algebra.function._
+import mimir.algebra.typeregistry._
 import mimir.models.{Model, ModelManager}
 import Arith.{Add, Sub, Mult, Div, And, Or, BitAnd, BitOr, ShiftLeft, ShiftRight}
 import Cmp.{Gt, Lt, Lte, Gte, Eq, Neq, Like, NotLike}
 
 class TypecheckError(msg: String, e: Throwable, context: Option[Operator] = None)
-	extends Exception(msg, e)
+  extends Exception(msg, e)
 {
-	def errorTypeString =
-		getClass().getTypeName()
+  def errorTypeString =
+    getClass().getTypeName()
 
-	override def toString =
-		context match {
-			case None => s"$errorTypeString : $msg"
-			case Some(oper) => s"$errorTypeString : $msg\n$oper"
-		}
+  override def toString =
+    context match {
+      case None => s"$errorTypeString : $msg"
+      case Some(oper) => s"$errorTypeString : $msg\n$oper"
+    }
 
 
-	override def getMessage =
-		context match {
-			case None => msg
-			case Some(oper) => s"$msg in ${oper.toString.filter { _ != '\n' }.take(200)}"
-		}
+  override def getMessage =
+    context match {
+      case None => msg
+      case Some(oper) => s"$msg in ${oper.toString.filter { _ != '\n' }.take(200)}"
+    }
 }
 
 class MissingVariable(varName: String, e: Throwable, context: Option[Operator] = None)
-	extends TypecheckError(varName, e, context);
+  extends TypecheckError(varName, e, context);
 
 /**
  * ExpressionChecker wraps around a bit of context that makes
@@ -51,116 +52,127 @@ class MissingVariable(varName: String, e: Throwable, context: Option[Operator] =
  *             error with this operator.
  */
 class Typechecker(
-	functions: Option[FunctionRegistry] = None, 
-	aggregates: Option[AggregateRegistry] = None,
-	models: Option[ModelManager] = None
+  functions: Option[FunctionRegistry] = None, 
+  aggregates: Option[AggregateRegistry] = None,
+  types: TypeRegistry = DefaultTypeRegistry,
+  models: Option[ModelManager] = None
 ) extends LazyLogging {
-	/* Assert that the expressions claimed type is its type */
-	def assert(e: Expression, t: Type, scope: (String => Type), context: Option[Operator] = None, msg: String = "Typechecker"): Unit = {
-		val eType = typeOf(e, scope);
-		if(!Typechecker.canCoerce(eType, t)){
-			logger.trace(s"LUB: ${Typechecker.leastUpperBound(eType, t)}")
-			throw new TypeException(eType, t, msg, Some(e))
-		}
-	}
-
-	def weakTypeOf(e: Expression) =
-		typeOf(e, (_) => TAny())
-
-	def typeOf(e: Expression, o: Operator): Type =
-		typeOf(e, scope = schemaOf(o).toMap, context = Some(o))
-
-	def typeOf(
-		e: Expression, 
-		scope: (String => Type) = { (_:String) => throw new RAException("Need a scope to typecheck expressions with variables") }, 
-		context: Option[Operator] = None
-	): Type = {
-		val recur = typeOf(_:Expression, scope, context)
-
-		e match {
-			case p: PrimitiveValue => p.getType;
-			case Not(child) => assert(child, TBool(), scope, context, "NOT"); TBool()
-			case p: Proc => p.getType(p.children.map(recur(_)))
-			case Arithmetic(op, lhs, rhs) => 
-				Typechecker.escalate(recur(lhs), recur(rhs), op, "Arithmetic", e)
-			case Comparison(op, lhs, rhs) => {
-				op match {
-					case (Eq | Neq) => 
-						Typechecker.assertLeastUpperBound(recur(lhs), recur(rhs), "Comparison", e)
-					case (Gt | Gte | Lt | Lte) => 
-						Typechecker.assertOneOf(
-							Typechecker.assertLeastUpperBound(
-								recur(lhs), 
-								recur(rhs), 
-								"Comparison", 
-								e
-							),
-							Set(TDate(), TInterval(), TTimestamp(), TInt(), TFloat()),
-							e
-						)
-					case (Like | NotLike) =>
-						assert(lhs, TString(), scope, context, "LIKE")
-						assert(rhs, TString(), scope, context, "LIKE")
-				}
-				TBool()
-			}
-			case Var(name) => 
-				try { 
-					val t = scope(name)
-					logger.debug(s"Type of $name is $t")
-					t
-				} catch {
-					case x:NoSuchElementException => throw new MissingVariable(name, x, context)
-				}
-			case JDBCVar(t) => t
-			case Function("CAST", fargs) =>
-				// Special case CAST
-				fargs(1) match {
-					case TypePrimitive(t) => t
-					case p:PrimitiveValue => { p match {
-              case StringPrimitive(s) => Type.toSQLiteType(Integer.parseInt(s))
-              case IntPrimitive(i)  =>  Type.toSQLiteType(i.toInt)
-      	      case _ => throw new RAException("Invalid CAST to '"+p+"' of type: "+recur(p))
-            }
-					}
-					case _ => TAny()
-				}
-			case Function(name, args) => 
-				returnTypeOfFunction(name, args.map { recur(_) })
-
-			case Conditional(condition, thenClause, elseClause) => 
-				assert(condition, TBool(), scope, context, "WHEN")
-				Typechecker.assertLeastUpperBound(
-					recur(elseClause),
-					recur(thenClause),
-					"CASE-WHEN",
-					e
-				)
-			case IsNullExpression(child) =>
-				recur(child);
-				TBool()
-			case RowIdVar() => TRowId()
-			case VGTerm(model, idx, args, hints) => 
-				models match {
-					case Some(registry) =>
-						registry.get(model).varType(idx, args.map(recur(_)))
-					case None => throw new RAException("Need Model Manager to typecheck expressions with VGTerms")
-				}
+  /* Assert that the expressions claimed type is its type */
+  def assert(e: Expression, t: Type, scope: (String => Type), context: Option[Operator] = None, msg: String = "Typechecker"): Unit = {
+    val eType = typeOf(e, scope);
+    if(!Typechecker.canCoerce(eType, t, types)){
+      logger.trace(s"LUB: ${Typechecker.leastUpperBound(eType, t, types)}")
+      throw new TypeException(eType, t, msg, Some(e))
     }
   }
 
-	def returnTypeOfFunction(name: String, args: Seq[Type]): Type = {
+  def weakTypeOf(e: Expression) =
+    typeOf(e, (_) => TAny())
+
+  def typeOf(e: Expression, o: Operator): Type =
+    typeOf(e, scope = schemaOf(o).toMap, context = Some(o))
+
+  def rootType = types.rootType _
+
+  def typeOf(
+    e: Expression, 
+    scope: (String => Type) = { (_:String) => throw new RAException("Need a scope to typecheck expressions with variables") }, 
+    context: Option[Operator] = None
+  ): Type = {
+    val recur = typeOf(_:Expression, scope, context)
+
+    e match {
+      case p: PrimitiveValue => p.getType;
+      case Not(child) => assert(child, TBool(), scope, context, "NOT"); TBool()
+      case p: Proc => p.getType(p.children.map { recur(_) }
+                                          .map { types.rootType(_) }
+                                )
+      case Arithmetic(op, lhs, rhs) => 
+        Typechecker.escalate(types.rootType(recur(lhs)), types.rootType(recur(rhs)), op, "Arithmetic", e)
+      case Comparison(op, lhs, rhs) => {
+        op match {
+          case (Eq | Neq) => 
+            Typechecker.assertLeastUpperBound(recur(lhs), recur(rhs), "Comparison", e, types)
+          case (Gt | Gte | Lt | Lte) => 
+            Typechecker.assertOneOf(
+              types.rootType(
+                Typechecker.assertLeastUpperBound(
+                  recur(lhs), 
+                  recur(rhs), 
+                  "Comparison", 
+                  e,
+                  types
+                )
+              ),
+              Set(TDate(), TInterval(), TTimestamp(), TInt(), TFloat()),
+              e
+            )
+          case (Like | NotLike) =>
+            assert(lhs, TString(), scope, context, "LIKE")
+            assert(rhs, TString(), scope, context, "LIKE")
+        }
+        TBool()
+      }
+      case Var(name) => 
+        try { 
+          val t = scope(name)
+          logger.debug(s"Type of $name is $t")
+          t
+        } catch {
+          case x:NoSuchElementException => throw new MissingVariable(name, x, context)
+        }
+      case JDBCVar(t) => t
+      case Function("CAST", fargs) =>
+        // Special case CAST
+        fargs(1) match {
+          case TypePrimitive(t) => t
+          case p:PrimitiveValue => { p match {
+              case StringPrimitive(s) => types.typeForId(Integer.parseInt(s))
+              case IntPrimitive(i)  =>  types.typeForId(i.toInt)
+              case _ => throw new RAException("Invalid CAST to '"+p+"' of type: "+recur(p))
+            }
+          }
+          case _ => TAny()
+        }
+      case Function(name, args) => 
+        returnTypeOfFunction(name, args.map { recur(_) }.map { types.rootType(_) })
+
+      case Conditional(condition, thenClause, elseClause) => 
+        assert(condition, TBool(), scope, context, "WHEN")
+        Typechecker.assertLeastUpperBound(
+          recur(elseClause),
+          recur(thenClause),
+          "CASE-WHEN",
+          e,
+          types
+        )
+      case IsNullExpression(child) =>
+        recur(child);
+        TBool()
+      case RowIdVar() => TRowId()
+      case VGTerm(model, idx, args, hints) => 
+        models match {
+          case Some(registry) =>
+            registry.get(model).varType(idx, 
+              args.map { recur(_) }.map { types.rootType(_) }
+            )
+          case None => throw new RAException("Need Model Manager to typecheck expressions with VGTerms")
+        }
+    }
+  }
+
+  def returnTypeOfFunction(name: String, args: Seq[BaseType]): BaseType = {
     try {
       functions.flatMap { _.getOption(name) } match {
         case Some(NativeFunction(_, _, getType, _)) => 
           getType(args)
         case Some(ExpressionFunction(_, argNames, expr)) => 
-          typeOf(expr, scope = argNames.zip(args).toMap)
+          types.rootType(typeOf(expr, scope = argNames.zip(args).toMap))
         case Some(FoldFunction(_, expr)) =>
           args.tail.foldLeft(args.head){ case (curr,next) => 
-            typeOf(expr, Map("CURR" -> curr, "NEXT" -> next)) }
+            types.rootType(typeOf(expr, Map("CURR" -> curr, "NEXT" -> next))) }
         case None => 
-        	throw new RAException(s"Function $name(${args.mkString(",")}) is undefined")
+          throw new RAException(s"Function $name(${args.mkString(",")}) is undefined")
       }
     } catch {
       case TypeException(found, expected, detail, None) =>
@@ -168,195 +180,233 @@ class Typechecker(
     }
   }
 
-
-	def schemaOf(o: Operator): Seq[(String, Type)] =
-	{
-		o match {
-			case Project(cols, src) =>
-				val schema = schemaOf(src).toMap
-				cols.map( { 
-						case ProjectArg(col, expression) =>
-							(col, typeOf(expression, scope = schema(_), context = Some(src)))
-					})
-			
-			case ProvenanceOf(psel) => 
-				// Not 100% sure this is kosher... doesn't ProvenanceOf introduce new columns?
+  def schemaOf(o: Operator): Seq[(String, Type)] =
+  {
+    o match {
+      case Project(cols, src) =>
+        val schema = schemaOf(src).toMap
+        cols.map( { 
+            case ProjectArg(col, expression) =>
+              (col, typeOf(expression, scope = schema(_), context = Some(src)))
+          })
+      
+      case ProvenanceOf(psel) => 
+        // Not 100% sure this is kosher... doesn't ProvenanceOf introduce new columns?
         schemaOf(psel)
       
-			case Annotate(subj,invisScm) => {
+      case Annotate(subj,invisScm) => {
         schemaOf(subj)
       }
       
-			case Recover(subj,invisScm) => {
+      case Recover(subj,invisScm) => {
         schemaOf(subj).union(invisScm.map(_._2).map(pasct => (pasct.name,pasct.typ)))
       }
-			
+      
       case Select(cond, src) => {
-				val srcSchema = schemaOf(src);
-      	assert(cond, TBool(), srcSchema.toMap, Some(src), "SELECT")
-      	return srcSchema
+        val srcSchema = schemaOf(src);
+        assert(cond, TBool(), srcSchema.toMap, Some(src), "SELECT")
+        return srcSchema
       }
 
-			case Aggregate(gbCols, aggCols, src) =>
-				aggregates match {
-					case None => throw new RAException("Need Aggregate Registry to typecheck aggregates")
-					case Some(registry) => {
+      case Aggregate(gbCols, aggCols, src) =>
+        aggregates match {
+          case None => throw new RAException("Need Aggregate Registry to typecheck aggregates")
+          case Some(registry) => {
 
-						/* Nested Typechecker */
-						val srcSchema = schemaOf(src).toMap
-						val chk = typeOf(_:Expression, scope = srcSchema, context = Some(src))
+            /* Nested Typechecker */
+            val srcSchema = schemaOf(src).toMap
+            val chk = typeOf(_:Expression, scope = srcSchema, context = Some(src))
 
-						/* Get Group By Args and verify type */
-						val groupBySchema: Seq[(String, Type)] = gbCols.map(x => (x.toString, chk(x)))
+            /* Get Group By Args and verify type */
+            val groupBySchema: Seq[(String, Type)] = gbCols.map(x => (x.toString, chk(x)))
 
-						/* Get function name, check for AVG *//* Get function parameters, verify type */
-						val aggSchema: Seq[(String, Type)] = aggCols.map(x => 
-							(
-								x.alias, 
-								registry.typecheck(x.function, x.args.map(chk(_)))
-							)
-						)
+            /* Get function name, check for AVG *//* Get function parameters, verify type */
+            val aggSchema: Seq[(String, Type)] = aggCols.map(x => 
+              (
+                x.alias, 
+                registry.typecheck(x.function, x.args.map { chk(_) }.map { types.rootType(_) })
+              )
+            )
 
-						/* Send schema to parent operator */
-						val sch = groupBySchema ++ aggSchema
-						//println(sch)
-						sch
+            /* Send schema to parent operator */
+            val sch = groupBySchema ++ aggSchema
+            //println(sch)
+            sch
 
-					}
+          }
 
-				}
+        }
 
-			case Join(lhs, rhs) =>
-				val lSchema = schemaOf(lhs);
-				val rSchema = schemaOf(rhs);
+      case Join(lhs, rhs) =>
+        val lSchema = schemaOf(lhs);
+        val rSchema = schemaOf(rhs);
 
-				val overlap = lSchema.map(_._1).toSet & rSchema.map(_._1).toSet
-				if(!(overlap.isEmpty)){
-					throw new RAException("Ambiguous Keys ('"+overlap+"') in Cross Product\n"+o);
-				}
-				lSchema ++ rSchema
+        val overlap = lSchema.map(_._1).toSet & rSchema.map(_._1).toSet
+        if(!(overlap.isEmpty)){
+          throw new RAException("Ambiguous Keys ('"+overlap+"') in Cross Product\n"+o);
+        }
+        lSchema ++ rSchema
 
-			case LeftOuterJoin(lhs, rhs, condition) =>
-				schemaOf(Select(condition, Join(lhs, rhs)))
+      case LeftOuterJoin(lhs, rhs, condition) =>
+        schemaOf(Select(condition, Join(lhs, rhs)))
 
-			case Union(lhs, rhs) =>
-				val lSchema = schemaOf(lhs);
-				val rSchema = schemaOf(rhs);
+      case Union(lhs, rhs) =>
+        val lSchema = schemaOf(lhs);
+        val rSchema = schemaOf(rhs);
 
-				if(!(lSchema.map(_._1).toSet.equals(rSchema.map(_._1).toSet))){
-					throw new RAException("Schema Mismatch in Union\n"+o+s"$lSchema <> $rSchema");
-				}
-				lSchema
+        if(!(lSchema.map(_._1).toSet.equals(rSchema.map(_._1).toSet))){
+          throw new RAException("Schema Mismatch in Union\n"+o+s"$lSchema <> $rSchema");
+        }
+        lSchema
 
-			case Table(_, _, sch, meta) => (sch ++ meta.map( x => (x._1, x._3) ))
+      case Table(_, _, sch, meta) => (sch ++ meta.map( x => (x._1, x._3) ))
 
-			case View(_, query, _) => schemaOf(query)
-			case AdaptiveView(_, _, query, _) => schemaOf(query)
+      case View(_, query, _) => schemaOf(query)
+      case AdaptiveView(_, _, query, _) => schemaOf(query)
 
-			case HardTable(sch,_) => sch
+      case HardTable(sch,_) => sch
 
-			case Limit(_, _, src) => schemaOf(src)
+      case Limit(_, _, src) => schemaOf(src)
 
-			case Sort(_, src) => schemaOf(src)
-		}
-	}
+      case Sort(_, src) => schemaOf(src)
+    }
+  }
+
+  def baseSchemaOf(o: Operator): Seq[(String, BaseType)] = 
+    schemaOf(o).map { case (name, t) => (name, types.rootType(t)) }
 }
 
 object Typechecker 
   extends LazyLogging
 {
 
-	val trivialTypechecker = new Typechecker()
+  val trivialTypechecker = new Typechecker()
 
-	def assertNumeric(t: Type, e: Expression): Type =
- 	{
-		if(!Type.isNumeric(t)){
-			throw new TypeException(t, TFloat(), "Numeric", Some(e))
- 		}
- 		t;
- 	}
+  def assertNumeric(t: BaseType, e: Expression): BaseType =
+  {
+    if(t.isNumeric){
+      throw new TypeException(t, TFloat(), "Numeric", Some(e))
+    }
+    t;
+  }
 
- 	def canCoerce(from: Type, to: Type): Boolean =
- 	{
- 		logger.debug("Coerce from $from to $to")
- 		leastUpperBound(from, to) match {
- 			case Some(lub) => lub.equals(to)
- 			case None => false
-		}
- 	}
+  def canCoerce(from: BaseType, to: BaseType): Boolean =
+  {
+    logger.debug("Coerce from $from to $to")
+    leastUpperBound(from, to) match {
+      case Some(lub) => lub.equals(to)
+      case None => false
+    }
+  }
 
- 	def leastUpperBound(a: Type, b: Type): Option[Type] =
- 	{
- 		if(a.equals(b)){ return Some(a); }
- 		(a, b) match {
- 			case (TAny(), _) => Some(b)
-			case (_, TAny()) => Some(a)
-			case (TInt(), TFloat()) => Some(TFloat())
-			case (TFloat(), TInt()) => Some(TFloat())
-			case (TDate(), TTimestamp()) => Some(TTimestamp())
-			case (TTimestamp(), TDate()) => Some(TTimestamp())
-			case (TRowId(), TString()) => Some(TRowId())
-			case (TString(), TRowId()) => Some(TRowId())
-			case (TRowId(), TInt()) => Some(TInt())
-			case (TInt(), TRowId()) => Some(TInt())
-			case (TUser(name), _) => leastUpperBound(TypeRegistry.baseType(name), b)
-			case (_, TUser(name)) => leastUpperBound(a, TypeRegistry.baseType(name))
-			case _ => return None
- 		}
- 	}
+  def canCoerce(from: Type, to: Type, types: TypeRegistry): Boolean =
+  {
+    logger.debug("Coerce from $from to $to")
+    leastUpperBound(from, to, types) match {
+      case Some(lub) => lub.equals(to)
+      case None => false
+    }
+  }
 
- 	def leastUpperBound(tl: TraversableOnce[Type]): Option[Type] =
- 	{
- 		tl.map { Some(_) }.fold(Some(TAny()):Option[Type]) { case (Some(a), Some(b)) => leastUpperBound(a, b) case _ => None }
- 	}
+  def leastUpperBound(a: BaseType, b: BaseType): Option[BaseType] =
+  {
+    if(a.equals(b)){ return Some(a); }
+    (a, b) match {
+      case (TAny(), _) => Some(b)
+      case (_, TAny()) => Some(a)
+      case (TInt(), TFloat()) => Some(TFloat())
+      case (TFloat(), TInt()) => Some(TFloat())
+      case (TDate(), TTimestamp()) => Some(TTimestamp())
+      case (TTimestamp(), TDate()) => Some(TTimestamp())
+      case (TRowId(), TString()) => Some(TRowId())
+      case (TString(), TRowId()) => Some(TRowId())
+      case (TRowId(), TInt()) => Some(TInt())
+      case (TInt(), TRowId()) => Some(TInt())
+      case _ => return None
+    }
+  }
 
- 	def assertLeastUpperBound(a: Type, b: Type, msg: String, e: Expression): Type =
- 	{
- 		leastUpperBound(a, b) match {
- 			case Some(t) => t
- 			case None => throw new TypeException(a, b, msg, Some(e))
- 		}
- 	}
- 	def assertLeastUpperBound(tl: TraversableOnce[Type], msg: String, e: Expression): Type =
- 	{
- 		tl.fold(TAny()) { assertLeastUpperBound(_, _, msg, e) }
- 	}
+  def leastUpperBound(tl: TraversableOnce[BaseType]): Option[BaseType] =
+  {
+    tl.map { Some(_) }.fold(Some(TAny()):Option[BaseType]) { case (Some(a), Some(b)) => leastUpperBound(a, b) case _ => None }
+  }
 
- 	def assertOneOf(a: Type, candidates: TraversableOnce[Type], e: Expression): Type =
- 	{
-		candidates.flatMap { leastUpperBound(a, _) }.collectFirst { case x => x } match {
-			case Some(t) => t
-			case None => 
-				throw new TypeException(a, TAny(), s"Not one of $candidates", Some(e))
-		}
- 	}
+  def assertLeastUpperBound(a: BaseType, b: BaseType, msg: String, e: Expression): BaseType =
+  {
+    leastUpperBound(a, b) match {
+      case Some(t) => t
+      case None => throw new TypeException(a, b, msg, Some(e))
+    }
+  }
+  def assertLeastUpperBound(tl: TraversableOnce[BaseType], msg: String, e: Expression): BaseType =
+  {
+    tl.fold(TAny()) { assertLeastUpperBound(_, _, msg, e) }
+  }
 
-	def escalate(a: Type, b: Type, op: Arith.Op, msg: String, e: Expression): Type = 
-	{
-		escalate(a, b, op) match {
-			case Some(t) => t
-			case None => throw new TypeException(a, b, msg, Some(e));
-		}
-	}
-	def escalate(a: Type, b: Type, op: Arith.Op): Option[Type] = 
-	{
-		// Start with special case overrides
-		(a, b, op) match {
-		  case (TDate() | TTimestamp(), 
-						TDate() | TTimestamp(), 
-						Arith.Add)                => return Some(TDate())
+  def assertOneOf(a: BaseType, candidates: TraversableOnce[BaseType], e: Expression): BaseType =
+  {
+    candidates.flatMap { leastUpperBound(a, _) }.collectFirst { case x => x } match {
+      case Some(t) => t
+      case None => 
+        throw new TypeException(a, TAny(), s"Not one of $candidates", Some(e))
+    }
+  }
+
+  def leastUpperBound(a: Type, b: Type, types:TypeRegistry): Option[Type] =
+  {
+    (a, b) match {
+      case (TUser(_), TUser(_))             => leastUpperBound(types.parentType(a), b, types)
+                                                .map { Some(_) }
+                                                .getOrElse{ leastUpperBound(a, types.parentType(b), types) }
+      case (TUser(_), _:BaseType)           => leastUpperBound(types.parentType(a), b, types)
+      case (_:BaseType, TUser(_))           => leastUpperBound(a, types.parentType(b), types)
+      case (aBase:BaseType, bBase:BaseType) => leastUpperBound(aBase, bBase)
+    }
+  }
+
+  def leastUpperBound(tl: TraversableOnce[Type], types:TypeRegistry): Option[Type] =
+  {
+    tl.map { Some(_) }.fold(Some(TAny()):Option[Type]) { case (Some(a), Some(b)) => leastUpperBound(a, b, types) case _ => None }
+  }
+
+  def assertLeastUpperBound(a: Type, b: Type, msg: String, e: Expression, types:TypeRegistry): Type =
+  {
+    leastUpperBound(a, b, types) match {
+      case Some(t) => t
+      case None => throw new TypeException(a, b, msg, Some(e))
+    }
+  }
+  def assertLeastUpperBound(tl: TraversableOnce[Type], msg: String, e: Expression, types:TypeRegistry): Type =
+  {
+    tl.fold(TAny()) { assertLeastUpperBound(_, _, msg, e, types) }
+  }
+
+  def escalate(a: BaseType, b: BaseType, op: Arith.Op, msg: String, e: Expression): BaseType = 
+  {
+    escalate(a, b, op) match {
+      case Some(t) => t
+      case None => throw new TypeException(a, b, msg, Some(e));
+    }
+  }
+  def escalate(a: BaseType, b: BaseType, op: Arith.Op): Option[BaseType] = 
+  {
+    // Start with special case overrides
+    (a, b, op) match {
+      case (TDate() | TTimestamp(), 
+            TDate() | TTimestamp(), 
+            Arith.Add)                => return Some(TDate())
       // Interval Arithmetic
-			case (TDate() | TTimestamp(), 
-						TDate() | TTimestamp(), 
-						Arith.Sub)                => return Some(TInterval())
-			case (TDate() | TTimestamp() | TInterval(), 
-						TInterval(), 
-						Arith.Sub | Arith.Add)    => return Some(a)
-			case (TInt() | TFloat(), TInterval(), Arith.Mult) | 
-					 (TInterval(), TInt() | TFloat(), Arith.Mult | Arith.Div)  
-					                              => return Some(TInterval())
-			case (TInterval(), TInterval(), Arith.Div)
-			                                      => return Some(TFloat())
+      case (TDate() | TTimestamp(), 
+            TDate() | TTimestamp(), 
+            Arith.Sub)                => return Some(TInterval())
+      case (TDate() | TTimestamp() | TInterval(), 
+            TInterval(), 
+            Arith.Sub | Arith.Add)    => return Some(a)
+      case (TInt() | TFloat(), TInterval(), Arith.Mult) | 
+           (TInterval(), TInt() | TFloat(), Arith.Mult | Arith.Div)  
+                                        => return Some(TInterval())
+      case (TInterval(), TInterval(), Arith.Div)
+                                            => return Some(TFloat())
 
       // TAny() cases
       case (TAny(), TAny(), _)        => return Some(TAny())
@@ -364,45 +414,45 @@ object Typechecker
             Arith.Sub)                => Some(TInterval())
       case (TDate() | TTimestamp(), TAny(), 
             Arith.Sub)                => Some(TAny()) // Either TInterval or TDate, depending
-			case _ => ()
-		}
+      case _ => ()
+    }
 
-		(op) match {
-			case (Arith.Add | Arith.Sub | Arith.Mult | Arith.Div) => 
-				if(Type.isNumeric(a, treatTAnyAsNumeric = true) && Type.isNumeric(b, treatTAnyAsNumeric = true)){
-					leastUpperBound(a, b)
-				} else {
+    (op) match {
+      case (Arith.Add | Arith.Sub | Arith.Mult | Arith.Div) => 
+        if( (a.isNumeric || a == TAny()) && (b.isNumeric || b == TAny()) ){
+          leastUpperBound(a, b)
+        } else {
           None
-				}
+        }
 
       case (Arith.BitAnd | Arith.BitOr | Arith.ShiftLeft | Arith.ShiftRight) =>
-        (Type.rootType(a), Type.rootType(b)) match {
+        (a, b) match {
           case (TInt() | TAny(), TInt() | TAny()) => Some(TInt())
           case _ => None
         }
 
       case (Arith.And | Arith.Or) =>
-        (Type.rootType(a), Type.rootType(b)) match {
+        (a, b) match {
           case (TBool() | TAny(), TBool() | TAny()) => Some(TBool())
           case _ => None
         }
-		}
-	}
-	def escalate(a: Option[Type], b: Option[Type], op: Arith.Op): Option[Type] =
-	{
-		(a, b) match {
-			case (None,_) => b
-			case (_,None) => a
-			case (Some(at), Some(bt)) => escalate(at, bt, op)
-		}
-	}
+    }
+  }
+  def escalate(a: Option[BaseType], b: Option[BaseType], op: Arith.Op): Option[BaseType] =
+  {
+    (a, b) match {
+      case (None,_) => b
+      case (_,None) => a
+      case (Some(at), Some(bt)) => escalate(at, bt, op)
+    }
+  }
 
-	def escalate(l: TraversableOnce[Type], op: Arith.Op): Option[Type] =
-	{
-		l.map(Some(_)).fold(None)(escalate(_,_,op))
-	}
-	def escalate(l: TraversableOnce[Type], op: Arith.Op, msg: String, e: Expression): Type =
-	{
-		l.fold(TAny())(escalate(_,_,op,msg,e))
-	}
+  def escalate(l: TraversableOnce[BaseType], op: Arith.Op): Option[BaseType] =
+  {
+    l.map(Some(_)).fold(None)(escalate(_,_,op))
+  }
+  def escalate(l: TraversableOnce[BaseType], op: Arith.Op, msg: String, e: Expression): BaseType =
+  {
+    l.fold(TAny())(escalate(_,_,op,msg,e))
+  }
 }

--- a/src/main/scala/mimir/algebra/Typechecker.scala
+++ b/src/main/scala/mimir/algebra/Typechecker.scala
@@ -284,7 +284,7 @@ object Typechecker
 
   def assertNumeric(t: BaseType, e: Expression): BaseType =
   {
-    if(t.isNumeric){
+    if(!t.isNumeric){
       throw new TypeException(t, TFloat(), "Numeric", Some(e))
     }
     t;

--- a/src/main/scala/mimir/algebra/function/AggregateRegistry.scala
+++ b/src/main/scala/mimir/algebra/function/AggregateRegistry.scala
@@ -5,10 +5,10 @@ import mimir.algebra._
 
 case class RegisteredAggregate(
   aggName: String,
-  typechecker: (Seq[Type] => Type),
+  typechecker: (Seq[BaseType] => BaseType),
   defaultValue: PrimitiveValue
 ){
-  def typecheck(args: Seq[Type]) = typechecker(args)
+  def typecheck(args: Seq[BaseType]) = typechecker(args)
 }
 
 class AggregateRegistry
@@ -28,14 +28,14 @@ class AggregateRegistry
     register("GROUP_BITWISE_AND", List(TInt()), TInt(), IntPrimitive(Long.MaxValue))
     register("GROUP_BITWISE_OR", List(TInt()), TInt(), IntPrimitive(0))
     register("JSON_GROUP_ARRAY", (t) => TString(), StringPrimitive("[]"))
-    register("FIRST", (t:Seq[Type]) => t.head, NullPrimitive())
-    register("FIRST_FLOAT", (t:Seq[Type]) => t.head, NullPrimitive())
-    register("FIRST_INT", (t:Seq[Type]) => t.head, NullPrimitive())
+    register("FIRST", (t:Seq[BaseType]) => t.head, NullPrimitive())
+    register("FIRST_FLOAT", (t:Seq[BaseType]) => t.head, NullPrimitive())
+    register("FIRST_INT", (t:Seq[BaseType]) => t.head, NullPrimitive())
   }
 
   def register(
     aggName: String, 
-    typechecker: Seq[Type] => Type, 
+    typechecker: Seq[BaseType] => BaseType, 
     defaultValue: PrimitiveValue
   ): Unit = {
     prototypes.put(aggName, RegisteredAggregate(aggName, typechecker, defaultValue))
@@ -58,8 +58,8 @@ class AggregateRegistry
 
   def register(
     aggName: String,
-    argTypes: Seq[Type],
-    retType: Type, 
+    argTypes: Seq[BaseType],
+    retType: BaseType, 
     defaultValue: PrimitiveValue
   ): Unit = {
     register(
@@ -79,7 +79,7 @@ class AggregateRegistry
     )
   }
 
-  def typecheck(aggName: String, args: Seq[Type]): Type = 
+  def typecheck(aggName: String, args: Seq[BaseType]): BaseType = 
     prototypes(aggName).typecheck(args)
 
   def isAggregate(aggName: String): Boolean =

--- a/src/main/scala/mimir/algebra/function/FunctionRegistry.scala
+++ b/src/main/scala/mimir/algebra/function/FunctionRegistry.scala
@@ -12,7 +12,7 @@ sealed abstract class RegisteredFunction { val name: String }
 case class NativeFunction(
 	name: String, 
 	evaluator: Seq[PrimitiveValue] => PrimitiveValue, 
-	typechecker: Seq[Type] => Type,
+	typechecker: Seq[BaseType] => BaseType,
 	passthrough:Boolean = false
 ) extends RegisteredFunction
 
@@ -49,14 +49,14 @@ class FunctionRegistry {
   def register(
     fname:String,
     eval:Seq[PrimitiveValue] => PrimitiveValue, 
-    typechecker: Seq[Type] => Type
+    typechecker: Seq[BaseType] => BaseType
   ): Unit =
     register(new NativeFunction(fname, eval, typechecker))
     
   def registerPassthrough(
     fname:String,
     eval:Seq[PrimitiveValue] => PrimitiveValue, 
-    typechecker: Seq[Type] => Type
+    typechecker: Seq[BaseType] => BaseType
   ): Unit =
     register(new NativeFunction(fname, eval, typechecker, true))
 

--- a/src/main/scala/mimir/algebra/function/GeoFunctions.scala
+++ b/src/main/scala/mimir/algebra/function/GeoFunctions.scala
@@ -26,7 +26,7 @@ object GeoFunctions
           args(3).asDouble  //lat2
         ))
       },
-      (args) => {
+      (args:Seq[BaseType]) => {
         (0 until 4).foreach { i => Typechecker.assertNumeric(args(i), Function("DST", List())) }; 
         TFloat()
       }

--- a/src/main/scala/mimir/algebra/function/JsonFunctions.scala
+++ b/src/main/scala/mimir/algebra/function/JsonFunctions.scala
@@ -14,7 +14,7 @@ object JsonFunctions
     }
   }
 
-  def extract(args: Seq[PrimitiveValue], t: Type): PrimitiveValue =
+  def extract(args: Seq[PrimitiveValue], t: BaseType): PrimitiveValue =
   {
     Json.toPrimitive(t, extract(args))
   }

--- a/src/main/scala/mimir/algebra/function/NumericFunctions.scala
+++ b/src/main/scala/mimir/algebra/function/NumericFunctions.scala
@@ -14,14 +14,14 @@ object NumericFunctions
         case Seq(NullPrimitive())   => NullPrimitive()
         case x => throw new RAException("Non-numeric parameter to absolute: '"+x+"'")
       },
-      (x: Seq[Type]) => Typechecker.assertNumeric(x(0), Function("ABSOLUTE", List()))
+      (x: Seq[BaseType]) => Typechecker.assertNumeric(x(0), Function("ABSOLUTE", List()))
     )
 
     fr.register("SQRT",
       {
         case Seq(n:NumericPrimitive) => FloatPrimitive(Math.sqrt(n.asDouble))
       },
-      (x: Seq[Type]) => Typechecker.assertNumeric(x(0), Function("SQRT", List()))
+      (x: Seq[BaseType]) => Typechecker.assertNumeric(x(0), Function("SQRT", List()))
     )
 
     fr.register("BITWISE_AND", 
@@ -38,17 +38,17 @@ object NumericFunctions
     fr.register("STDDEV",(_) => ???, (_) => TFloat())
     fr.register("min",
         {
-          case ints:Seq[IntPrimitive] => IntPrimitive(ints.foldLeft(ints.head.v)( (init, intval) => Math.min(init, intval.v)))
+          (ints:Seq[PrimitiveValue]) => IntPrimitive(ints.foldLeft(ints.head.asInt)( (init, intval) => Math.min(init, intval.asInt)))
         }, (_) => TInt())
     fr.register("max",{
-          case ints:Seq[IntPrimitive] => IntPrimitive(ints.foldLeft(ints.head.v)( (init, intval) => Math.max(init, intval.v)))
+          (ints:Seq[PrimitiveValue]) => IntPrimitive(ints.foldLeft(ints.head.asInt)( (init, intval) => Math.max(init, intval.asInt)))
         }, (_) => TInt())
     fr.register("MIN",
         {
-          case ints:Seq[IntPrimitive] => IntPrimitive(ints.foldLeft(ints.head.v)( (init, intval) => Math.min(init, intval.v)))
+          (ints:Seq[PrimitiveValue]) => IntPrimitive(ints.foldLeft(ints.head.asInt)( (init, intval) => Math.min(init, intval.asInt)))
         }, (_) => TInt())
     fr.register("MAX",{
-          case ints:Seq[IntPrimitive] => IntPrimitive(ints.foldLeft(ints.head.v)( (init, intval) => Math.max(init, intval.v)))
+          (ints:Seq[PrimitiveValue]) => IntPrimitive(ints.foldLeft(ints.head.asInt)( (init, intval) => Math.max(init, intval.asInt)))
         }, (_) => TInt())
     
     fr.register("ROUND",
@@ -60,7 +60,7 @@ object NumericFunctions
           FloatPrimitive(Math.round(number).toDouble)
         }
       },
-      (x: Seq[Type]) => TFloat()
+      (x: Seq[BaseType]) => TFloat()
     )
 
     fr.register("ABS", 

--- a/src/main/scala/mimir/algebra/function/SampleFunctions.scala
+++ b/src/main/scala/mimir/algebra/function/SampleFunctions.scala
@@ -21,7 +21,7 @@ object SampleFunctions
           case None => NullPrimitive()
         }
       },
-      (types: Seq[Type]) => {
+      (types: Seq[BaseType]) => {
         val debugExpr = Function("BEST_SAMPLE", types.map(TypePrimitive(_)))
 
         Typechecker.assertNumeric(types.head, debugExpr)
@@ -42,7 +42,7 @@ object SampleFunctions
         FloatPrimitive(
           WorldBits.confidence(args(0).asLong, args(0).asLong.toInt)
         ),
-      (types: Seq[Type]) => {
+      (types: Seq[BaseType]) => {
         Typechecker.assertNumeric(types(0), 
           Function("SAMPLE_CONFIDENCE", types.map(TypePrimitive(_))))
         Typechecker.assertNumeric(types(1),

--- a/src/main/scala/mimir/algebra/function/TypeFunctions.scala
+++ b/src/main/scala/mimir/algebra/function/TypeFunctions.scala
@@ -24,7 +24,8 @@ object TypeFunctions
         functionName,
         (params: Seq[PrimitiveValue]) => {
           params match {
-            case Seq(x, TypePrimitive(t)) => Cast(t, x)
+            case Seq(x, TypePrimitive(t:BaseType)) => Cast(t, x)
+            case Seq(x, TypePrimitive(t:TUser)) => throw new RAException("Casting to User-defined types unsupported")
             case _ => throw new RAException("Invalid cast: "+params)
           }
         },

--- a/src/main/scala/mimir/algebra/spark/function/SparkFunctions.scala
+++ b/src/main/scala/mimir/algebra/spark/function/SparkFunctions.scala
@@ -2,16 +2,16 @@ package mimir.algebra.spark.function
 
 import mimir.algebra.function.FunctionRegistry
 import mimir.algebra.PrimitiveValue
-import mimir.algebra.Type
+import mimir.algebra.BaseType
 import com.typesafe.scalalogging.slf4j.LazyLogging
 
 
 object SparkFunctions 
  extends LazyLogging {
   
-  val sparkFunctions = scala.collection.mutable.Map[String, (Seq[PrimitiveValue] => PrimitiveValue, Seq[Type] => Type)]()
+  val sparkFunctions = scala.collection.mutable.Map[String, (Seq[PrimitiveValue] => PrimitiveValue, Seq[BaseType] => BaseType)]()
   
-  def addSparkFunction(fname:String,eval:Seq[PrimitiveValue] => PrimitiveValue, typechecker: Seq[Type] => Type) : Unit = {
+  def addSparkFunction(fname:String,eval:Seq[PrimitiveValue] => PrimitiveValue, typechecker: Seq[BaseType] => BaseType) : Unit = {
     sparkFunctions.put(fname, (eval, typechecker))
   }
   

--- a/src/main/scala/mimir/algebra/typeregistry/DefaultTypeRegistry.scala
+++ b/src/main/scala/mimir/algebra/typeregistry/DefaultTypeRegistry.scala
@@ -45,7 +45,7 @@ object DefaultTypeRegistry extends TypeRegistry with Serializable
     // And then find user-defined types that match
     validBaseTypes
       .map { 
-        typesByBaseType(_) 
+        typesByBaseType.get(_).toSeq.flatten
           .filter { _.constraints.forall { _.test(value) } }
           .map { t => TUser(t.name) }
       }

--- a/src/main/scala/mimir/algebra/typeregistry/DefaultTypeRegistry.scala
+++ b/src/main/scala/mimir/algebra/typeregistry/DefaultTypeRegistry.scala
@@ -1,0 +1,93 @@
+package mimir.algebra.typeregistry
+
+import mimir.algebra._
+
+case class RegisteredType(name:String, constraints:Set[TypeConstraint], basedOn:Type = TString())
+
+object DefaultTypeRegistry extends TypeRegistry 
+{  
+  val types:Seq[RegisteredType] = Seq(
+    RegisteredType("credits",       Set(RegexpConstraint("^[0-9]{1,3}(\\.[0-9]{0,2})?$".r))),
+    RegisteredType("email",         Set(RegexpConstraint("^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$".r))),
+    RegisteredType("productid",     Set(RegexpConstraint("^P\\d+$".r))),
+    RegisteredType("firecompany",   Set(RegexpConstraint("^[a-zA-Z]\\d{3}$".r))),
+    RegisteredType("zipcode",       Set(RegexpConstraint("^\\d{5}(?:[-\\s]\\d{4})?$".r))),
+    RegisteredType("container",     Set(RegexpConstraint("^[A-Z]{4}[0-9]{7}$".r))),
+    RegisteredType("carriercode",   Set(RegexpConstraint("^[A-Z]{4}$".r))),
+    RegisteredType("mmsi",          Set(RegexpConstraint("^MID\\d{6}|0MID\\d{5}|00MID\\{4}$".r))),
+    RegisteredType("billoflanding", Set(RegexpConstraint("^[A-Z]{8}[0-9]{8}$".r))),
+    RegisteredType("imo_code",      Set(RegexpConstraint("^\\d{7}$".r)))
+  )
+  val typesByName = types.map { t => t.name -> t }.toMap
+  val typesByBaseType = types.groupBy { _.basedOn }
+  val indexesByName = types.zipWithIndex.map { t => t._1.name -> t._2}.toMap
+
+  def getDefinition(name:String): RegisteredType =
+  {
+    typesByName.get(name) match {
+      case Some(definition) => definition
+      case None => throw new RAException(s"Undefined user defined type: $name")
+    }
+  }
+  def contains(name:String): Boolean =
+    typesByName contains name
+
+  def baseType(t: Type): Type = 
+    t match { 
+      case TUser(name) => getDefinition(name).basedOn
+      case _ => t
+    }
+  def pickType(possibilities: Set[Type]): Type = 
+  {
+    if(possibilities.isEmpty){ throw new RAException("Can't pick from empty list of types") }
+    val userTypes = 
+      possibilities.map { case x:TUser => Some(x) case _ => None }.flatten
+
+    // User types beat everything else.  Use alpha order arbitrarily
+    if(!userTypes.isEmpty){ return userTypes.toSeq.sortBy(_.name).head }
+    // TInt beats TFloat
+    if(possibilities contains TInt()) { return TInt() }
+    // Otherwise pick arbitrarily
+    return possibilities.toSeq.sortBy(_.toString).head
+  }
+  def testForTypes(value: String): Set[Type] = 
+  {
+    // First find base types that match
+    val validBaseTypes = 
+      Type.tests
+          .filter { _._2.findFirstMatchIn(value) != None }
+          .map { _._1 }
+          .toSet
+
+    // And then find user-defined types that match
+    validBaseTypes.map { 
+            typesByBaseType(_) 
+              .filter { _.constraints.forall { _.test(value) } }
+              .map { t => TUser(t.name) }
+      } .flatten
+        .toSet ++ validBaseTypes
+  }
+  def typeCaster(t: Type, target:Expression): Expression = 
+  {
+    val castTarget = Function("CAST", Seq(target, TypePrimitive(rootType(t))))
+    t match {
+      case TUser(name) => {
+        Conditional(
+          ExpressionUtils.makeAnd(
+            getDefinition(name)
+              .constraints
+              .map { _.tester(castTarget) }
+          ),
+          castTarget,
+          NullPrimitive()
+        )
+      }
+      case _ => castTarget
+    }
+  }
+  def typeFromInt(i: Integer) = TUser(types(i).name)
+  def typeToInt(t: TUser): Integer = indexesByName(t.name)
+
+  def typeFromString(name: String) = TUser(getDefinition(name).name)
+  def typeToString(t: TUser): String = t.name
+}

--- a/src/main/scala/mimir/algebra/typeregistry/TypeConstraint.scala
+++ b/src/main/scala/mimir/algebra/typeregistry/TypeConstraint.scala
@@ -1,0 +1,49 @@
+package mimir.algebra.typeregistry
+
+import mimir.algebra._
+import scala.util.matching.Regex
+import mimir.util.TextUtils
+
+sealed abstract class TypeConstraint
+{
+  def test(v: String): Boolean
+  def tester(target:Expression): Expression
+}
+
+case class RegexpConstraint(matcher: Regex) extends TypeConstraint
+{
+  def test(v:String) = { (matcher findFirstMatchIn v) != None }
+  def tester(target:Expression) = Function("rlike", Seq(target, StringPrimitive(matcher.regex)))
+}
+
+case class EnumConstraint(values: Set[String], caseSensitive: Boolean = false) extends TypeConstraint
+{
+  lazy val caseSensitiveValues = 
+    if(caseSensitive) { values } 
+    else { values.map { _.toLowerCase } }
+
+  def test(v:String) = 
+    if(caseSensitive) { values contains v }
+    else { values contains v.toLowerCase }
+  def tester(target:Expression) = 
+    ExpressionUtils.makeOr(
+      caseSensitiveValues.map { v =>
+        Comparison(Cmp.Eq, target, StringPrimitive(v))
+      }
+    )
+  def base = TString()
+}
+
+case class IntExpressionConstraint(constraint: Expression, targetType: Type) extends TypeConstraint
+{
+  lazy val eval = new Eval()
+  
+  def test(v: String) = 
+    eval.evalBool(constraint, Map(
+      "x" -> TextUtils.parsePrimitive(targetType, v)
+    ))
+  def tester(target:Expression) =
+    Eval.inline(constraint, Map(
+      "x" -> target
+    ))
+}

--- a/src/main/scala/mimir/algebra/typeregistry/TypeConstraint.scala
+++ b/src/main/scala/mimir/algebra/typeregistry/TypeConstraint.scala
@@ -34,7 +34,7 @@ case class EnumConstraint(values: Set[String], caseSensitive: Boolean = false) e
   def base = TString()
 }
 
-case class IntExpressionConstraint(constraint: Expression, targetType: Type) extends TypeConstraint
+case class IntExpressionConstraint(constraint: Expression, targetType: BaseType) extends TypeConstraint
 {
   lazy val eval = new Eval()
   

--- a/src/main/scala/mimir/algebra/typeregistry/TypeRegistry.scala
+++ b/src/main/scala/mimir/algebra/typeregistry/TypeRegistry.scala
@@ -4,21 +4,69 @@ import mimir.algebra._
 
 abstract class TypeRegistry
 {
-  def typeFromString(name: String): TUser
-  def typeToString(t: TUser): String
-  def typeFromInt(i: Integer): Type
-  def typeToInt(t: TUser): Integer
-  def contains(name:String): Boolean
+  def userTypeForId(i: Integer): TUser
+  def idForUserType(t: TUser): Integer
+  def supportsUserType(name:String): Boolean
 
-  def testForTypes(record: String): Set[Type]
-  def pickType(possibilities: Set[Type]): Type
-  def typeCaster(t:Type, target: Expression): Expression
+  def testForUserTypes(record: String, validBaseTypes:Set[BaseType]): Set[TUser]
+  def pickUserType(possibilities: Set[TUser]): Type
+  def userTypeCaster(t:Type, target: Expression): Expression
 
-  def baseType(t:Type): Type
+  def parentOfUserType(t:TUser): Type
   def rootType(t:Type): BaseType =
     t match { 
-      case u:TUser => rootType(baseType(u)); 
-      case TAny() => throw new RAException("TAny doesn't have a root type")
+      case u:TUser => rootType(parentOfUserType(u)); 
       case b:BaseType => b
     }
+  def parentType(t:Type): Type =
+    t match { 
+      case u:TUser => parentOfUserType(u)
+      case _:BaseType => t
+    }
+
+  def testForTypes(value:String): Set[Type] =
+  {
+    val validBaseTypes = 
+      BaseType.tests
+              .filter { _._2.findFirstMatchIn(value) != None }
+              .map { _._1 }
+              .toSet
+    testForUserTypes(value, validBaseTypes) ++ validBaseTypes
+  }
+  def pickType(possibilities: Set[Type]): Type =
+  {
+    if(possibilities.isEmpty){ throw new RAException("Can't pick from empty list of types") }
+    val userTypes = 
+      possibilities.map { case x:TUser => Some(x) case _ => None }.flatten
+
+    // User types beat everything else.  Use alpha order arbitrarily
+    if(!userTypes.isEmpty){ return pickUserType(userTypes) }
+    // TInt beats TFloat
+    if(possibilities contains TInt()) { return TInt() }
+    // Otherwise pick arbitrarily
+    return possibilities.toSeq.sortBy(_.toString).head
+  }
+
+  def fromString(name:String) = 
+  {
+    BaseType.fromString(name)
+            .getOrElse { 
+              if(supportsUserType(name)){ TUser(name) }
+              else { throw new RAException("Unsupported Type: "+name) }
+            }
+  }
+
+  val idForBaseType = BaseType.idTypeOrder.zipWithIndex.toMap
+
+  def typeForId(i:Integer) = 
+    if(i < BaseType.idTypeOrder.size){ BaseType.idTypeOrder(i) }
+    else { userTypeForId(i - BaseType.idTypeOrder.size) }
+  def idForType(t:Type):Integer =
+    t match { 
+      case u:TUser => idForUserType(u)
+      case b:BaseType => idForBaseType(b)
+    }
+
+  def getSerializable:(TypeRegistry with Serializable)
+
 }

--- a/src/main/scala/mimir/algebra/typeregistry/TypeRegistry.scala
+++ b/src/main/scala/mimir/algebra/typeregistry/TypeRegistry.scala
@@ -1,0 +1,24 @@
+package mimir.algebra.typeregistry
+
+import mimir.algebra._
+
+abstract class TypeRegistry
+{
+  def typeFromString(name: String): TUser
+  def typeToString(t: TUser): String
+  def typeFromInt(i: Integer): Type
+  def typeToInt(t: TUser): Integer
+  def contains(name:String): Boolean
+
+  def testForTypes(record: String): Set[Type]
+  def pickType(possibilities: Set[Type]): Type
+  def typeCaster(t:Type, target: Expression): Expression
+
+  def baseType(t:Type): Type
+  def rootType(t:Type): BaseType =
+    t match { 
+      case u:TUser => rootType(baseType(u)); 
+      case TAny() => throw new RAException("TAny doesn't have a root type")
+      case b:BaseType => b
+    }
+}

--- a/src/main/scala/mimir/ctables/CTExplainer.scala
+++ b/src/main/scala/mimir/ctables/CTExplainer.scala
@@ -339,7 +339,7 @@ class CTExplainer(db: Database) extends LazyLogging {
 
 		val optQuery = db.compiler.optimize(inlinedQuery)
 
-		val finalSchema = db.typechecker.schemaOf(optQuery)
+		val finalSchema = db.typechecker.baseSchemaOf(optQuery)
 
 		//val sqlQuery = db.ra.convert(optQuery)
 
@@ -348,7 +348,10 @@ class CTExplainer(db: Database) extends LazyLogging {
 		val results = db.backend.execute(optQuery)//sqlQuery)
 
 		val baseData = 
-			SparkUtils.extractAllRows(results, finalSchema.map(_._2)).flush
+			SparkUtils.extractAllRows(
+				results, 
+				finalSchema.map { _._2 }
+			).flush
 
 		if(baseData.isEmpty){
 			val resultRowString = baseData.map( _.mkString(", ") ).mkString("\n")

--- a/src/main/scala/mimir/ctables/CTPercolator.scala
+++ b/src/main/scala/mimir/ctables/CTPercolator.scala
@@ -3,6 +3,7 @@ package mimir.ctables
 import java.sql.SQLException
 import com.typesafe.scalalogging.slf4j.LazyLogging
 
+import mimir.Database
 import mimir.algebra._
 import mimir.util._
 import mimir.optimizer._
@@ -597,8 +598,8 @@ object CTPercolator
     }
   }
   
-  def percolateGProM(oper: Operator): (Operator, Map[String,Expression], Expression) =
+  def percolateGProM(oper: Operator, db: Database): (Operator, Map[String,Expression], Expression) =
   {
-    mimir.algebra.gprom.OperatorTranslation.compileTaintWithGProM(oper)
+    db.gpromTranslator.compileTaintWithGProM(oper)
   }
 }

--- a/src/main/scala/mimir/ctables/CTPercolatorClassic.scala
+++ b/src/main/scala/mimir/ctables/CTPercolatorClassic.scala
@@ -264,6 +264,7 @@ object CTPercolatorClassic {
       case ProvenanceOf(psel) => {
         percolateOne(psel)
       }
+      case _ => ??? // This code is deprecated.  It's only getting called for research use.
     }
   }
   
@@ -284,7 +285,7 @@ object CTPercolatorClassic {
       case Union(_,_) => false
       case Join(_,_) => false
       case Aggregate(_,_,_) => false
-      case (Annotate(_, _) | ProvenanceOf(_) | Recover(_, _)) => ???
+      case _ => ??? // This code is deprecated.  It's only getting called for research use.
     }
   }
   
@@ -382,7 +383,7 @@ object CTPercolatorClassic {
             Table(name, alias, sch, metadata)
           }
           
-        case (Annotate(_, _) | ProvenanceOf(_) | Recover(_, _)) => ???
+        case _ => ??? // This code is deprecated.  It's only getting called for research use.
     }
   }
 

--- a/src/main/scala/mimir/ctables/vgterm/BestGuess.scala
+++ b/src/main/scala/mimir/ctables/vgterm/BestGuess.scala
@@ -11,7 +11,7 @@ case class BestGuess(
   vgHints: Seq[Expression]
 ) extends Proc(vgArgs++vgHints) {
   override def toString() = "{{ BEST GUESS: "+model.name+";"+idx+"["+vgArgs.mkString(", ")+"]["+vgHints.mkString(", ")+"] }}"
-  override def getType(bindings: Seq[Type]):Type = model.varType(idx, bindings)
+  override def getType(bindings: Seq[BaseType]):BaseType = model.varType(idx, bindings)
   override def children: Seq[Expression] = vgArgs ++ vgHints
   override def rebuild(x: Seq[Expression]) = {
     val (a, h) = x.splitAt(vgArgs.length)

--- a/src/main/scala/mimir/ctables/vgterm/DomainDumper.scala
+++ b/src/main/scala/mimir/ctables/vgterm/DomainDumper.scala
@@ -13,7 +13,7 @@ case class DomainDumper(
   vgHints: Seq[Expression]
 ) extends Proc(vgArgs++vgHints) {
   override def toString() = "{{ DOMAIN DUMP: "+model.name+";"+idx+"["+vgArgs.mkString(", ")+"]["+vgHints.mkString(", ")+"] }}"
-  override def getType(bindings: Seq[Type]):Type = TString()
+  override def getType(bindings: Seq[BaseType]):BaseType = TString()
   override def children: Seq[Expression] = vgArgs ++ vgHints
   override def rebuild(x: Seq[Expression]) = {
     val (a, h) = x.splitAt(vgArgs.length)

--- a/src/main/scala/mimir/ctables/vgterm/IsAcknowledged.scala
+++ b/src/main/scala/mimir/ctables/vgterm/IsAcknowledged.scala
@@ -12,7 +12,7 @@ case class IsAcknowledged(
 ) 
   extends Proc( vgArgs )
 {
-  def getType(argTypes: Seq[Type]): Type = TBool()
+  def getType(argTypes: Seq[BaseType]): BaseType = TBool()
   def get(v: Seq[PrimitiveValue]): PrimitiveValue = 
   {
     BoolPrimitive(model.isAcknowledged(idx, v))

--- a/src/main/scala/mimir/ctables/vgterm/Sampler.scala
+++ b/src/main/scala/mimir/ctables/vgterm/Sampler.scala
@@ -14,7 +14,7 @@ case class Sampler(
 ) 
   extends Proc(  (seed :: (vgArgs.toList ++ vgHints.toList))  )
 {
-  def getType(argTypes: Seq[Type]): Type =
+  def getType(argTypes: Seq[BaseType]): BaseType =
     model.varType(idx, argTypes)
   def get(v: Seq[PrimitiveValue]): PrimitiveValue = 
   {

--- a/src/main/scala/mimir/exec/mode/BestGuess.scala
+++ b/src/main/scala/mimir/exec/mode/BestGuess.scala
@@ -50,7 +50,7 @@ object BestGuess
       if(false && ExperimentalOptions.isEnabled("GPROM-DETERMINISM")
         && ExperimentalOptions.isEnabled("GPROM-PROVENANCE")
         && ExperimentalOptions.isEnabled("GPROM-BACKEND")){
-      OperatorTranslation.compileProvenanceAndTaintWithGProM(oper)
+      db.gpromTranslator.compileProvenanceAndTaintWithGProM(oper)
     }
     else {
       // The names that the provenance compilation step assigns will
@@ -60,7 +60,7 @@ object BestGuess
       val provenance = 
       if(ExperimentalOptions.isEnabled("GPROM-PROVENANCE")
           && ExperimentalOptions.isEnabled("GPROM-BACKEND"))
-        { Provenance.compileGProM(oper) }
+        { db.gpromTranslator.compileProvenanceWithGProM(oper) }
         else { Provenance.compile(oper) }
   
       oper               = provenance._1
@@ -72,7 +72,7 @@ object BestGuess
       // Tag rows/columns with provenance metadata
       val tagging = if(ExperimentalOptions.isEnabled("GPROM-DETERMINISM")
           && ExperimentalOptions.isEnabled("GPROM-BACKEND"))
-        { CTPercolator.percolateGProM(oper) }
+        { CTPercolator.percolateGProM(oper, db) }
         else { CTPercolator.percolateLite(oper, db.models.get(_)) } 
       (tagging._1,
       provenanceCols,

--- a/src/main/scala/mimir/exec/mode/DumpDomain.scala
+++ b/src/main/scala/mimir/exec/mode/DumpDomain.scala
@@ -55,7 +55,7 @@ object DumpDomain
     val provenance = 
     if(ExperimentalOptions.isEnabled("GPROM-PROVENANCE")
         && db.backend.isInstanceOf[mimir.sql.GProMBackend])
-      { Provenance.compileGProM(oper) }
+      { db.gpromTranslator.compileProvenanceWithGProM(oper) }
       else { Provenance.compile(oper) }
 
     oper               = provenance._1
@@ -67,7 +67,7 @@ object DumpDomain
     // Tag rows/columns with provenance metadata
     val tagging = if(ExperimentalOptions.isEnabled("GPROM-DETERMINISM")
         && db.backend.isInstanceOf[mimir.sql.GProMBackend])
-      { CTPercolator.percolateGProM(oper) }
+      { CTPercolator.percolateGProM(oper, db) }
       else { CTPercolator.percolateLite(oper, db.models.get(_)) } 
     oper               = tagging._1
     val colDeterminism = tagging._2.filter( col => rawColumns(col._1) )

--- a/src/main/scala/mimir/exec/result/JDBCResultIterator.scala
+++ b/src/main/scala/mimir/exec/result/JDBCResultIterator.scala
@@ -3,6 +3,7 @@ package mimir.exec.result
 import java.sql._
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import mimir.algebra._
+import mimir.algebra.typeregistry.TypeRegistry
 import mimir.util._
 import mimir.exec._
 import mimir.sql.MetadataBackend
@@ -12,6 +13,7 @@ class JDBCResultIterator(
   inputSchema: Seq[(String,Type)],
   query: SelectBody,
   backend: MetadataBackend,
+  types: TypeRegistry,
   dateType: (Type)
 )
   extends ResultIterator
@@ -26,7 +28,7 @@ class JDBCResultIterator(
       zipWithIndex.
       map { case ((name, t), idx) => 
         logger.debug(s"Extracting Raw: $name (@$idx) -> $t")
-        val fn = JDBCUtils.convertFunction(t, idx+1, dateType = dateType)
+        val fn = JDBCUtils.convertFunction(types.rootType(t), idx+1, dateType = dateType)
         () => { fn(source) }
       }
 

--- a/src/main/scala/mimir/exec/result/SparkResultIterator.scala
+++ b/src/main/scala/mimir/exec/result/SparkResultIterator.scala
@@ -3,6 +3,7 @@ package mimir.exec.result
 import org.apache.spark.sql.DataFrame
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import mimir.algebra._
+import mimir.algebra.typeregistry.TypeRegistry
 import mimir.sql.RABackend
 import mimir.util.SparkUtils
 import mimir.util.Timer
@@ -11,6 +12,7 @@ class SparkResultIterator(
   inputSchema: Seq[(String,Type)],
   query: Operator,
   backend: RABackend,
+  types: TypeRegistry,
   dateType: (Type)
 ) 
   extends ResultIterator
@@ -24,7 +26,7 @@ class SparkResultIterator(
       zipWithIndex.
       map { case ((name, t), idx) => 
         logger.debug(s"Extracting Raw: $name (@$idx) -> $t")
-        val fn = SparkUtils.convertFunction(t, idx, dateType = dateType)
+        val fn = SparkUtils.convertFunction(types.rootType(t), idx, dateType = dateType)
         () => { fn(row) }
       }
 

--- a/src/main/scala/mimir/lenses/CommentLens.scala
+++ b/src/main/scala/mimir/lenses/CommentLens.scala
@@ -45,7 +45,7 @@ object CommentLens {
             "COMMENT_ARG_"+index
         (
           ProjectArg(outputCol, VGTerm(modelName, index, Seq(RowIdVar()), Seq(expr))),
-          (outputCol, db.typechecker.typeOf(expr, query)),
+          (outputCol, db.types.rootType(db.typechecker.typeOf(expr, query))),
           comment
         )
       }

--- a/src/main/scala/mimir/lenses/MissingKeyLens.scala
+++ b/src/main/scala/mimir/lenses/MissingKeyLens.scala
@@ -19,11 +19,11 @@ object MissingKeyLens {
     args:Seq[Expression]
   ): (Operator, Seq[Model]) =
   {
-    val schema = db.typechecker.schemaOf(query)
+    val schema = db.typechecker.baseSchemaOf(query)
     val schemaMap = schema.toMap
     var missingOnly = false;
     var sortCols = Seq[(String, Boolean)]()
-    val keys: Seq[(String, Type)] = args.flatMap {
+    val keys: Seq[(String, BaseType)] = args.flatMap {
       case Var(col) => {
         if(schemaMap contains col){ Some((col, schemaMap(col))) }
         else {

--- a/src/main/scala/mimir/lenses/PickerLens.scala
+++ b/src/main/scala/mimir/lenses/PickerLens.scala
@@ -31,7 +31,7 @@ object PickerLens {
     
     val (pickFromColumns, pickerColTypes ) = args.flatMap {
       case Function("PICK_FROM", cols ) => 
-        Some( cols.map { case col:Var => (col.name, schemaMap(col.name)) 
+        Some( cols.map { case col:Var => (col.name, db.types.rootType(schemaMap(col.name)))
                          case col => throw new RAException(s"Invalid pick_from argument: $col in PickerLens $name (not a column reference)")
                        } )
       case _ => None

--- a/src/main/scala/mimir/lenses/RepairKeyLens.scala
+++ b/src/main/scala/mimir/lenses/RepairKeyLens.scala
@@ -56,8 +56,8 @@ object RepairKeyLens extends LazyLogging {
             s"$name:$col", 
             name, 
             query, 
-            keys.map { k => (k, schemaMap(k)) }, 
-            col, t,
+            keys.map { k => (k, db.types.rootType(schemaMap(k))) }, 
+            col, db.types.rootType(t),
             scoreCol
           )
         model.trainDomain(db)//.reconnectToDatabase(db)

--- a/src/main/scala/mimir/ml/spark/Classification.scala
+++ b/src/main/scala/mimir/ml/spark/Classification.scala
@@ -48,8 +48,8 @@ object Classification extends SparkML {
     applyModelDB(model, query, db)
   }
   
-  def classify( model : PipelineModel, cols:Seq[(String, Type)], testData : List[Seq[PrimitiveValue]]): DataFrame = {
-    applyModel(model, cols, testData)
+  def classify( model : PipelineModel, cols:Seq[(String, BaseType)], testData : List[Seq[PrimitiveValue]], sparkTranslator: OperatorTranslation): DataFrame = {
+    applyModel(model, cols, testData, sparkTranslator)
   }
     
   override def extractPredictions(model : PipelineModel, predictions:DataFrame, maxPredictions:Int = 5) : Seq[(String, (String, Double))] = {

--- a/src/main/scala/mimir/ml/spark/Regression.scala
+++ b/src/main/scala/mimir/ml/spark/Regression.scala
@@ -26,8 +26,8 @@ object Regression extends SparkML {
     applyModelDB(model, query, db)
   }
   
-  def regress( model : PipelineModel, cols:Seq[(String, Type)], testData : List[Seq[PrimitiveValue]]): DataFrame = {
-    applyModel(model, cols, testData)
+  def regress( model : PipelineModel, cols:Seq[(String, BaseType)], testData : List[Seq[PrimitiveValue]], sparkTranslator: OperatorTranslation): DataFrame = {
+    applyModel(model, cols, testData, sparkTranslator)
   }
   
   override def extractPredictions(model : PipelineModel, predictions:DataFrame, maxPredictions:Int = 5) : Seq[(String, (String, Double))] = {

--- a/src/main/scala/mimir/ml/spark/SparkML.scala
+++ b/src/main/scala/mimir/ml/spark/SparkML.scala
@@ -32,10 +32,10 @@ object SparkML {
     sc = Some(spark.sparkSession.sparkContext)
     sqlCtx = Some(spark)
   }
-  def getDataFrameWithProvFromQuery(db:Database, query:Operator) : (Seq[(String, Type)], DataFrame) = {
+  def getDataFrameWithProvFromQuery(db:Database, query:Operator) : (Seq[(String, BaseType)], DataFrame) = {
     val prov = if(ExperimentalOptions.isEnabled("GPROM-PROVENANCE")
         && ExperimentalOptions.isEnabled("GPROM-BACKEND"))
-      { Provenance.compileGProM(query) }
+      { db.gpromTranslator.compileProvenanceWithGProM(query) }
       else { Provenance.compile(query) }
     val oper           = prov._1
     val provenanceCols = prov._2
@@ -46,7 +46,7 @@ object SparkML {
     val dfOut = dfPreOut.schema.fields.filter(col => Seq(DateType, TimestampType).contains(col.dataType)).foldLeft(dfPreOut)((init, cur) => init.withColumn(cur.name,init(cur.name).cast(LongType)) )
     (db.typechecker.schemaOf(operWProv).map(el => el._2 match {
       case TDate() | TTimestamp() => (el._1, TInt())
-      case _ => el
+      case _ => (el._1, db.types.rootType(el._2))
     }), dfOut)
   }
 }
@@ -106,16 +106,22 @@ abstract class SparkML {
     val data = db.query(query)(results => {
       results.toList.map(row => row.provenance +: row.tupleSchema.zip(row.tuple).filterNot(_._1._1.equalsIgnoreCase("rowid")).unzip._2)
     })
-    applyModel(model, ("rowid", TString()) +:db.typechecker.schemaOf(query).filterNot(_._1.equalsIgnoreCase("rowid")), data, dfTransformer)
+    applyModel(
+      model, 
+      ("rowid", TString()) +:db.typechecker.baseSchemaOf(query).filterNot(_._1.equalsIgnoreCase("rowid")), 
+      data,
+      db.sparkTranslator, 
+      dfTransformer
+    )
   }
   
-  def applyModel( model : PipelineModel, cols:Seq[(String, Type)], testData : List[Seq[PrimitiveValue]], dfTransformer:Option[DataFrameTransformer] = None): DataFrame = {
+  def applyModel( model : PipelineModel, cols:Seq[(String, BaseType)], testData : List[Seq[PrimitiveValue]], sparkTranslator: OperatorTranslation, dfTransformer:Option[DataFrameTransformer] = None): DataFrame = {
     val sqlContext = getSparkSqlContext()
     import sqlContext.implicits._
     val modDF = dfTransformer.getOrElse((df:DataFrame) => df)
     model.transform(modDF(sqlContext.createDataFrame(
       getSparkSession().parallelize(testData.map( row => {
-        Row(row.zip(cols).map(value => OperatorTranslation.mimirExprToSparkExpr(null, value._1)):_*)
+        Row(row.zip(cols).map(value => sparkTranslator.mimirExprToSparkExpr(null, value._1)):_*)
       })), StructType(cols.toList.map(col => StructField(col._1, OperatorTranslation.getSparkType(col._2), true))))))
   }
   
@@ -127,7 +133,7 @@ abstract class SparkML {
   
   def extractPredictionsForRow(model : PipelineModel, predictions:DataFrame, rowid:String, maxPredictions:Int = 5) : Seq[(String, Double)]
    
-  def getNative(value:PrimitiveValue, t:Type): Any = {
+  def getNative(value:PrimitiveValue, t:BaseType): Any = {
     value match {
       case NullPrimitive() => t match {
         case TInt() => 0L
@@ -136,12 +142,10 @@ abstract class SparkML {
         case TString() => ""
         case TBool() => new java.lang.Boolean(false)
         case TRowId() => ""
-        case TType() => ""
+        case TType() => "any"
         case TAny() => ""
         case TTimestamp() => OperatorTranslation.defaultTimestamp
-        case TInterval() => ""
-        case TUser(name) => getNative(value, mimir.algebra.TypeRegistry.registeredTypes(name)._2)
-        case x => ""
+        case TInterval() => OperatorTranslation.defaultInterval
       }
       case RowIdPrimitive(s) => s
       case StringPrimitive(s) => s
@@ -150,7 +154,8 @@ abstract class SparkML {
       case BoolPrimitive(b) => new java.lang.Boolean(b)
       case ts@TimestampPrimitive(y,m,d,h,mm,s,ms) => SparkUtils.convertTimestamp(ts)
       case dt@DatePrimitive(y,m,d) => SparkUtils.convertDate(dt)
-      case x =>  x.asString
+      case IntervalPrimitive(period) => period
+      case TypePrimitive(t) => t
     }
   }
 }

--- a/src/main/scala/mimir/models/BasicModels.scala
+++ b/src/main/scala/mimir/models/BasicModels.scala
@@ -7,7 +7,7 @@ import scala.util._
 object UniformDistribution extends Model("UNIFORM") with Serializable {
   def argTypes(idx: Int) = List(TFloat(), TFloat())
   def hintTypes(idx: Int) = Seq()
-  def varType(idx: Int, argTypes: Seq[Type]) = TFloat()
+  def varType(idx: Int, argTypes: Seq[BaseType]) = TFloat()
   def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]) = 
     FloatPrimitive((args(0).asDouble + args(1).asDouble) / 2.0)
   def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]) = {
@@ -53,7 +53,7 @@ case class NoOpModel(override val name: String, reasonText:String)
 
   def argTypes(idx: Int) = List(TAny())
   def hintTypes(idx: Int) = Seq()
-  def varType(idx: Int, args: Seq[Type]) = args(0)
+  def varType(idx: Int, args: Seq[BaseType]) = args(0)
   def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]) = args(0)
   def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]) = args(0)
   def reason(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): String = reasonText

--- a/src/main/scala/mimir/models/CommentModel.scala
+++ b/src/main/scala/mimir/models/CommentModel.scala
@@ -14,7 +14,7 @@ import java.sql.SQLException
  * The return value is an integer identifying the ordinal position of the selected value, starting with 0.
  */
 @SerialVersionUID(1001L)
-class CommentModel(override val name: String, cols:Seq[String], colTypes:Seq[Type], comments:Seq[String]) 
+class CommentModel(override val name: String, cols:Seq[String], colTypes:Seq[BaseType], comments:Seq[String]) 
   extends Model(name) 
   with Serializable
   with SourcedFeedback
@@ -23,7 +23,7 @@ class CommentModel(override val name: String, cols:Seq[String], colTypes:Seq[Typ
   def getFeedbackKey(idx: Int, args: Seq[PrimitiveValue] ) : String = s"${args(0).asString}:$idx"
   
   def argTypes(idx: Int) = Seq(TRowId())
-  def varType(idx: Int, args: Seq[Type]) = colTypes(idx)
+  def varType(idx: Int, args: Seq[BaseType]) = colTypes(idx)
   def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]  ) = {
     getFeedback(idx, args) match {
       case Some(v) => v
@@ -48,7 +48,7 @@ class CommentModel(override val name: String, cols:Seq[String], colTypes:Seq[Typ
     setFeedback(idx, args, v)
   }
   def isAcknowledged (idx: Int, args: Seq[PrimitiveValue]): Boolean = hasFeedback(idx, args)
-  def hintTypes(idx: Int): Seq[mimir.algebra.Type] = colTypes
+  def hintTypes(idx: Int): Seq[BaseType] = colTypes
   //def getDomain(idx: Int, args: Seq[PrimitiveValue], hints:Seq[PrimitiveValue]): Seq[(PrimitiveValue,Double)] = Seq((hints(0), 0.0))
 
   def confidence (idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): Double = {

--- a/src/main/scala/mimir/models/DefaultMetaModel.scala
+++ b/src/main/scala/mimir/models/DefaultMetaModel.scala
@@ -18,7 +18,7 @@ class DefaultMetaModel(name: String, context: String, models: Seq[String])
   with NoArgModel
   with FiniteDiscreteDomain
 {
-  def varType(idx: Int, args: Seq[Type]): Type = TString()
+  def varType(idx: Int, args: Seq[BaseType]): BaseType = TString()
   def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): PrimitiveValue =
     choices(idx).getOrElse( StringPrimitive(models.head))
   def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): PrimitiveValue =

--- a/src/main/scala/mimir/models/DetectHeaderModel.scala
+++ b/src/main/scala/mimir/models/DetectHeaderModel.scala
@@ -52,6 +52,9 @@ with SourcedFeedback
     }
     else
     {
+      // TODO: COMMENT THIS CODE
+      //   From Oliver 12/16/2018: 
+      //      This code is really hard to follow.  It needs some serious commenting love.
       val top6 = trainingData
       val (header, topRecords) = (top6.head.map(col => sanitizeColumnName(col match {
           case NullPrimitive() => "NULL" 
@@ -62,10 +65,10 @@ with SourcedFeedback
            (pv._1 match {
              case NullPrimitive() => TAny()
              case x => {
-               Type.rootTypes.foldLeft(TAny():Type)((tinit, ttype) => {
-                 Cast.apply(ttype,x) match {
+               BaseType.tests.foldLeft(TAny():Type)((tinit, ttype) => {
+                 Cast(ttype._1,x) match {
                    case NullPrimitive() => tinit
-                   case x => ttype
+                   case x => ttype._1
                  }
                })
              }
@@ -118,7 +121,7 @@ with SourcedFeedback
   def argTypes(idx: Int) = {
     Seq(TInt())
   }
-  def varType(idx: Int, args: Seq[Type]) = {
+  def varType(idx: Int, args: Seq[BaseType]) = {
     TString()
   }
   def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]  ) = {
@@ -143,7 +146,7 @@ with SourcedFeedback
   def isAcknowledged (idx: Int, args: Seq[PrimitiveValue]): Boolean = {
     hasFeedback(idx, args)
   }
-  def hintTypes(idx: Int): Seq[mimir.algebra.Type] = {
+  def hintTypes(idx: Int): Seq[BaseType] = {
     Seq()
   }
   def getFeedbackKey(idx: Int, args: Seq[PrimitiveValue]) = {

--- a/src/main/scala/mimir/models/GeocodingModel.scala
+++ b/src/main/scala/mimir/models/GeocodingModel.scala
@@ -43,7 +43,7 @@ class GeocodingModel(override val name: String, addrCols:Seq[Expression], geocod
   def argTypes(idx: Int) = {
       Seq(TRowId()).union(addrCols.map(_ => TString()))
   }
-  def varType(idx: Int, args: Seq[Type]) = TFloat()
+  def varType(idx: Int, args: Seq[BaseType]) = TFloat()
   def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]  ) = {
     val rowid = RowIdPrimitive(args(0).asString)
     getFeedback(idx, args) match {
@@ -91,7 +91,7 @@ class GeocodingModel(override val name: String, addrCols:Seq[Expression], geocod
   def isAcknowledged (idx: Int, args: Seq[PrimitiveValue]): Boolean = {
     hasFeedback(idx, args)
   }
-  def hintTypes(idx: Int): Seq[mimir.algebra.Type] = Seq()
+  def hintTypes(idx: Int): Seq[BaseType] = Seq()
    
   def getDomain(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): Seq[(PrimitiveValue,Double)] = 
   {

--- a/src/main/scala/mimir/models/MissingKeyModel.scala
+++ b/src/main/scala/mimir/models/MissingKeyModel.scala
@@ -13,7 +13,7 @@ import mimir.util._
  * The return value is an integer identifying the ordinal position of the selected value, starting with 0.
  */
 @SerialVersionUID(1001L)
-class MissingKeyModel(override val name: String, keys:Seq[String], colTypes:Seq[Type]) 
+class MissingKeyModel(override val name: String, keys:Seq[String], colTypes:Seq[BaseType]) 
   extends Model(name) 
   with Serializable
   with FiniteDiscreteDomain
@@ -25,7 +25,7 @@ class MissingKeyModel(override val name: String, keys:Seq[String], colTypes:Seq[
   def argTypes(idx: Int) = {
       Seq(TRowId())
   }
-  def varType(idx: Int, args: Seq[Type]) = colTypes(idx)
+  def varType(idx: Int, args: Seq[BaseType]) = colTypes(idx)
   def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]  ) = {
     //println(s"MissingKeyModel:bestGuess: idx: $idx args: ${args.mkString("[ ",","," ]")} hints: ${hints.mkString("[ ",","," ]")}")
     getFeedback(idx, args) match {
@@ -63,7 +63,7 @@ class MissingKeyModel(override val name: String, keys:Seq[String], colTypes:Seq[
   def isAcknowledged (idx: Int, args: Seq[PrimitiveValue]): Boolean = {
     hasFeedback(idx, args)
   }
-  def hintTypes(idx: Int): Seq[mimir.algebra.Type] = Seq(TAny())
+  def hintTypes(idx: Int): Seq[BaseType] = Seq(TAny())
   def getDomain(idx: Int, args: Seq[PrimitiveValue], hints:Seq[PrimitiveValue]): Seq[(PrimitiveValue,Double)] = Seq((hints(0), 0.0))
 
   def confidence (idx: Int, args: Seq[PrimitiveValue], hints:Seq[PrimitiveValue]) : Double = {

--- a/src/main/scala/mimir/models/Model.scala
+++ b/src/main/scala/mimir/models/Model.scala
@@ -51,18 +51,18 @@ abstract class Model(val name: String) extends Serializable {
   /**
    * The list of expected arg types (may be TAny)
    */
-  def argTypes       (idx: Int): Seq[Type]
+  def argTypes       (idx: Int): Seq[BaseType]
   /**
    * The list of expected hint types (may be TAny)
    */
-  def hintTypes      (idx: Int): Seq[Type]
+  def hintTypes      (idx: Int): Seq[BaseType]
 
   /**
    * Infer the type of the model from the types of the inputs
    * @param argTypes    The types of the arguments the the VGTerm
    * @return            The type of the value returned by this model
    */
-  def varType        (idx: Int, argTypes: Seq[Type]): Type
+  def varType        (idx: Int, argTypes: Seq[BaseType]): BaseType
 
   /**
    * Generate a best guess for a variable represented by this model.

--- a/src/main/scala/mimir/models/ModelBuildingBlocks.scala
+++ b/src/main/scala/mimir/models/ModelBuildingBlocks.scala
@@ -4,7 +4,7 @@ import mimir.algebra._
 
 trait NoArgModel
 {
-  def argTypes(x: Int): Seq[Type] = List()
+  def argTypes(x: Int): Seq[BaseType] = List()
   def hintTypes(idx: Int) = Seq()
 }
 

--- a/src/main/scala/mimir/models/ModelRegistry.scala
+++ b/src/main/scala/mimir/models/ModelRegistry.scala
@@ -85,8 +85,8 @@ object ModelRegistry
   type SchemaMatchConstructor =
     ((Database, 
       String, 
-      Either[Operator,Seq[(String,Type)]],
-      Either[Operator,Seq[(String,Type)]]) => 
+      Either[Operator,Seq[(String,BaseType)]],
+      Either[Operator,Seq[(String,BaseType)]]) => 
         Map[String,(Model,Int)])
 
   /////////////////// PREDEFINED CONSTRUCTORS ///////////////////

--- a/src/main/scala/mimir/models/RepairKeyModel.scala
+++ b/src/main/scala/mimir/models/RepairKeyModel.scala
@@ -23,9 +23,9 @@ class RepairKeyModel(
   name: String, 
   context: String, 
   source: Operator, 
-  keys: Seq[(String, Type)], 
+  keys: Seq[(String, BaseType)], 
   target: String,
-  targetType: Type,
+  targetType: BaseType,
   scoreCol: Option[String]
 ) 
   extends Model(name)
@@ -37,7 +37,7 @@ class RepairKeyModel(
   
   def getFeedbackKey(idx: Int, args: Seq[PrimitiveValue]) : List[PrimitiveValue] = args.toList
   
-  def varType(idx: Int, args: Seq[Type]): Type = targetType
+  def varType(idx: Int, args: Seq[BaseType]): BaseType = targetType
   def argTypes(idx: Int) = keys.map(_._2)
   def hintTypes(idx: Int) = Seq(TString(), TString())
 
@@ -78,7 +78,7 @@ class RepairKeyModel(
             source
           )
         )
-     val mopSchema = db.typechecker.schemaOf(mop)
+     val mopSchema = db.typechecker.baseSchemaOf(mop)
     domainCache = db.backend.execute(mop).map( row => {
           ( SparkUtils.convertField(mopSchema(0)._2, row, 0, TString()), 
             scoreCol match { 
@@ -139,7 +139,7 @@ class RepairKeyModel(
     case TString() => StringPrimitive(value.asInstanceOf[String])
     case TBool() => BoolPrimitive(value.asInstanceOf[Boolean])
     case TRowId() => RowIdPrimitive(value.asInstanceOf[String])
-    case TType() => TypePrimitive(Type.fromString(value.asInstanceOf[String]))
+    // case TType() => TypePrimitive(BaseType.fromString(value.asInstanceOf[String]))
     //case TAny() => NullPrimitive()
     //case TUser(name) => name.toLowerCase
     //case TInterval() => Primitive(value.asInstanceOf[Long])

--- a/src/main/scala/mimir/models/SeriesMissingValueModel.scala
+++ b/src/main/scala/mimir/models/SeriesMissingValueModel.scala
@@ -68,11 +68,11 @@ class SimpleSeriesModel(name: String, colNames: Seq[String], query: Operator)
   
   var predictions:Seq[Dataset[(String, Double)]] = Seq()
   var queryDf: DataFrame = null
-  var rowIdType:Type = TString()
-  var dateType:Type = TDate()
+  var rowIdType:BaseType = TString()
+  var dateType:BaseType = TDate()
     //colNames.map { _ => Seq[(String,Double)]() }
   var queryCols:Seq[String] = colNames
-  var querySchema:Seq[(String,Type)] = 
+  var querySchema:Seq[(String,BaseType)] = 
     colNames.map { x => (x, TAny()) }
 
   def getCacheKey(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue] ) : String = s"${idx}_${args(0).asString}_${hints(0).asString}"
@@ -80,7 +80,7 @@ class SimpleSeriesModel(name: String, colNames: Seq[String], query: Operator)
 
   def train(db: Database): Seq[Boolean] = 
   {
-    querySchema = db.typechecker.schemaOf(query)
+    querySchema = db.typechecker.baseSchemaOf(query)
     queryCols = querySchema.unzip._1
     queryDf = db.backend.execute(query)
     rowIdType = db.backend.rowIdType
@@ -158,7 +158,7 @@ class SimpleSeriesModel(name: String, colNames: Seq[String], query: Operator)
 
   def argTypes(idx: Int) = Seq(TRowId())
 
-  def varType(idx: Int, args: Seq[Type]): Type = querySchema(idx)._2 
+  def varType(idx: Int, args: Seq[BaseType]): BaseType = querySchema(idx)._2 
   
   def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]  ): PrimitiveValue = 
   {
@@ -224,7 +224,7 @@ class SimpleSeriesModel(name: String, colNames: Seq[String], query: Operator)
   def isAcknowledged(idx: Int, args: Seq[PrimitiveValue]): Boolean =
     hasFeedback(idx, args)
   
-  def hintTypes(idx: Int): Seq[mimir.algebra.Type] = Seq()
+  def hintTypes(idx: Int): Seq[BaseType] = Seq()
   
   def confidence (idx: Int, args: Seq[PrimitiveValue], hints:Seq[PrimitiveValue]) : Double = {
     val df = predictions(idx)

--- a/src/main/scala/mimir/models/SparkClassifierModel.scala
+++ b/src/main/scala/mimir/models/SparkClassifierModel.scala
@@ -84,7 +84,7 @@ object SparkClassifierModel
 }
 
 @SerialVersionUID(1001L)
-class SimpleSparkClassifierModel(name: String, val colName:String, val schema:Seq[(String, Type)], val data:DataFrame)
+class SimpleSparkClassifierModel(name: String, val colName:String, val schema:Seq[(String, BaseType)], val data:DataFrame)
   extends Model(name) 
   with SourcedFeedback
   with ModelCache
@@ -102,11 +102,10 @@ class SimpleSparkClassifierModel(name: String, val colName:String, val schema:Se
 
   
  
-  def guessSparkModelType(t:Type) : String = {
+  def guessSparkModelType(t:BaseType) : String = {
     t match {
       case TFloat() if columns.length == 1 => "Regression"
       case TInt() | TDate() | TString() | TBool() | TRowId() | TType() | TAny() | TTimestamp() | TInterval() => "Classification"
-      case TUser(name) => guessSparkModelType(mimir.algebra.TypeRegistry.registeredTypes(name)._2)
       case x => "Classification"
     }
   }
@@ -153,13 +152,13 @@ class SimpleSparkClassifierModel(name: String, val colName:String, val schema:Se
     }
   }
 
-  def guessInputType: Type =
+  def guessInputType: BaseType =
     schema(colIdx)._2
 
-  def argTypes(idx: Int): Seq[Type] = List(TRowId())
+  def argTypes(idx: Int): Seq[BaseType] = List(TRowId())
   def hintTypes(idx: Int) = schema.reverse.tail.reverse.map(_._2)
 
-  def varType(idx: Int, args: Seq[Type]): Type = guessInputType
+  def varType(idx: Int, args: Seq[BaseType]): BaseType = guessInputType
   
   def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): PrimitiveValue =
   {

--- a/src/main/scala/mimir/optimizer/Optimizer.scala
+++ b/src/main/scala/mimir/optimizer/Optimizer.scala
@@ -53,7 +53,4 @@ object Optimizer
     opts.foldLeft(e)( (currE, f) => f(currE) )
   }
 
-  def gpromOptimize(rawOper: Operator): Operator = {
-    OperatorTranslation.optimizeWithGProM(rawOper)
-  }
 }

--- a/src/main/scala/mimir/optimizer/operator/PropagateEmptyViews.scala
+++ b/src/main/scala/mimir/optimizer/operator/PropagateEmptyViews.scala
@@ -31,7 +31,7 @@ class PropagateEmptyViews(typechecker: Typechecker, aggregates: AggregateRegistr
                 aggregates.typecheck(
                   function, 
                   args.map { expr => 
-                    typechecker.typeOf(expr,schMap)
+                    typechecker.rootType(typechecker.typeOf(expr,schMap))
                   }
                 )
               ), 

--- a/src/main/scala/mimir/parser/ExpressionParser.scala
+++ b/src/main/scala/mimir/parser/ExpressionParser.scala
@@ -142,7 +142,7 @@ object ExpressionParser extends RegexParsers {
 
 	def exprType: Parser[Type] = (
 		"int" | "decimal" | "date" | "string" | "rowid" | "type" | "float" | "real" | "varchar" | "any"
-	) ^^ { Type.fromString(_) }
+	) ^^ { BaseType.fromString(_).get }
 
 	def typeLeaf: Parser[Expression] = 
 		exprType ^^ { (t) => TypePrimitive(t) }

--- a/src/main/scala/mimir/provenance/Provenance.scala
+++ b/src/main/scala/mimir/provenance/Provenance.scala
@@ -16,10 +16,6 @@ object Provenance extends LazyLogging {
 
   val mergeRowIdFunction = "MIMIR_MAKE_ROWID"
   val rowidColnameBase = "MIMIR_ROWID"
-
-  def compileGProM(oper: Operator): (Operator, Seq[String]) = {
-    OperatorTranslation.compileProvenanceWithGProM(oper)
-  }
   
   
   def compile(oper: Operator): (Operator, Seq[String]) = {
@@ -348,7 +344,7 @@ object Provenance extends LazyLogging {
       }
       
       case Aggregate(gbCols, aggCols, src) =>
-        val sch = db.typechecker.schemaOf(src).toMap
+        val sch = db.typechecker.baseSchemaOf(src).toMap
 
         val castTokenValues = 
           gbCols.map { col => (col.name, Cast(sch(col.name), rowIds(col.name))) }.toMap

--- a/src/main/scala/mimir/sql/GProMBackend.scala
+++ b/src/main/scala/mimir/sql/GProMBackend.scala
@@ -115,8 +115,14 @@ class GProMBackend(backend: String, filename: String, var gpromLogLevel : Int)
   def dropDB():Unit = sparkBackend.dropDB() 
   def materializeView(name:String): Unit = sparkBackend.materializeView(name)
   def createTable(tableName: String,oper: mimir.algebra.Operator): Unit = sparkBackend.createTable(tableName, oper)
-  def readDataSource(name: String,format: String,options: Map[String,String],schema: Option[Seq[(String, mimir.algebra.Type)]],load: Option[String]): Unit = sparkBackend.readDataSource(name, format, options, schema, load)
-  def getTableSchema(table: String): Option[Seq[(String, Type)]] = sparkBackend.getTableSchema(table)
+  def readDataSource(
+    name: String,
+    format: String,
+    options: Map[String,String],
+    schema: Option[Seq[(String, mimir.algebra.BaseType)]],
+    load: Option[String]
+  ): Unit = sparkBackend.readDataSource(name, format, options, schema, load)
+  def getTableSchema(table: String): Option[Seq[(String, BaseType)]] = sparkBackend.getTableSchema(table)
   
   
   def getAllTables(): Seq[String] = sparkBackend.getAllTables()
@@ -124,8 +130,8 @@ class GProMBackend(backend: String, filename: String, var gpromLogLevel : Int)
 
  
   def canHandleVGTerms: Boolean = sparkBackend.canHandleVGTerms
-  def rowIdType: Type = sparkBackend.rowIdType
-  def dateType: Type = sparkBackend.dateType
+  def rowIdType: BaseType = sparkBackend.rowIdType
+  def dateType: BaseType = sparkBackend.dateType
   def specializeQuery(q: Operator, db: Database): Operator = sparkBackend.specializeQuery(q, db)
 
   def listTablesQuery: Operator = sparkBackend.listTablesQuery

--- a/src/main/scala/mimir/sql/GProMMedadataLookup.scala
+++ b/src/main/scala/mimir/sql/GProMMedadataLookup.scala
@@ -75,11 +75,11 @@ with LazyLogging
   		    case "&" => "DT_INT"
   		    case "MIMIR_MAKE_ROWID" => "DT_STRING"
   		    case _ => {
-  		      val argTypes = args.map(arg => getMimirTypeFromGProMDataTypeString(arg)) 
+  		      val argTypes = args.map(arg => getMimirTypeFromGProMDataTypeString(arg)).map { db.types.rootType(_) }
             //logger.debug(s"Metadata lookup: function: $fName(${argSeq.mkString(",")})")
             getGProMDataTypeStringFromMimirType( fName match {
       		    case "sys_op_map_nonnull" => argTypes(0)
-      		    case "MIMIR_ENCODED_VGTERM" => db.typechecker.returnTypeOfFunction(VGTermFunctions.bestGuessVGTermFn,argTypes)
+      		    case "MIMIR_ENCODED_VGTERM" => db.typechecker.returnTypeOfFunction(VGTermFunctions.bestGuessVGTermFn, argTypes)
       		    case "UNCERT" => argTypes(0)
       		    case "LEAST" => db.typechecker.returnTypeOfFunction("MIN",argTypes) 
       		    case _ => {
@@ -199,6 +199,7 @@ with LazyLogging
                             case TBool() => BoolPrimitive(false)
                             case TRowId() => RowIdPrimitive("0")
                             case TType() => TypePrimitive(TInt())
+                            case _ => ??? // This code is not in the active path for now.  Suppressing warning
                           }
                         })
                         oName match {

--- a/src/main/scala/mimir/sql/RABackend.scala
+++ b/src/main/scala/mimir/sql/RABackend.scala
@@ -30,10 +30,10 @@ abstract class RABackend(val database:String) {
   def resultValue(sel:SelectBody):PrimitiveValue =
     resultRows(sel).head.head*/
   
-  def readDataSource(name:String, format:String, options:Map[String, String], schema:Option[Seq[(String, Type)]], load:Option[String]) : Unit
+  def readDataSource(name:String, format:String, options:Map[String, String], schema:Option[Seq[(String, BaseType)]], load:Option[String]) : Unit
   
   
-  def getTableSchema(table: String): Option[Seq[(String, Type)]]
+  def getTableSchema(table: String): Option[Seq[(String, BaseType)]]
   
   
   def getAllTables(): Seq[String]
@@ -43,8 +43,8 @@ abstract class RABackend(val database:String) {
   def close()
 
   def canHandleVGTerms: Boolean
-  def rowIdType: Type
-  def dateType: Type
+  def rowIdType: BaseType
+  def dateType: BaseType
   def specializeQuery(q: Operator, db: Database): Operator
 
   def listTablesQuery: Operator

--- a/src/main/scala/mimir/sql/SqlToRA.scala
+++ b/src/main/scala/mimir/sql/SqlToRA.scala
@@ -603,11 +603,13 @@ class SqlToRA(db: Database)
           throw new SQLException(s"Invalid CAST: $cast")
         }
         val target = convert(params(0))
-        val t = params(1) match {
-          case s: StringValue => Type.fromString(s.toRawString)
-          case c: Column => Type.fromString(c.getColumnName)
-          case _ => throw new SQLException(s"Invalid CAST Type: $cast")
-        }
+        val t = (params(1) match {
+            case s: StringValue => BaseType.fromString(s.toRawString)
+            case c: Column      => BaseType.fromString(c.getColumnName)
+            case _              => None
+          }).getOrElse { 
+            throw new SQLException(s"Invalid CAST Type: $cast")
+          }
 
         return mimir.algebra.Function("CAST", Seq(target, TypePrimitive(t)))
       }

--- a/src/main/scala/mimir/sql/sqlite/MimirFunction.scala
+++ b/src/main/scala/mimir/sql/sqlite/MimirFunction.scala
@@ -3,7 +3,6 @@ package mimir.sql.sqlite;
 import java.sql.SQLException
 
 import mimir.algebra._
-import mimir.algebra.Type._
 import mimir.util._
 
 abstract class MimirFunction extends org.sqlite.Function
@@ -11,7 +10,7 @@ abstract class MimirFunction extends org.sqlite.Function
   def value_mimir(idx: Int): PrimitiveValue =
     value_mimir(idx, TAny())
 
-  def value_mimir(idx: Int, t:Type): PrimitiveValue =
+  def value_mimir(idx: Int, t:BaseType): PrimitiveValue =
   {
     if(value_type(idx) == SQLiteCompat.NULL){ NullPrimitive() }
     else { t match {
@@ -40,13 +39,13 @@ abstract class MimirFunction extends org.sqlite.Function
       case RowIdPrimitive(r)    => result(r)
       case t:TimestampPrimitive => result(t.asString)
       case i:IntervalPrimitive => result(i.asString)
-      case TypePrimitive(t)     => result(Type.toString(t))
+      case TypePrimitive(t)     => result(t.toString)
       case NullPrimitive()      => result()
     }
   }
 }
 
-abstract class SimpleMimirFunction(argTypes: List[Type]) extends MimirFunction
+abstract class SimpleMimirFunction(argTypes: List[BaseType]) extends MimirFunction
 {
   def apply(args: List[PrimitiveValue]): PrimitiveValue
 

--- a/src/main/scala/mimir/sql/sqlite/SpecializeForSQLite.scala
+++ b/src/main/scala/mimir/sql/sqlite/SpecializeForSQLite.scala
@@ -9,13 +9,13 @@ import mimir.util._
 
 object SpecializeForSQLite {
 
-  def apply(e: Expression): Expression =
+  def apply(e: Expression, db: Database): Expression =
   {
     (e match {
   
       case Function("CAST", Seq(target, TypePrimitive(t))) => 
         {//println("TYPE ID: "+t.id(t))
-          Function("MIMIRCAST", Seq(target, IntPrimitive(Type.id(t))))}
+          Function("MIMIRCAST", Seq(target, IntPrimitive(db.types.idForType(db.types.rootType(t)).toLong)))}
 
       case Function("CAST", _) =>
         throw new SQLException("Invalid CAST: "+e)
@@ -49,7 +49,7 @@ object SpecializeForSQLite {
 
       case _ => e
 
-    }).recur( apply(_:Expression) )
+    }).recur( apply(_:Expression, db) )
   }
 
   def apply(agg: AggFunction, typeOf: Expression => Type): AggFunction =
@@ -68,7 +68,7 @@ object SpecializeForSQLite {
   def apply(o: Operator, db: Database): Operator = 
   {
     o.recurExpressions( 
-      apply(_:Expression) 
+      apply(_:Expression, db) 
     ) match {
       case Aggregate(gb, agg, source) => {
 

--- a/src/main/scala/mimir/util/JSONBuilder.scala
+++ b/src/main/scala/mimir/util/JSONBuilder.scala
@@ -81,7 +81,7 @@ object JSONBuilder {
       case d:Double => JsNumber(d)
       case b:Boolean => JsBoolean(b)
       case seq:Seq[Any] => listJs(seq)
-      case map:Map[String,Any] => dictJs(map)
+      case map:Map[_,_] => dictJs(map.asInstanceOf[Map[String,Any]])
       case jsval:JsValue => jsval
       case prim:PrimitiveValue => primJs(prim)
 			case _ =>  JsString(content.toString())

--- a/src/main/scala/mimir/util/LoadCSV.scala
+++ b/src/main/scala/mimir/util/LoadCSV.scala
@@ -34,12 +34,12 @@ object LoadCSV extends StrictLogging {
   def handleLoadTableRaw(db: Database, targetTable: String, sourceFile: File, options: Map[String,String] = Map()){
     //we need to handle making csv publicly accessible here and adding it to spark for remote connections
     val path = if(sourceFile.getPath.contains(":/")) sourceFile.getPath.replaceFirst(":/", "://") else sourceFile.getAbsolutePath
-    db.backend.readDataSource(targetTable, "csv", options, db.tableSchema(targetTable), Some(path)) 
+    db.backend.readDataSource(targetTable, "csv", options, db.tableBaseSchema(targetTable), Some(path)) 
   }
 
-  def handleLoadTableRaw(db: Database, targetTable: String, targetSchema:Option[Seq[(String,Type)]], sourceFile: File, options: Map[String,String]){
+  def handleLoadTableRaw(db: Database, targetTable: String, targetSchema:Option[Seq[(String,BaseType)]], sourceFile: File, options: Map[String,String]){
     val schema = targetSchema match {
-      case None => db.tableSchema(targetTable)
+      case None => db.tableBaseSchema(targetTable)
       case _ => targetSchema
     }
     //we need to handle making csv publicly accessible here and adding it to spark for remote connections

--- a/src/main/scala/mimir/util/SealedSubclassEnumeration.scala
+++ b/src/main/scala/mimir/util/SealedSubclassEnumeration.scala
@@ -1,0 +1,45 @@
+package mimir.util
+
+import language.experimental.macros
+import scala.reflect.macros.Context
+
+// Adapted from 
+// https://stackoverflow.com/questions/13671734/iteration-over-a-sealed-trait-in-scala
+object SealedSubclassEnumeration {
+  def values[A]: Set[A] = macro values_impl[A]
+
+  def values_impl[A: c.WeakTypeTag](c: Context) = {
+    import c.universe._
+
+    val symbol = weakTypeOf[A].typeSymbol
+
+    if (!symbol.isClass) c.abort(
+      c.enclosingPosition,
+      "Can only enumerate values of a sealed trait or class."
+    ) else if (!symbol.asClass.isSealed) c.abort(
+      c.enclosingPosition,
+      "Can only enumerate values of a sealed trait or class."
+    ) else {
+      val children = symbol.asClass.knownDirectSubclasses.toList
+
+      if (!children.forall(_.isModuleClass)) c.abort(
+        c.enclosingPosition,
+        "All children must be objects."
+      ) else c.Expr[Set[A]] {
+        def sourceModuleRef(sym: Symbol) = Ident(
+          sym.asInstanceOf[
+            scala.reflect.internal.Symbols#Symbol
+          ].sourceModule.asInstanceOf[Symbol]
+        )
+
+        Apply(
+          Select(
+            reify(Set).tree,
+            newTermName("apply")
+          ),
+          children.map(sourceModuleRef(_))
+        )
+      }
+    }
+  }
+}

--- a/src/main/scala/mimir/util/SqlUtils.scala
+++ b/src/main/scala/mimir/util/SqlUtils.scala
@@ -200,6 +200,7 @@ object SqlUtils {
             case Some(tblSchmd) => tblSchmd
             case None => db.backend.getTableSchema(table.getName()) match {
               case Some(tblSch) => tblSch
+              case None => throw new SQLException("Unknown Table: "+table.getName())
             }
           }).map(_._1).toList++List("ROWID")
           )

--- a/src/main/scala/mimir/util/TextUtils.scala
+++ b/src/main/scala/mimir/util/TextUtils.scala
@@ -5,7 +5,7 @@ import mimir.algebra._
 
 object TextUtils extends LazyLogging {
 
-  def parsePrimitive(t: Type, s: String, baseType: (String => Type) = (_ => throw new RAException("Unable to cast user-defined type here"))): PrimitiveValue = 
+  def parsePrimitive(t: BaseType, s: String): PrimitiveValue = 
   {
     t match {
       case TInt()    => IntPrimitive(java.lang.Long.parseLong(s))
@@ -20,9 +20,8 @@ object TextUtils extends LazyLogging {
           case "NO"  | "FALSE" | "0" => BoolPrimitive(false)
         }
       case TRowId()  => RowIdPrimitive(s)
-      case TType()   => TypePrimitive(Type.fromString(s))
+      case TType()   => TypePrimitive(BaseType.fromString(s).getOrElse { TUser(s) })
       case TAny()    => throw new RAException("Can't cast string to TAny")
-      case TUser(t)  => parsePrimitive(baseType(t), s)
     }
   }
 

--- a/src/main/scala/mimir/util/TextUtils.scala
+++ b/src/main/scala/mimir/util/TextUtils.scala
@@ -5,7 +5,7 @@ import mimir.algebra._
 
 object TextUtils extends LazyLogging {
 
-  def parsePrimitive(t: Type, s: String): PrimitiveValue = 
+  def parsePrimitive(t: Type, s: String, baseType: (String => Type) = (_ => throw new RAException("Unable to cast user-defined type here"))): PrimitiveValue = 
   {
     t match {
       case TInt()    => IntPrimitive(java.lang.Long.parseLong(s))
@@ -22,7 +22,7 @@ object TextUtils extends LazyLogging {
       case TRowId()  => RowIdPrimitive(s)
       case TType()   => TypePrimitive(Type.fromString(s))
       case TAny()    => throw new RAException("Can't cast string to TAny")
-      case TUser(t)  => parsePrimitive(TypeRegistry.baseType(t), s)
+      case TUser(t)  => parsePrimitive(baseType(t), s)
     }
   }
 

--- a/src/main/scala/mimir/views/ViewManager.scala
+++ b/src/main/scala/mimir/views/ViewManager.scala
@@ -103,7 +103,7 @@ class ViewManager(db:Database) extends LazyLogging {
     results.take(1).headOption.map(_.toSeq).map( 
       { 
         case Seq(StringPrimitive(s), IntPrimitive(meta)) => {
-          val query = Json.toOperator(Json.parse(s))
+          val query = Json.toOperator(Json.parse(s), db.types)
           val isMaterialized = 
             meta != 0
           

--- a/src/test/scala/mimir/algebra/SerializationSpec.scala
+++ b/src/test/scala/mimir/algebra/SerializationSpec.scala
@@ -50,7 +50,7 @@ object SerializationSpec extends SQLTestSpecification("SerializationTest") {
               i = i + 1;
               val query = db.sql.convert(s)
               val serialized = Json.ofOperator(query)
-              val deserialized = Json.toOperator(serialized)
+              val deserialized = Json.toOperator(serialized, db.types)
 
               Some(deserialized must be equalTo query)
             }

--- a/src/test/scala/mimir/demo/MimirGProMDemo.scala
+++ b/src/test/scala/mimir/demo/MimirGProMDemo.scala
@@ -56,7 +56,7 @@ object MimirGProMDemo extends GProMSQLTestSpecification("MimirGProMDemo")
 			//	"mimir.algebra.gprom.OperatorTranslation"
 			//){
         val table = db.table("MVQ")
-        val (oper, provCols) = OperatorTranslation.compileProvenanceWithGProM(table) 
+        val (oper, provCols) = db.gpromTranslator.compileProvenanceWithGProM(table) 
         provOp = oper;
         query(table){ 
   				_.toSeq.map { _.provenance.asString } must contain(
@@ -71,7 +71,7 @@ object MimirGProMDemo extends GProMSQLTestSpecification("MimirGProMDemo")
     }
     
     "Compile Determinism for Mimir Operators" >> { 
-      val (oper, colDet, rowDet) = OperatorTranslation.compileTaintWithGProM(provOp) 
+      val (oper, colDet, rowDet) = db.gpromTranslator.compileTaintWithGProM(provOp) 
       val table = db.table("MVQ")
       query(table){ 
 				_.toList.map( row => {
@@ -105,7 +105,7 @@ object MimirGProMDemo extends GProMSQLTestSpecification("MimirGProMDemo")
       println("------------mimir Op Json-----------------")
       println(mimir.serialization.Json.ofOperator(oper).toString)
       println("------------------------------------------")*/
-      val gpromNode = TranslationUtils.scalaListToGProMList(Seq(OperatorTranslation.mimirOperatorToGProMOperator(oper)))
+      val gpromNode = TranslationUtils.scalaListToGProMList(Seq(db.gpromTranslator.mimirOperatorToGProMOperator(oper)))
       gpromNode.write()
       val gpNodeStr = GProMWrapper.inst.gpromNodeToString(gpromNode.getPointer())
       .replaceAll("ADDRESS: '[a-z0-9]+'", "ADDRESS: ''")
@@ -121,7 +121,7 @@ object MimirGProMDemo extends GProMSQLTestSpecification("MimirGProMDemo")
   def transGOpPrint(oper:Operator) : String = {
     org.gprom.jdbc.jna.GProM_JNA.GC_LOCK.synchronized{
       val memctx = GProMWrapper.inst.gpromCreateMemContext()
-      val gpromNode = TranslationUtils.scalaListToGProMList(Seq(OperatorTranslation.mimirOperatorToGProMOperator(oper)))
+      val gpromNode = TranslationUtils.scalaListToGProMList(Seq(db.gpromTranslator.mimirOperatorToGProMOperator(oper)))
       gpromNode.write()
       val gpNodeStr = GProMWrapper.inst.gpromNodeToString(gpromNode.getPointer())
       .replaceAll("ADDRESS: '[a-z0-9]+'", "ADDRESS: ''")
@@ -129,7 +129,7 @@ object MimirGProMDemo extends GProMSQLTestSpecification("MimirGProMDemo")
       /*println("---------------gprom Op-------------------")
       println(gpNodeStr)
       println("------------------------------------------")*/
-      val opOut = OperatorTranslation.gpromStructureToMimirOperator(0, gpromNode, null)
+      val opOut = db.gpromTranslator.gpromStructureToMimirOperator(0, gpromNode, null)
       /*println("--------------mimir Op--------------------")
       println(opOut.toString())
       println("------------mimir Op Json-----------------")

--- a/src/test/scala/mimir/demo/SimpleDemoScript.scala
+++ b/src/test/scala/mimir/demo/SimpleDemoScript.scala
@@ -95,7 +95,7 @@ object SimpleDemoScript
 			query("SELECT * FROM RATINGS1 WHERE RATING > 4;"){ _.toSeq must have size(2) }
 			query("SELECT * FROM RATINGS2;"){ _.toSeq must have size(3) }
 			db.typechecker.schemaOf(select("SELECT * FROM RATINGS2;")).
-				map(_._2).map(Type.rootType _) must be equalTo List(TString(), TFloat(), TFloat())
+				map(_._2).map(db.types.rootType _) must be equalTo List(TString(), TFloat(), TFloat())
 		}
 
 		"Create and Query Domain Constraint Repair Lenses" >> {

--- a/src/test/scala/mimir/lenses/TypeInferenceSpec.scala
+++ b/src/test/scala/mimir/lenses/TypeInferenceSpec.scala
@@ -32,8 +32,8 @@ object TypeInferenceSpec
 
     "Detect Timestamps Correctly" >> {
 
-      Type.matches(TTimestamp(), "2014-06-15 08:23:19") must beTrue
-      Type.matches(TTimestamp(), "2013-10-07 08:23:19.120") must beTrue
+      db.types.testForTypes("2014-06-15 08:23:19") must contain(TTimestamp())
+      db.types.testForTypes("2013-10-07 08:23:19.120") must contain(TTimestamp())
 
 
       db.loadTable("DETECTSERIESTEST1", new File("test/data/DetectSeriesTest1.csv"))

--- a/src/test/scala/mimir/models/EditDistanceMatchModelSpec.scala
+++ b/src/test/scala/mimir/models/EditDistanceMatchModelSpec.scala
@@ -7,7 +7,7 @@ import mimir.algebra._
 object EditDistanceMatchModelSpec extends Specification
 {
   
-  def train(src: Map[String,Type], tgt: Map[String,Type]): Map[String,(Model,Int)] =
+  def train(src: Map[String,BaseType], tgt: Map[String,BaseType]): Map[String,(Model,Int)] =
   {
     EditDistanceMatchModel.train(null, "TEMP",
       Right(src.toList), Right(tgt.toList)

--- a/src/test/scala/mimir/models/TypeInferenceModelSpec.scala
+++ b/src/test/scala/mimir/models/TypeInferenceModelSpec.scala
@@ -14,7 +14,14 @@ object TypeInferenceModelSpec extends SQLTestSpecification("TypeInferenceTests")
 
   def train(elems: List[String]): TypeInferenceModel = 
   {
-    val model = new TypeInferenceModel("TEST_MODEL", Array("TEST_COLUMN"), 0.5, db.backend.asInstanceOf[BackendWithSparkContext].getSparkContext(),None)
+    val model = new TypeInferenceModel(
+      "TEST_MODEL", 
+      Array("TEST_COLUMN"), 
+      0.5, 
+      db.backend.asInstanceOf[BackendWithSparkContext].getSparkContext(),
+      None,
+      db.types.getSerializable
+    )
     elems.foreach( model.learn(0, _) )
     return model
   }
@@ -53,7 +60,14 @@ object TypeInferenceModelSpec extends SQLTestSpecification("TypeInferenceTests")
       LoggerUtils.debug(
         "mimir.models.TypeInferenceModel"
       ){
-        val model = new TypeInferenceModel("CPUSPEED:CORES", Array("CORES"), 0.5, db.backend.asInstanceOf[BackendWithSparkContext].getSparkContext(), Some(db.backend.execute(table("CPUSPEED"))))
+        val model = new TypeInferenceModel(
+          "CPUSPEED:CORES", 
+          Array("CORES"), 
+          0.5, 
+          db.backend.asInstanceOf[BackendWithSparkContext].getSparkContext(), 
+          Some(db.backend.execute(table("CPUSPEED"))),
+          db.types.getSerializable
+        )
         //model.train(db.backend.execute(table("CPUSPEED")))
         guess(model) must be equalTo(TInt())
       }

--- a/src/test/scala/mimir/test/GProMSQLTestSpecification.scala
+++ b/src/test/scala/mimir/test/GProMSQLTestSpecification.scala
@@ -35,6 +35,7 @@ object GProMDBTestInstances
           val oldDBExists = dbFile.exists();
           val backend = new GProMBackend(jdbcBackendMode, tempDBName+".db", 1)
           val tmpDB = new Database(backend, new JDBCMetadataBackend(jdbcBackendMode, tempDBName+".db"));
+          backend.sparkBackend.sparkTranslator = tmpDB.sparkTranslator
           if(shouldResetDB){
             if(dbFile.exists()){ dbFile.delete(); }
           }
@@ -57,8 +58,6 @@ object GProMDBTestInstances
           ExperimentalOptions.enable("GPROM-BACKEND")
           ExperimentalOptions.enable("GPROM-PROVENANCE")
           ExperimentalOptions.enable("GPROM-DETERMINISM")
-          mimir.algebra.gprom.OperatorTranslation.db = tmpDB
-          mimir.algebra.spark.OperatorTranslation.db = tmpDB
           databases.put(tempDBName, (tmpDB, backend))
           (tmpDB, backend)
         }

--- a/src/test/scala/mimir/test/PDBench.scala
+++ b/src/test/scala/mimir/test/PDBench.scala
@@ -7,7 +7,7 @@ object PDBench
 {
   def isDownloaded = new File("test/pdbench").exists()
 
-  val tables = Map[String, (Seq[String], Seq[(String,String,Type,Double)])](
+  val tables = Map[String, (Seq[String], Seq[(String,String,BaseType,Double)])](
     "customer" -> (
       Seq("custkey"),
       Seq(

--- a/src/test/scala/mimir/test/SQLTestSpecification.scala
+++ b/src/test/scala/mimir/test/SQLTestSpecification.scala
@@ -46,13 +46,13 @@ object DBTestInstances
           val backend = new JDBCMetadataBackend(jdbcBackendMode, tempDBName+".db")
           val sback = new SparkBackend(tempDBName)
           val tmpDB = new Database(sback, backend);
+          sback.sparkTranslator = tmpDB.sparkTranslator
           if(shouldCleanupDB){    
             dbFile.deleteOnExit();
           }
           tmpDB.metadataBackend.open()
           tmpDB.backend.open();
           SparkML(sback.sparkSql)
-          OperatorTranslation.db = tmpDB
           if(shouldResetDB || !oldDBExists){
             config.get("initial_db") match {
               case None => ()

--- a/src/test/scala/mimir/timing/vldb2017/MCDBTimingSpec.scala
+++ b/src/test/scala/mimir/timing/vldb2017/MCDBTimingSpec.scala
@@ -58,7 +58,7 @@ object MCDBTimingSpec
 
     }
 
-    def createTable(tableInfo:(String, String, Seq[(String, Type)], Double), tableSuffix: String = "_cleaned") =  
+    def createTable(tableInfo:(String, String, Seq[(String, BaseType)], Double), tableSuffix: String = "_cleaned") =  
     {
       val (baseTable, ddl, schema, timeout) = tableInfo
       

--- a/src/test/scala/mimir/timing/vldb2017/VLDB2017TimingTest.scala
+++ b/src/test/scala/mimir/timing/vldb2017/VLDB2017TimingTest.scala
@@ -29,7 +29,7 @@ abstract class VLDB2017TimingTest(dbName: String, config: Map[String,String])
   val sampler     = new SampleRows( (0 until 10).map { _ => random.nextLong })
 
 
-  def loadTable(tableFields:(String, String, Type, Double), run:Int=1) =
+  def loadTable(tableFields:(String, String, BaseType, Double), run:Int=1) =
   {
     println(s"VLDB2017TimingTest.loadTable(${tableFields})")
     val (baseTable, columnName, columnType, timeout) = tableFields


### PR DESCRIPTION
Small edits with far-reaching effects.

The big edits are:
1. New Type matchers
2. TypeRegistry is now a class rather than a global
3. There's now a distinction between BaseType (which most of the system knows how to handle) and Type (which also includes TUser, which needs TypeRegistry to handle).  

Also cut out the OperatorTransform global database instance hack.