### PR TITLE
Type inference warnings

### DIFF
--- a/src/main/scala/mimir/Database.scala
+++ b/src/main/scala/mimir/Database.scala
@@ -403,12 +403,16 @@ case class Database(backend: RABackend, metadataBackend: MetadataBackend)
             case null => (load.getFile.getName.replaceAll("\\..*", "").toUpperCase, false)
             case s => (s, true)
           }
+        val format = 
+          if(load.getFormat == null) { "csv" } 
+          else{ load.getFormat }
+
 
         loadTable(
           target, 
           load.getFile, 
           force = force,
-          (load.getFormat, load.getFormatArgs.asScala.toSeq.map { sql.convert(_) })
+          (format, load.getFormatArgs.asScala.toSeq.map { sql.convert(_) })
         )
       }
 

--- a/src/main/scala/mimir/Mimir.scala
+++ b/src/main/scala/mimir/Mimir.scala
@@ -319,11 +319,18 @@ object Mimir extends LazyLogging {
           " (" + reason.args.mkString(",") + ")"
         } else { "" }
       output.print(reason.reason)
-      if(!reason.confirmed){
-        output.print(s"   ... repair with `FEEDBACK ${reason.model.name} ${reason.idx}$argString IS ${ reason.repair.exampleString }`");
-        output.print(s"   ... confirm with `FEEDBACK ${reason.model.name} ${reason.idx}$argString IS ${ reason.guess }`");
-      } else {
-        output.print(s"   ... ammend with `FEEDBACK ${reason.model.name} ${reason.idx}$argString IS ${ reason.repair.exampleString }`");
+      reason match {
+        case _:DataWarningReason => 
+          if(!reason.confirmed) { 
+            output.print(s"    ... acknowledge with `FEEDBACK ${reason.model.name} ${reason.idx}$argString IS ${reason.repair.exampleString}`")
+          }
+        case _ => 
+          if(!reason.confirmed){
+            output.print(s"   ... repair with `FEEDBACK ${reason.model.name} ${reason.idx}$argString IS ${ reason.repair.exampleString }`");
+            output.print(s"   ... confirm with `FEEDBACK ${reason.model.name} ${reason.idx}$argString IS ${ reason.guess }`");
+          } else {
+            output.print(s"   ... ammend with `FEEDBACK ${reason.model.name} ${reason.idx}$argString IS ${ reason.repair.exampleString }`");
+          }
       }
       output.print("")
     }

--- a/src/main/scala/mimir/Mimir.scala
+++ b/src/main/scala/mimir/Mimir.scala
@@ -234,12 +234,21 @@ object Mimir extends LazyLogging {
     output.print(raw.toString)
     db.typechecker.schemaOf(raw)        // <- discard results, just make sure it typechecks
     val optimized = db.compiler.optimize(raw)
-    output.print("--- Optimized Query ---")
+    output.print("\n--- Optimized Query ---")
     output.print(optimized.toString)
     db.typechecker.schemaOf(optimized)  // <- discard results, just make sure it typechecks
-    output.print("--- SQL ---")
+    output.print("\n-------- SQL --------")
     try {
       output.print(db.ra.convert(optimized).toString)
+    } catch {
+      case e:Throwable =>
+        output.print("Unavailable: "+e.getMessage())
+    }
+    output.print("\n------- Spark -------")
+    try {
+      output.print(
+        mimir.algebra.spark.OperatorTranslation.mimirOpToSparkOp(optimized).toString
+      )
     } catch {
       case e:Throwable =>
         output.print("Unavailable: "+e.getMessage())

--- a/src/main/scala/mimir/Mimir.scala
+++ b/src/main/scala/mimir/Mimir.scala
@@ -110,6 +110,7 @@ object Mimir extends LazyLogging {
                     finishByReadingFromConsole = false
                   }
                 case "csv" => {
+                    output.print("Loading "+file+"...")
                     db.loadTable(
                       new File(file).getName().replaceAll("\\..*", "").toUpperCase,
                       new File(file),

--- a/src/main/scala/mimir/adaptive/TypeInference.scala
+++ b/src/main/scala/mimir/adaptive/TypeInference.scala
@@ -43,7 +43,7 @@ object TypeInference
         case _ => None
       }).toIndexedSeq
 
-    val model = 
+    val attributeTypeModel = 
       new TypeInferenceModel(
         s"MIMIR_TI_ATTR_${viewName}",
         modelColumns,
@@ -52,13 +52,19 @@ object TypeInference
         Some(db.backend.execute(config.query.limit(TypeInferenceModel.sampleLimit, 0)))
       )
 
+    val warningModel = 
+      new WarningModel(
+        s"MIMIR_TI_WARNING_${viewName}",
+        Seq(TString(), TString(), TString())
+      )
+
     val columnIndexes = 
       modelColumns.zipWithIndex.toMap
 
-    logger.debug(s"Training $model.name on ${config.query}")
+    logger.debug(s"Training $attributeTypeModel.name on ${config.query}")
     //model.train(db.backend.execute(config.query))
     
-    Seq(model)
+    Seq(attributeTypeModel, warningModel)
   }
 
   def tableCatalogFor(db: Database, config: MultilensConfig): Operator =
@@ -116,18 +122,38 @@ object TypeInference
       val model = db.models.get(s"MIMIR_TI_ATTR_${config.schema}").asInstanceOf[TypeInferenceModel]
       val columnIndexes = model.columns.zipWithIndex.toMap
       Some(Project(
-        config.query.columnNames.map { colName =>
+        config.query.columnNames.map { colName => {
+          val bestGuessType = model.bestGuess(0, Seq(IntPrimitive(columnIndexes(colName))), Seq())
           ProjectArg(colName, 
             if(columnIndexes contains colName){ 
-              Function("CAST", Seq(
-                Var(colName),
-                model.bestGuess(0, Seq(IntPrimitive(columnIndexes(colName))), Seq())
-              ))
+              val castExpression = Function("CAST", Seq(
+                  Var(colName),
+                  bestGuessType
+                ))
+              Conditional(
+                IsNullExpression(Var(colName)),
+                NullPrimitive(),
+                Conditional(
+                  IsNullExpression(castExpression),
+                  DataWarning(
+                    s"MIMIR_TI_WARNING_${config.schema}",
+                    NullPrimitive(),
+                    Function("CONCAT", Seq(
+                      StringPrimitive("Couldn't Cast [ "),
+                      Var(colName),
+                      StringPrimitive(" ] to "+bestGuessType+" on row "),
+                      RowIdVar()
+                    )),
+                    Seq(StringPrimitive(colName), Var(colName), StringPrimitive(bestGuessType.toString))
+                  ),
+                  castExpression
+                )
+              )
             } else {
               Var(colName)
             }
           )
-        }, config.query
+        }}, config.query
       ))  
     } else { None }
   }

