### PR TITLE
Mimir vizier without sql parser

### DIFF
--- a/src/main/scala/mimir/MimirVizier.scala
+++ b/src/main/scala/mimir/MimirVizier.scala
@@ -396,39 +396,54 @@ object MimirVizier extends LazyLogging {
     pythonCallThread = Thread.currentThread()
     val timeRes = logTime("createLens") {
       logger.debug("createLens: From Vistrails: [" + input + "] [" + params.mkString(",") + "] [" + _type + "]"  ) ;
-      val paramsStr = params.mkString(",").replaceAll("\\{\\{\\s*input\\s*\\}\\}", input.toString) 
-      val lensName = "LENS_" + _type + ((input.toString() + _type + paramsStr + make_input_certain + materialize).hashCode().toString().replace("-", "") )
-      var query:String = null
-      db.getView(lensName) match {
-        case None => {
-          if(make_input_certain){
-            val materializedInput = "MATERIALIZED_"+input
-            query = s"CREATE LENS ${lensName} AS SELECT * FROM ${materializedInput} WITH ${_type}(${paramsStr})"  
-            if(db.getAllTables().contains(materializedInput)){
-                logger.debug("createLens: From Vistrails: Materialized Input Already Exists: " + materializedInput)
-            }
-            else{  
-              val inputQuery = s"SELECT * FROM ${input}"
-              val oper = db.sql.convert(db.parse(inputQuery).head.asInstanceOf[Select])
-              db.selectInto(materializedInput, oper)
-            }
+      // val paramsStr = params.mkString(",").replaceAll("\\{\\{\\s*input\\s*\\}\\}", input.toString) 
+      val lensNameBase = (input.toString() + _type + paramsStr + make_input_certain + materialize).hashCode()
+      val inputQuery = s"SELECT * FROM ${input}"
+
+      val lensName = ("LENS_" + _type + (lensNameBase.toString().replace("-", ""))).toUpperCase()
+      val lensType = _type.toUpperCase()
+      val parsedParams = params.map { ExpressionParser.expr(_) }
+
+      if(db.tableExists(lensName)) {
+        logger.debug("createLens: From Vistrails: Lens (or Table) already exists: " + lensName)
+        // (Should be) safe to fall through since we might still be getting asked to materialize 
+        // the table.
+      } else {
+        // Need to create the lens if it doesn't already exist.
+
+        val inputSQL = db.parse(s"SELECT * FROM $input").head
+        // query is a var because we might need to rewrite it below.
+        var query:Operator = db.sql.convert(inputSQL)
+
+        // "Make Certain" is implemented by dumping the lens contents into a temporary table
+        if(make_input_certain){
+          val materializedInput = "MATERIALIZED_"+input
+          val querySchema = db.typechecker.schemaOf(query)
+
+          if(db.tableExists(materializedInput)){
+            logger.debug("createLens: From Vistrails: Materialized Input Already Exists: " + materializedInput)
+          } else {
+            // Dump the query into a table if necessary 
+            db.selectInto(materializedInput, query)
           }
-          else{
-            val inputQuery = s"SELECT * FROM ${input}"
-            query = s"CREATE LENS ${lensName} AS $inputQuery WITH ${_type}(${paramsStr})"  
-          }
-          logger.debug("createLens: query: " + query)
-          db.update(db.parse(query).head) 
+
+          // And override the default lens input with the table.
+          query = db.table(materializedInput)
         }
-        case Some(_) => {
-          logger.debug("createLens: From Vistrails: Lens already exists: " + lensName)
-        }
+
+        // Regardless of where we're reading from, next we need to run: 
+        //   CREATE LENS ${lensName} 
+        //            AS $query 
+        //          WITH ${_type}( ${params.mkString(",")} )
+        // Skip the parser and do what Mimir does internally
+        db.lenses.create(lensType, lensName, query, params)
       }
       if(materialize){
-        if(!db.views(lensName).isMaterialized)
-          db.update(db.parse(s"ALTER VIEW ${lensName} MATERIALIZE").head)
+        if(!db.views(lensName).isMaterialized){
+          db.views.materialize(lensName)
+        }
       }
-      val lensOp = parseQuery(s"SELECT * FROM $lensName LIMIT 200")
+      val lensOp = db.table(lensName).limit(200)
       val lensAnnotations = db.explainer.explainSubsetWithoutOptimizing(lensOp, lensOp.columnNames.toSet, false, false, false, Some(lensName))
       val lensReasons = lensAnnotations.map(_.size(db)).sum.toString//JSONBuilder.list(lensAnnotations.map(_.all(db).toList).flatten.map(_.toJSON))
       logger.debug(s"createLens reasons for first 200 rows: ${lensReasons}")

--- a/src/test/scala/mimir/MimirVizierSpec.scala
+++ b/src/test/scala/mimir/MimirVizierSpec.scala
@@ -1,0 +1,74 @@
+package mimir
+
+import java.io._
+import scala.sys.process.Process
+
+
+import org.specs2.mutable._
+import org.specs2.specification._
+
+import mimir.sql._
+
+class MimirVizierSpec 
+  extends Specification
+  with BeforeAll
+{
+
+  def beforeAll = {
+    val dbFileName = "MimirVizierSpec.db"
+
+    val args = Seq(
+      "--db", dbFileName
+    )
+    Mimir.conf = new MimirConfig(args);
+    val database = Mimir.conf.dbname().split("[\\\\/]").last.replaceAll("\\..*", "")
+    val sback = new SparkBackend(database)
+    MimirVizier.db = new Database(sback, new JDBCMetadataBackend(Mimir.conf.backend(), Mimir.conf.dbname()))
+    MimirVizier.db.metadataBackend.open()
+    MimirVizier.db.backend.open()
+    val otherExcludeFuncs = Seq("NOT","AND","!","%","&","*","+","-","/","<","<=","<=>","=","==",">",">=","^","|","OR")
+    sback.registerSparkFunctions(MimirVizier.db.functions.functionPrototypes.map(el => el._1).toSeq ++ otherExcludeFuncs , MimirVizier.db.functions)
+    sback.registerSparkAggregates(MimirVizier.db.aggregates.prototypes.map(el => el._1).toSeq, MimirVizier.db.aggregates)
+    MimirVizier.vizierdb.sparkSession = sback.sparkSql.sparkSession
+    MimirVizier.db.initializeDBForMimir()
+
+    if(!MimirVizier.db.tableExists("CPUSPEED")){
+      MimirVizier.db.loadTable(
+        "CPUSPEED",
+        new File("test/data/CPUSpeed.csv"), 
+        force = true,
+        format = ("CSV", Seq())
+      )
+    }
+  }
+
+  "MimirVizier" should {
+
+    "be set up properly" >> { 
+      MimirVizier.db.tableExists("CPUSPEED") must beTrue
+      MimirVizier.db.tableExists("NOT_A_TABLE") must beFalse
+
+      val schema = MimirVizier.db.tableSchema("CPUSPEED") 
+      schema must not be(None) 
+      schema.get.map { _._1 } must contain("BUS_SPEED_MHZ")
+    }
+
+    "create missing value lenses properly" >> { 
+      if(MimirVizier.db.tableExists("CPUSPEED_MISSING")){
+        MimirVizier.db.lenses.drop("CPUSPEED_MISSING")
+      }
+      MimirVizier.db.tableExists("CPUSPEED_MISSING") must beFalse
+      val response = MimirVizier.createLens(
+        "CPUSPEED",
+        Seq("BUS_SPEED_MHZ"),
+        "MISSING_VALUE",
+        false,
+        false
+      )
+      MimirVizier.db.query(
+        MimirVizier.db.table(response.lensName).limit(1)
+      ) { response => response.toSeq } must not beEmpty
+    }
+
+  }
+}


### PR DESCRIPTION
MimirVizier no longer relies on SQLParser for parsing CREATE LENS statements. 
* ExpressionParser is used for lens parameters
* All other parts of the lens are used directly