### PR TITLE
Bugfixes

### DIFF
--- a/src/main/scala/mimir/adaptive/TypeInference.scala
+++ b/src/main/scala/mimir/adaptive/TypeInference.scala
@@ -123,9 +123,9 @@ object TypeInference
       val columnIndexes = model.columns.zipWithIndex.toMap
       Some(Project(
         config.query.columnNames.map { colName => {
-          val bestGuessType = model.bestGuess(0, Seq(IntPrimitive(columnIndexes(colName))), Seq())
           ProjectArg(colName, 
             if(columnIndexes contains colName){ 
+              val bestGuessType = model.bestGuess(0, Seq(IntPrimitive(columnIndexes(colName))), Seq())
               val castExpression = Function("CAST", Seq(
                   Var(colName),
                   bestGuessType

--- a/src/main/scala/mimir/algebra/Expression.scala
+++ b/src/main/scala/mimir/algebra/Expression.scala
@@ -373,6 +373,11 @@ abstract sealed class PrimitiveValue(t: Type)
    * return the contents of the variable as just an object.
    */
   def payload: Object;
+  /**
+   * Execute the nested expression only if the value is not null.  Otherwise
+   * return null
+   */
+  def ifNotNull(cmd: (PrimitiveValue => PrimitiveValue)) = cmd(this)
 }
 
 abstract sealed class NumericPrimitive(t: Type) extends PrimitiveValue(t)
@@ -559,6 +564,7 @@ case class NullPrimitive()
   def asDateTime: DateTime = throw new NullTypeException(TAny(), TDate(), "Hard Cast")
   def asInterval: Period = throw new TypeException(TAny(), TInterval(), "Hard Cast")
   def payload: Object = null
+  override def ifNotNull(cmd: (PrimitiveValue => PrimitiveValue)) = this
 }
 
 

--- a/src/main/scala/mimir/algebra/ExpressionUtils.scala
+++ b/src/main/scala/mimir/algebra/ExpressionUtils.scala
@@ -259,7 +259,7 @@ object ExpressionUtils {
     e match {
       case BoolPrimitive(false) => List[Expression]()
       case Arithmetic(Arith.Or, a, b) => 
-        getConjuncts(a) ++ getConjuncts(b)
+        getDisjuncts(a) ++ getDisjuncts(b)
       case _ => List(e)
     }
   }

--- a/src/main/scala/mimir/ctables/CTExplainer.scala
+++ b/src/main/scala/mimir/ctables/CTExplainer.scala
@@ -281,7 +281,10 @@ class CTExplainer(db: Database) extends LazyLogging {
 				new DataWarningReason(
 					db.models.get(name),
 					db.interpreter.eval(InlineVGTerms(value, db), tuple),
-					db.interpreter.eval(InlineVGTerms(value, db), tuple).asString,
+					db.interpreter.eval(InlineVGTerms(value, db), tuple) match {
+						case NullPrimitive() => s"Error reading warning ($name(${key.mkString(",")}))"
+						case message => message.asString
+					},
 					key.map { arg => 
 						db.interpreter.eval(InlineVGTerms(arg, db),tuple)
 					}

--- a/src/main/scala/mimir/exec/result/LazyRow.scala
+++ b/src/main/scala/mimir/exec/result/LazyRow.scala
@@ -13,7 +13,15 @@ case class LazyRow(
   def tuple: Seq[PrimitiveValue] = 
     tupleDefinition.map { _(input) }
   def apply(idx: Int): PrimitiveValue = 
-    tupleDefinition(idx)(input)
+  {
+    try { tupleDefinition(idx)(input) }
+    catch { case e:Throwable => 
+      throw new RuntimeException(
+        s"Error Decoding ${tupleSchema(idx)._1} (${tupleSchema(idx)._2})",
+        e
+      )
+    }
+  }
   def annotation(name: String): PrimitiveValue = 
     annotation(annotationIndexes(name))
   def annotation(idx: Int): PrimitiveValue = 

--- a/src/main/scala/mimir/parser/ExpressionParser.scala
+++ b/src/main/scala/mimir/parser/ExpressionParser.scala
@@ -42,10 +42,10 @@ object ExpressionParser extends RegexParsers {
 		| arith ~ cmpSym ~ arith ^^ { 
 				case lhs ~ op ~ rhs => Comparison(op, lhs, rhs)
 			}
-		| arith ~ "AND" ~ arith ^^ {
+		| arith ~ "AND" ~ boolExpr ^^ {
 				case lhs ~ _ ~ rhs => Arithmetic(Arith.And, lhs, rhs)
 			}
-		| arith ~ "OR" ~ arith ^^ {
+		| arith ~ "OR" ~ boolExpr ^^ {
 				case lhs ~ _ ~ rhs => Arithmetic(Arith.Or, lhs, rhs)
 			}
 		| "NOT(" ~> arith <~ ")" ^^ { Not(_) }

--- a/src/main/scala/mimir/util/SparkUtils.scala
+++ b/src/main/scala/mimir/util/SparkUtils.scala
@@ -26,7 +26,7 @@ object SparkUtils {
     }
     
     t match {
-      case TAny() =>        if(ExperimentalOptions.isEnabled("XNULL")) (r) => NullPrimitive() else throw new SQLException(s"Can't extract TAny: $field")
+      case TAny() =>        if(ExperimentalOptions.isEnabled("XNULL")) { (r) => NullPrimitive() } else throw new SQLException(s"Can't extract TAny: $field")
       case TFloat() =>      (r) => checkNull(r, FloatPrimitive(r.getDouble(field)))
       case TInt() =>        (r) => checkNull(r, { 
         try {

--- a/src/test/scala/mimir/parser/ExpressionParserSpec.scala
+++ b/src/test/scala/mimir/parser/ExpressionParserSpec.scala
@@ -1,0 +1,38 @@
+package mimir.parser
+
+import org.specs2.mutable._
+
+import mimir.algebra._
+
+class ExpressionParserSpec extends Specification
+{
+
+  "ExpressionUtils (in possibly related matters)" >> 
+  {
+    "Extract from sequences of ORs" >> {
+      ExpressionUtils.getDisjuncts(
+        Var("A").or(
+          Var("B").or(
+            Var("C")
+          )
+        )
+      ) must contain(allOf[Expression](Var("A"), Var("B"), Var("C")))
+    }
+  }
+
+  "The Expression Parser" >> 
+  {
+    "Handle sequences of ORs" >> {
+      ExpressionUtils.getDisjuncts(
+        ExpressionParser.expr("(A) OR (B) OR (C)") 
+      ) must contain(allOf[Expression](Var("A"), Var("B"), Var("C")))
+    }
+    "Handle sequences of ANDs" >> {
+      ExpressionUtils.getConjuncts(
+        ExpressionParser.expr("(A) AND (B) AND (C)") 
+      ) must contain(allOf[Expression](Var("A"), Var("B"), Var("C")))
+    }
+
+  }
+
+}


### PR DESCRIPTION
- Warnings exposed a bug in EvalInlined's handling of IS NULL when the null test was
  applied to a conditional.  EvalInlined now behaves properly.
- Fixed a bug in the type inference lens when not all columns were String-typed
- CTExplainer no longer barfs if it can't materialize an error string for data warnings
- Made ReasonSets for warnings a little more robust
- CTAnalyzer.sampleExpression now handles DataWarnings properly
- CTAnalyzer classes now special-case UncertaintyCausingExpression and should throw an warning later on if we add new expression types.