--- a/src/main/scala/mimir/algebra/Eval.scala
+++ b/src/main/scala/mimir/algebra/Eval.scala
@@ -83,6 +83,7 @@ class Eval(
       case RowIdVar() => throw new RAException("Evaluating RowIds in the Interpreter Unsupported")
       case JDBCVar(t) => throw new RAException("Evaluating JDBCVars in the Interpreter Unsupported")
       case v:VGTerm => throw new RAException(s"Evaluating VGTerms ($v) in the Interpreter Unsupported")
+      case v:DataWarning => throw new RAException(s"Evaluating Warnings ($v) in the Interpreter Unsupported")
       // Special case And/Or arithmetic to enable shortcutting
       case Arithmetic(Arith.And, lhs, rhs) =>
         eval(lhs, bindings) match {

--- a/src/main/scala/mimir/algebra/Typechecker.scala
+++ b/src/main/scala/mimir/algebra/Typechecker.scala
@@ -146,6 +146,7 @@ class Typechecker(
 						registry.get(model).varType(idx, args.map(recur(_)))
 					case None => throw new RAException("Need Model Manager to typecheck expressions with VGTerms")
 				}
+			case DataWarning(_, v, _, _) => recur(v)
     }
   }
 

--- a/src/main/scala/mimir/algebra/spark/OperatorTranslation.scala
+++ b/src/main/scala/mimir/algebra/spark/OperatorTranslation.scala
@@ -560,14 +560,17 @@ object OperatorTranslation
         BestGuessUDF(oper, model, idx, args, hints).getUDF
         //UnresolvedFunction(mimir.ctables.CTables.FN_BEST_GUESS, mimirExprToSparkExpr(oper,StringPrimitive(name)) +: mimirExprToSparkExpr(oper,IntPrimitive(idx)) +: (args.map(mimirExprToSparkExpr(oper,_)) ++ hints.map(mimirExprToSparkExpr(oper,_))), true )
       }
+      case DataWarning(_, v, _, _) => {
+        mimirExprToSparkExpr(oper, v)
+      }
       case IsNullExpression(iexpr) => {
         IsNull(mimirExprToSparkExpr(oper,iexpr))
       }
       case Not(nexpr) => {
         org.apache.spark.sql.catalyst.expressions.Not(mimirExprToSparkExpr(oper,nexpr))
       }
-      case x => {
-        throw new Exception(s"Expression Translation not implemented ${x.getClass}: '$x'")
+      case (JDBCVar(_) | _:Proc) => {
+        throw new RAException("Spark doesn't support: "+expr)
       }
     }
   }

--- a/src/main/scala/mimir/ctables/CTAnalyzer.scala
+++ b/src/main/scala/mimir/ctables/CTAnalyzer.scala
@@ -92,6 +92,15 @@ object CTAnalyzer {
         } else {
           IsAcknowledged(models(v.name), v.idx, v.args)
         }
+
+      case w: DataWarning => 
+        if(w.key.isEmpty){
+          BoolPrimitive(
+            models(w.name).isAcknowledged(0, Seq())
+          )
+        } else {
+          IsAcknowledged(models(w.name), 0, w.key)
+        }
       
       case Var(v) => 
         varMap.get(v).getOrElse(BoolPrimitive(true))
@@ -111,10 +120,10 @@ object CTAnalyzer {
    * under which each of those terms affect the result.  Similar to compileDeterministic,
    * but on a term-by-term basis.
    */
-  def compileCausality(expr: Expression): Seq[(Expression, VGTerm)] =
+  def compileCausality(expr: Expression): Seq[(Expression, UncertaintyCausingExpression)] =
     compileCausality(expr, BoolPrimitive(true))
 
-  private def compileCausality(expr: Expression, inputCondition: Expression): Seq[(Expression, VGTerm)] = 
+  private def compileCausality(expr: Expression, inputCondition: Expression): Seq[(Expression, UncertaintyCausingExpression)] = 
   {
     expr match { 
       case Conditional(condition, thenClause, elseClause) => {
@@ -173,7 +182,7 @@ object CTAnalyzer {
         }
       }
       
-      case x: VGTerm => List( (inputCondition, x) )
+      case x: UncertaintyCausingExpression => List( (inputCondition, x) )
 
       case _ => expr.children.flatMap(compileCausality(_, inputCondition))
 

--- a/src/main/scala/mimir/ctables/InlineVGTerms.scala
+++ b/src/main/scala/mimir/ctables/InlineVGTerms.scala
@@ -36,6 +36,8 @@ object InlineVGTerms {
 				}
 			}
 
+			case DataWarning(_, v, _, _) => v.recur(inline(_, db))
+
 			case _ => e.recur(inline(_, db))
 		}
 	}

--- a/src/main/scala/mimir/ctables/Reason.scala
+++ b/src/main/scala/mimir/ctables/Reason.scala
@@ -5,12 +5,6 @@ import mimir.algebra._
 import mimir.models._
 import mimir.util.JSONBuilder
 
-object Reason
-{
-  def make(model: Model, idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): Reason =
-    new ModelReason(model, idx, args, hints)
-}
-
 abstract class Reason
 {
   def toString: String
@@ -85,6 +79,25 @@ class ModelReason(
 
   override def hashCode: Int = 
     model.hashCode * idx * args.map(_.hashCode).sum
+}
+
+class DataWarningReason(
+  val model: Model,
+  val value: PrimitiveValue,
+  val message: String,
+  val key: Seq[PrimitiveValue]
+)
+  extends Reason
+{
+  override def toString = s" {{ $model[${key.mkString(", ")}] }}"
+
+  def idx: Int = 0
+  def args: Seq[PrimitiveValue] = key
+  def hints: Seq[PrimitiveValue] = Seq()
+
+  def reason: String = message
+  def repair: Repair = DataWarningRepair
+  override def guess: PrimitiveValue = value
 }
 
 class MultiReason(db: Database, reasons: ReasonSet)

--- a/src/main/scala/mimir/ctables/Repair.scala
+++ b/src/main/scala/mimir/ctables/Repair.scala
@@ -69,3 +69,13 @@ case class ModerationRepair(userRepairedValue:String)
   def toJSON: String = JSONBuilder.dict(Map( "value" -> userRepairedValue))
   def exampleString: String = s"< $userRepairedValue >"
 }
+
+object DataWarningRepair
+  extends Repair
+{
+  def toJSON =
+    JSONBuilder.dict(Map(
+      "selector" -> JSONBuilder.string("warning")
+    ))
+  def exampleString: String = "< Explain why in a string >"
+}

--- a/src/main/scala/mimir/exec/EvalInlined.scala
+++ b/src/main/scala/mimir/exec/EvalInlined.scala
@@ -388,6 +388,8 @@ class EvalInlined[T](scope: Map[String, (Type, (T => PrimitiveValue))], db: Data
         throw new RAException("Error: ROWIDVars should have been compiled out")
       case _:VGTerm => 
         throw new RAException("Error: VGTerms should have been compiled out")
+      case _:DataWarning => 
+        throw new RAException("Error: Warnings should have been compiled out")
     }
   }
   

--- a/src/main/scala/mimir/models/BasicModels.scala
+++ b/src/main/scala/mimir/models/BasicModels.scala
@@ -61,3 +61,23 @@ case class NoOpModel(override val name: String, reasonText:String)
   def isAcknowledged (idx: Int, args: Seq[PrimitiveValue]): Boolean = acked
   def confidence(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): Double = 0.5 // Random, so...
 }
+
+case class WarningModel(override val name: String, keyTypes: Seq[Type])
+  extends Model(name)
+  with Serializable
+  with SourcedFeedback
+{
+  def argTypes(idx: Int) = keyTypes
+  def hintTypes(idx: Int) = Seq(TAny(), TString())
+  def varType(idx: Int, args: Seq[Type]) = TString()
+  def bestGuess(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]) = 
+    StringPrimitive("I have no idea?")
+  def sample(idx: Int, randomness: Random, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]) = args(0)
+    StringPrimitive("You shouldn't be sampling from a model")
+  def reason(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): String = 
+    hints(1).asString
+  def feedback(idx: Int, args: Seq[PrimitiveValue], v: PrimitiveValue): Unit = setFeedback(0, args, v)
+  def isAcknowledged (idx: Int, args: Seq[PrimitiveValue]): Boolean = hasFeedback(0, args)
+  def confidence(idx: Int, args: Seq[PrimitiveValue], hints: Seq[PrimitiveValue]): Double = 0.0
+  def getFeedbackKey(idx: Int, args: Seq[PrimitiveValue]) = args.map { _.toString }.mkString(":::")
+}

--- a/src/main/scala/mimir/optimizer/expression/SimplifyExpressions.scala
+++ b/src/main/scala/mimir/optimizer/expression/SimplifyExpressions.scala
@@ -15,7 +15,7 @@ class SimplifyExpressions(interpreter: Eval, functionRegistry: FunctionRegistry)
   {
     originalExpression match {
       //////////////////// Leaves ////////////////////
-      case _:PrimitiveValue | _:Var | _:VGTerm | _:JDBCVar | _:RowIdVar => return originalExpression
+      case _:PrimitiveValue | _:Var | _:VGTerm | _:JDBCVar | _:RowIdVar | _:DataWarning => return originalExpression
 
       //////////////////// Arithmetic ////////////////////
 

--- a/src/main/scala/mimir/serialization/Json.scala
+++ b/src/main/scala/mimir/serialization/Json.scala
@@ -401,6 +401,15 @@ object Json
           "hints" -> ofExpressionList(hints)
         ))
 
+      case DataWarning(name, v, message, key) =>
+        JsObject(Map[String, JsValue](
+          "type" -> JsString("data_warning"),
+          "name" -> JsString(name),
+          "value" -> ofExpression(v),
+          "message" -> ofExpression(message),
+          "key" -> ofExpressionList(key)
+        ))
+
     }
   }
   def toExpression(json: JsValue): Expression = 
@@ -456,6 +465,14 @@ object Json
           fields("var_index").asInstanceOf[JsNumber].value.toLong.toInt,
           toExpressionList(fields("arguments")),
           toExpressionList(fields("hints"))
+        )
+
+      case "data_warning" => 
+        DataWarning(
+          fields("name").asInstanceOf[JsString].value,
+          toExpression(fields("value")),
+          toExpression(fields("message")),
+          toExpressionList(fields("key"))
         )
 
       // fall back to treating it as a primitive type

--- a/src/main/scala/mimir/views/ViewManager.scala
+++ b/src/main/scala/mimir/views/ViewManager.scala
@@ -206,13 +206,13 @@ class ViewManager(db:Database) extends LazyLogging {
    * List all views known to the view manager
    * @return     A list of all view names
    */
-  def list(): List[String] =
+  def list(): Seq[String] =
   {
     db.metadataBackend.
       resultRows(s"SELECT name FROM $viewTable").
       flatten.
       map( _.asString ).
-      toList
+      toSeq
   }
 
   /**
@@ -222,11 +222,9 @@ class ViewManager(db:Database) extends LazyLogging {
    */
   def listViewsQuery: Operator = 
   {
-    Project(
-      Seq(
-        ProjectArg("TABLE_NAME", Var("NAME"))
-      ),
-      db.metadataTable(viewTable)
+    HardTable(
+      Seq( ("TABLE_NAME", TString()) ),
+      list().map { StringPrimitive(_) }.map { Seq(_) }
     )
   }
 


### PR DESCRIPTION
* Added a specialized "DataWarning" operator as per today's discussion
* TypeInference now uses DataWarning to annotate Casting errors (as opposed to requiring a MissingValue lens)
* A handful of minor bugfixes and quality of life improvements for command-line mimir users.
   * LensManager now uploads its views as a HardTable rather than as a query redirected to its children (`SELECT * FROM [SYS_TABLES`)
   * `EXPLAIN _` now dumps out the spark plan (if applicable)
   * Slightly more friendly output for `ANALYZE _` over warnings
   * `LOAD TABLE` no longer freaks out if a format is not specified.
   * Mimir now tries a little harder to interpret files it gets on the command line