### PR TITLE
Error list performance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,12 @@ fork := true
 outputStrategy in run := Some(StdoutOutput)
 connectInput in run := true
 cancelable in Global := true
-javaOptions ++= Seq("-Dcom.github.fommil.netlib.BLAS=com.github.fommil.netlib.F2jBLAS", "-Dcom.github.fommil.netlib.LAPACK=com.github.fommil.netlib.F2jLAPACK", "-Dcom.github.fommil.netlib.ARPACK=com.github.fommil.netlib.F2jARPACK")
+javaOptions ++= Seq(
+  "-Dcom.github.fommil.netlib.BLAS=com.github.fommil.netlib.F2jBLAS", 
+  "-Dcom.github.fommil.netlib.LAPACK=com.github.fommil.netlib.F2jLAPACK", 
+  "-Dcom.github.fommil.netlib.ARPACK=com.github.fommil.netlib.F2jARPACK"
+  // ,"-agentlib:jdwp=transport=dt_shmem,address=jdbconn,server=y,suspend=n"
+)
 scalacOptions in Test ++= Seq("-Yrangepos")
 parallelExecution in Test := false
 testOptions in Test ++= Seq( Tests.Argument("junitxml"), Tests.Argument("console") )

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -14,6 +14,13 @@
   <logger name="mimir.util.PythonProcess$" level="ERROR"/>
   <logger name="mimir.plot.Plot$" level="ERROR"/>
   <logger name="mimir.models.SeriesMissingValueModel$" level="ERROR"/>
+  
+  <logger name="mimir.ctables.AnalyzeUncertainty" level="ERROR"/>
+  <logger name="mimir.MimirVizier$" level="ERROR"/>
+  <logger name="mimir.exec.Compiler" level="ERROR"/>
+  <logger name="mimir.exec.mode.BestGuess$" level="ERROR"/>
+  <logger name="mimir.exec.mode.UnannotatedBestGuess$" level="ERROR"/>
+  <logger name="mimir.optimizer.Optimizer$" level="ERROR"/>
 
   <logger name="org.apache.hadoop.util.Shell" level="OFF"/>
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -16,7 +16,7 @@
   <logger name="mimir.models.SeriesMissingValueModel$" level="ERROR"/>
   
   <logger name="mimir.ctables.AnalyzeUncertainty" level="ERROR"/>
-  <logger name="mimir.MimirVizier$" level="ERROR"/>
+  <logger name="mimir.MimirVizier$" level="TRACE"/>
   <logger name="mimir.exec.Compiler" level="ERROR"/>
   <logger name="mimir.exec.mode.BestGuess$" level="ERROR"/>
   <logger name="mimir.exec.mode.UnannotatedBestGuess$" level="ERROR"/>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -21,6 +21,7 @@
   <logger name="mimir.exec.mode.BestGuess$" level="ERROR"/>
   <logger name="mimir.exec.mode.UnannotatedBestGuess$" level="ERROR"/>
   <logger name="mimir.optimizer.Optimizer$" level="ERROR"/>
+  <logger name="mimir.ctables.ReasonSet$" level="ERROR"/>
 
   <logger name="org.apache.hadoop.util.Shell" level="OFF"/>
 

--- a/src/main/scala/mimir/Database.scala
+++ b/src/main/scala/mimir/Database.scala
@@ -460,7 +460,8 @@ case class Database(backend: QueryBackend, metadata: MetadataBackend)
     inferTypes: Option[Boolean] = None,
     detectHeaders: Option[Boolean] = None,
     format: ID = ID("csv"),
-    loadOptions: Map[String, String] = Map()
+    loadOptions: Map[String, String] = Map(),
+    humanReadableName: Option[String] = None
   ){
     // Pick a sane table name if necessary
     val realTargetTable = targetTable.getOrElse(fileToTableName(sourceFile))
@@ -491,18 +492,18 @@ case class Database(backend: QueryBackend, metadata: MetadataBackend)
       //detect headers 
       if(datasourceErrors) {
         val dseSchemaName = realTargetTable.withSuffix("_DSE")
-        adaptiveSchemas.create(dseSchemaName, ID("DATASOURCE_ERRORS"), oper, Seq(), realTargetTable.id)
+        adaptiveSchemas.create(dseSchemaName, ID("DATASOURCE_ERRORS"), oper, Seq(), humanReadableName.getOrElse(realTargetTable.id))
         oper = adaptiveSchemas.viewFor(dseSchemaName, ID("DATA")).get
       }
       if(detectHeaders.getOrElse(targetSchema.isEmpty)) {
         val dhSchemaName = realTargetTable.withSuffix("_DH")
-        adaptiveSchemas.create(dhSchemaName, ID("DETECT_HEADER"), oper, Seq(), realTargetTable.id)
+        adaptiveSchemas.create(dhSchemaName, ID("DETECT_HEADER"), oper, Seq(), humanReadableName.getOrElse(realTargetTable.id))
         oper = adaptiveSchemas.viewFor(dhSchemaName, ID("DATA")).get
       }
       //type inference
       if(inferTypes.getOrElse(true)){
         val tiSchemaName = realTargetTable.withSuffix("_TI")
-        adaptiveSchemas.create(tiSchemaName, ID("TYPE_INFERENCE"), oper, Seq(FloatPrimitive(.5)), realTargetTable.id) 
+        adaptiveSchemas.create(tiSchemaName, ID("TYPE_INFERENCE"), oper, Seq(FloatPrimitive(.5)), humanReadableName.getOrElse(realTargetTable.id)) 
         oper = adaptiveSchemas.viewFor(tiSchemaName, ID("DATA")).get
       }
       //finally create a view for the data

--- a/src/main/scala/mimir/Database.scala
+++ b/src/main/scala/mimir/Database.scala
@@ -344,7 +344,8 @@ case class Database(backend: QueryBackend, metadata: MetadataBackend)
           ID.upper(create.name),
           ID.upper(create.schemaType),
           sqlToRA(create.body),
-          create.args.map( sqlToRA(_, sqlToRA.literalBindings(_)) )
+          create.args.map( sqlToRA(_, sqlToRA.literalBindings(_)) ),
+          create.humanReadableName
         )
       }
 
@@ -490,18 +491,18 @@ case class Database(backend: QueryBackend, metadata: MetadataBackend)
       //detect headers 
       if(datasourceErrors) {
         val dseSchemaName = realTargetTable.withSuffix("_DSE")
-        adaptiveSchemas.create(dseSchemaName, ID("DATASOURCE_ERRORS"), oper, Seq())
+        adaptiveSchemas.create(dseSchemaName, ID("DATASOURCE_ERRORS"), oper, Seq(), realTargetTable.id)
         oper = adaptiveSchemas.viewFor(dseSchemaName, ID("DATA")).get
       }
       if(detectHeaders.getOrElse(targetSchema.isEmpty)) {
         val dhSchemaName = realTargetTable.withSuffix("_DH")
-        adaptiveSchemas.create(dhSchemaName, ID("DETECT_HEADER"), oper, Seq())
+        adaptiveSchemas.create(dhSchemaName, ID("DETECT_HEADER"), oper, Seq(), realTargetTable.id)
         oper = adaptiveSchemas.viewFor(dhSchemaName, ID("DATA")).get
       }
       //type inference
       if(inferTypes.getOrElse(true)){
         val tiSchemaName = realTargetTable.withSuffix("_TI")
-        adaptiveSchemas.create(tiSchemaName, ID("TYPE_INFERENCE"), oper, Seq(FloatPrimitive(.5))) 
+        adaptiveSchemas.create(tiSchemaName, ID("TYPE_INFERENCE"), oper, Seq(FloatPrimitive(.5)), realTargetTable.id) 
         oper = adaptiveSchemas.viewFor(tiSchemaName, ID("DATA")).get
       }
       //finally create a view for the data

--- a/src/main/scala/mimir/MimirVizier.scala
+++ b/src/main/scala/mimir/MimirVizier.scala
@@ -280,7 +280,7 @@ object MimirVizier extends LazyLogging {
           detectHeaders = Some(detectHeaders), 
           loadOptions = bkOpts.toMap, 
           format = ID(format),
-          humanReadableName = Some(csvFile)
+          humanReadableName = humanReadableName
         )
       }
       tableName 

--- a/src/main/scala/mimir/MimirVizier.scala
+++ b/src/main/scala/mimir/MimirVizier.scala
@@ -899,6 +899,7 @@ def vistrailsQueryMimirJson(query : String, includeUncertainty:Boolean, includeR
     logger.debug("explainEverything: From Vistrails: [" + query + "]"  ) ;
     val oper = db.sqlToRA(MimirSQL.Select(query))
     explainEverything(oper).map(/*_.all(db).toList*/rset => {
+        logger.trace(s"Explaining everything for $rset")
         val subReasons = rset.take(db, 4).toSeq
   			if(subReasons.size > 3){
   				logger.trace("   -> Too many explanations to fit in one group")

--- a/src/main/scala/mimir/MimirVizier.scala
+++ b/src/main/scala/mimir/MimirVizier.scala
@@ -480,7 +480,7 @@ val df = db.backend.execute(db.compileBestGuess(db.table(viewName)))
       val asViewName = ID("VIEW_"+adaptiveSchemaName)
       db.getView(adaptiveSchemaName) match {
         case None => {
-          db.adaptiveSchemas.create(adaptiveSchemaName, ID(_type), db.table(ID(input.toString)), paramExprs)
+          db.adaptiveSchemas.create(adaptiveSchemaName, ID(_type), db.table(ID(input.toString)), paramExprs, input.toString)
           val asTable = _type match {
             case "SHAPE_WATCHER" => adaptiveSchemaName
             case _ => ID("DATA")

--- a/src/main/scala/mimir/adaptive/AdaptiveSchemaManager.scala
+++ b/src/main/scala/mimir/adaptive/AdaptiveSchemaManager.scala
@@ -7,7 +7,7 @@ import mimir.algebra._
 import mimir.statistics.SystemCatalog
 import mimir.serialization._
 import mimir.util._
-import mimir.metadata.MetadataMap
+import mimir.metadata._
 import com.typesafe.scalalogging.slf4j.LazyLogging
 
 class AdaptiveSchemaManager(db: Database)
@@ -18,11 +18,11 @@ class AdaptiveSchemaManager(db: Database)
   def init(): Unit = 
   {
     adaptiveSchemas = db.metadata.registerMap(
-      ID("MIMIR_ADAPTIVE_SCHEMAS"), Seq(
+      ID("MIMIR_ADAPTIVE_SCHEMAS"), Seq(InitMap(Seq(
         ID("MLENS") -> TString(),
         ID("QUERY") -> TString(),
         ID("ARGS")  -> TString()
-    ))
+    ))))
   }
 
   def create(schema: ID, mlensType: ID, query: Operator, args: Seq[Expression]) = 

--- a/src/main/scala/mimir/adaptive/AdaptiveSchemaManager.scala
+++ b/src/main/scala/mimir/adaptive/AdaptiveSchemaManager.scala
@@ -18,14 +18,17 @@ class AdaptiveSchemaManager(db: Database)
   def init(): Unit = 
   {
     adaptiveSchemas = db.metadata.registerMap(
-      ID("MIMIR_ADAPTIVE_SCHEMAS"), Seq(InitMap(Seq(
-        ID("MLENS") -> TString(),
-        ID("QUERY") -> TString(),
-        ID("ARGS")  -> TString()
-    ))))
+      ID("MIMIR_ADAPTIVE_SCHEMAS"), Seq(
+        InitMap(Seq(
+          ID("MLENS") -> TString(),
+          ID("QUERY") -> TString(),
+          ID("ARGS")  -> TString()
+        )),
+        AddColumnToMap(ID("FRIENDLY_NAME"), TString(), None)
+    ))
   }
 
-  def create(schema: ID, mlensType: ID, query: Operator, args: Seq[Expression]) = 
+  def create(schema: ID, mlensType: ID, query: Operator, args: Seq[Expression], humanReadableName: String) = 
   {
     val constructor:Multilens = MultilensRegistry.multilenses(mlensType)
     val config = MultilensConfig(schema, query, args);
@@ -36,7 +39,8 @@ class AdaptiveSchemaManager(db: Database)
     adaptiveSchemas.put(schema, Seq(
       StringPrimitive(mlensType.id),
       StringPrimitive(Json.ofOperator(query).toString),
-      StringPrimitive(Json.ofExpressionList(args).toString)
+      StringPrimitive(Json.ofExpressionList(args).toString),
+      StringPrimitive(humanReadableName)
     ))
 
     // Persist the associated models

--- a/src/main/scala/mimir/adaptive/AdaptiveSchemaManager.scala
+++ b/src/main/scala/mimir/adaptive/AdaptiveSchemaManager.scala
@@ -31,7 +31,7 @@ class AdaptiveSchemaManager(db: Database)
   def create(schema: ID, mlensType: ID, query: Operator, args: Seq[Expression], humanReadableName: String) = 
   {
     val constructor:Multilens = MultilensRegistry.multilenses(mlensType)
-    val config = MultilensConfig(schema, query, args);
+    val config = MultilensConfig(schema, query, args, humanReadableName);
     val models = constructor.initSchema(db, config);
     
     logger.trace(s"Creating view $schema <- $mlensType(${args.mkString(", ")}")
@@ -57,18 +57,19 @@ class AdaptiveSchemaManager(db: Database)
   }
 
   def lensForRecord(record: (ID, Seq[PrimitiveValue])) =
-    record match {
-      case (name, content) => 
-        val mlensType = content(0).asString
-        val query = Json.toOperator(Json.parse(content(1).asString))
-        val args:Seq[Expression] = 
-          Json.toExpressionList(Json.parse(content(2).asString))
-   
-        ( 
-          MultilensRegistry.multilenses(ID(mlensType)), 
-          MultilensConfig(ID(name.asString), query, args)
-        )
-    }
+  {
+    val (name, content) = record
+    val mlensType = content(0).asString
+    val query = Json.toOperator(Json.parse(content(1).asString))
+    val args:Seq[Expression] = 
+      Json.toExpressionList(Json.parse(content(2).asString))
+    val humanReadableName = content(3).asString
+
+    ( 
+      MultilensRegistry.multilenses(ID(mlensType)), 
+      MultilensConfig(ID(name.asString), query, args, humanReadableName)
+    )
+  }
 
   def all: TraversableOnce[(Multilens, MultilensConfig)] =
   {

--- a/src/main/scala/mimir/adaptive/CheckHeader.scala
+++ b/src/main/scala/mimir/adaptive/CheckHeader.scala
@@ -26,7 +26,7 @@ object CheckHeader
     val detectmodel = 
       new DetectHeaderModel(
         modelName, 
-        viewName, 
+        config.humanReadableName, 
         config.query.columnNames, 
         db.query(Limit(0,Some(6),config.query))(_.toList.map(_.tuple)).toSeq
       )

--- a/src/main/scala/mimir/adaptive/DataSourceErrors.scala
+++ b/src/main/scala/mimir/adaptive/DataSourceErrors.scala
@@ -94,7 +94,7 @@ object DataSourceErrors
                   Conditional(IsNullExpression(Var(colName)),StringPrimitive("NULL"),Var(colName)),
                   StringPrimitive(" ] is uncertain because there is an error(s) in the data source on row "),
                   RowIdVar(),
-                  StringPrimitive(". The raw value of the row in the data source is [ "),
+                  StringPrimitive(" of ${config.humanReadableName}. The raw value of the row in the data source is [ "),
                   Var(mimirDataSourceErrorRowColumn),
                   StringPrimitive(" ]")
                 ),

--- a/src/main/scala/mimir/adaptive/Multilens.scala
+++ b/src/main/scala/mimir/adaptive/Multilens.scala
@@ -4,7 +4,7 @@ import mimir.Database
 import mimir.algebra._
 import mimir.models._
 
-case class MultilensConfig(schema: ID, query: Operator, args: Seq[Expression])
+case class MultilensConfig(schema: ID, query: Operator, args: Seq[Expression], humanReadableName: String)
 {
   override def toString: String =
     s"CONFIG FOR $schema(${args.mkString(", ")})"

--- a/src/main/scala/mimir/adaptive/TypeInference.scala
+++ b/src/main/scala/mimir/adaptive/TypeInference.scala
@@ -124,7 +124,7 @@ object TypeInference
       val model = db.models.get(ID("MIMIR_TI_ATTR_",config.schema)).asInstanceOf[TypeInferenceModel]
       val columnIndexes = model.columns.zipWithIndex.toMap
       Some(Project(
-        config.query.columnNames.map { colName => {
+        config.query.columnNames.zipWithIndex.map { case (colName, colIdx) => {
           ProjectArg(colName, 
             if(columnIndexes contains colName){ 
               val bestGuessType = model.bestGuess(0, Seq(IntPrimitive(columnIndexes(colName))), Seq())
@@ -141,9 +141,11 @@ object TypeInference
                       StringPrimitive("Couldn't Cast [ "),
                       Var(colName),
                       StringPrimitive(" ] to "+bestGuessType+" on row "),
-                      RowIdVar()
+                      RowIdVar(),
+                      StringPrimitive(s" of ${config.humanReadableName}.")
                     ),
-                    Seq(StringPrimitive(colName.id), Var(colName), StringPrimitive(bestGuessType.toString), RowIdVar())
+                    Seq(StringPrimitive(colName.id), Var(colName), StringPrimitive(bestGuessType.toString), RowIdVar()),
+                    colIdx
                   ),
                   castExpression
                 )

--- a/src/main/scala/mimir/adaptive/TypeInference.scala
+++ b/src/main/scala/mimir/adaptive/TypeInference.scala
@@ -124,7 +124,7 @@ object TypeInference
       val model = db.models.get(ID("MIMIR_TI_ATTR_",config.schema)).asInstanceOf[TypeInferenceModel]
       val columnIndexes = model.columns.zipWithIndex.toMap
       Some(Project(
-        config.query.columnNames.zipWithIndex.map { case (colName, colIdx) => {
+        config.query.columnNames.zipWithIndex.map { case (colName, colPosition) => {
           ProjectArg(colName, 
             if(columnIndexes contains colName){ 
               val bestGuessType = model.bestGuess(0, Seq(IntPrimitive(columnIndexes(colName))), Seq())
@@ -145,7 +145,7 @@ object TypeInference
                       StringPrimitive(s" of ${config.humanReadableName}.")
                     ),
                     Seq(StringPrimitive(colName.id), Var(colName), StringPrimitive(bestGuessType.toString), RowIdVar()),
-                    colIdx
+                    colPosition
                   ),
                   castExpression
                 )

--- a/src/main/scala/mimir/adaptive/TypeInference.scala
+++ b/src/main/scala/mimir/adaptive/TypeInference.scala
@@ -47,6 +47,7 @@ object TypeInference
     val attributeTypeModel = 
       new TypeInferenceModel(
         viewName.withPrefix("MIMIR_TI_ATTR_"),
+        config.humanReadableName,
         modelColumns,
         stringDefaultScore,
         db.backend.asInstanceOf[BackendWithSparkContext].getSparkContext(),

--- a/src/main/scala/mimir/algebra/Expression.scala
+++ b/src/main/scala/mimir/algebra/Expression.scala
@@ -670,6 +670,6 @@ case class DataWarning(
   override def toString() = s"($name(${(key :+ message).mkString(", ")}))@($value)"
   override def children: Seq[Expression] = Seq(value, message) ++ key
   override def rebuild(x: Seq[Expression]) = {
-    DataWarning(name, x(0), x(1), x.tail.tail)
+    DataWarning(name, x(0), x(1), x.tail.tail, index)
   }
 }

--- a/src/main/scala/mimir/algebra/Expression.scala
+++ b/src/main/scala/mimir/algebra/Expression.scala
@@ -664,7 +664,8 @@ case class DataWarning(
   name: ID,
   value: Expression,
   message: Expression, 
-  key: Seq[Expression]
+  key: Seq[Expression],
+  index: Int = 0
 ) extends UncertaintyCausingExpression {
   override def toString() = s"($name(${(key :+ message).mkString(", ")}))@($value)"
   override def children: Seq[Expression] = Seq(value, message) ++ key

--- a/src/main/scala/mimir/algebra/Typechecker.scala
+++ b/src/main/scala/mimir/algebra/Typechecker.scala
@@ -152,7 +152,7 @@ class Typechecker(
 						registry.get(model).varType(idx, args.map(recur(_)))
 					case None => throw new RAException("Need Model Manager to typecheck expressions with VGTerms")
 				}
-			case DataWarning(_, v, _, _) => recur(v)
+			case DataWarning(_, v, _, _, _) => recur(v)
     }
   }
 

--- a/src/main/scala/mimir/algebra/spark/OperatorTranslation.scala
+++ b/src/main/scala/mimir/algebra/spark/OperatorTranslation.scala
@@ -584,7 +584,7 @@ UnresolvedAttribute("ROWID")
         BestGuessUDF(oper, model, idx, args.map(arg => mimirExprToSparkExpr(oper,arg)), hints.map(hint => mimirExprToSparkExpr(oper,hint))).getUDF
         //UnresolvedFunction(mimir.ctables.CTables.FN_BEST_GUESS, mimirExprToSparkExpr(oper,StringPrimitive(name)) +: mimirExprToSparkExpr(oper,IntPrimitive(idx)) +: (args.map(mimirExprToSparkExpr(oper,_)) ++ hints.map(mimirExprToSparkExpr(oper,_))), true )
       }
-      case DataWarning(_, v, _, _) => {
+      case DataWarning(_, v, _, _, _) => {
         mimirExprToSparkExpr(oper, v)
       }
       case IsNullExpression(iexpr) => {

--- a/src/main/scala/mimir/api/MimirAPI.scala
+++ b/src/main/scala/mimir/api/MimirAPI.scala
@@ -25,9 +25,10 @@ import play.api.libs.json._
 object MimirAPI extends LazyLogging {
   
   var isRunning = true
+  val DEFAULT_API_PORT = 8089
   
-  def runAPIServerForViztrails() : Unit = {
-    val server = new Server(8089)
+  def runAPIServerForViztrails(port: Int = DEFAULT_API_PORT) : Unit = {
+    val server = new Server(port)
     val http_config = new HttpConfiguration();
     server.addConnector(new ServerConnector( server,  new HttpConnectionFactory(http_config)) );
     
@@ -52,7 +53,7 @@ object MimirAPI extends LazyLogging {
     server.setHandler(handlerList);
     server.start()
      
-    println("Mimir API Server Started...")
+    println(s"Mimir API Server Started on http://localhost:$port/...")
      while(isRunning){
        Thread.sleep(90000)
        

--- a/src/main/scala/mimir/api/Request.scala
+++ b/src/main/scala/mimir/api/Request.scala
@@ -221,9 +221,21 @@ case class ExplainEverythingAllRequest (
                   query: String
 ) extends Request {
   def handle(os:OutputStream) = {
-    os.write(Json.stringify(Json.toJson(ExplainReasonsResponse(MimirVizier.explainEverythingAll(query).map(rsn => 
-      Reason(rsn.reason, rsn.model.name.toString, rsn.idx, rsn.args.map(_.toString()), mimir.api.Repair(rsn.repair.toJSON), rsn.repair.exampleString)
-    )))).getBytes )
+    os.write(Json.stringify(Json.toJson(
+      ExplainReasonsResponse(
+        MimirVizier.explainEverythingAll(query).map { 
+          rsn => 
+            Reason(
+              rsn.reason, 
+              rsn.model.name.toString, 
+              rsn.idx, 
+              rsn.args.map(_.toString()), 
+              mimir.api.Repair(rsn.repair.toJSON), 
+              rsn.repair.exampleString
+            )
+        }
+      )
+    )).getBytes )
   }
 }
 
@@ -237,12 +249,21 @@ case class ExplainEverythingRequest (
                   query: String
 ) extends Request {
   def handle(os:OutputStream) = {
-    os.write(Json.stringify(Json.toJson(ExplainResponse(MimirVizier.explainEverything(query).map(rsn => 
-      ReasonSet(rsn.model.name.toString, rsn.idx, rsn.argLookup match {
-        case Some((query, args, hints)) => "[" + args.mkString(", ") + "][" + hints.mkString(", ") + "] <- \n" + query.toString("   ")
-        case None => ""
-      })
-    )))).getBytes )
+    os.write(Json.stringify(Json.toJson(
+      ExplainResponse(
+        MimirVizier.explainEverything(query).map { 
+          rsn => 
+            ReasonSet(
+              rsn.model.name.toString, 
+              rsn.idx, 
+              rsn.argLookup match {
+                case Some((query, args, hints)) => "[" + args.mkString(", ") + "][" + hints.mkString(", ") + "] <- \n" + query.toString("   ")
+                case None => ""
+              }
+            )
+        }
+      )
+    )).getBytes )
   }
 }
 

--- a/src/main/scala/mimir/api/Request.scala
+++ b/src/main/scala/mimir/api/Request.scala
@@ -34,11 +34,13 @@ case class LoadRequest (
                   inferTypes: Boolean,
             /* detect headers in datasource */
                   detectHeaders: Boolean,
+            /* optionally provide a name */
+                  humanReadableName: Option[String],
             /* options for spark datasource api */
                   backendOption: Seq[Tuple]
 ) extends Request {
   def handle(os:OutputStream) = {
-    os.write(Json.stringify(Json.toJson(LoadResponse(MimirVizier.loadDataSource(file, format, inferTypes, detectHeaders, backendOption.map(tup => tup.name -> tup.value))))).getBytes )
+    os.write(Json.stringify(Json.toJson(LoadResponse(MimirVizier.loadDataSource(file, format, inferTypes, detectHeaders, humanReadableName, backendOption.map(tup => tup.name -> tup.value))))).getBytes )
   }
 }
 

--- a/src/main/scala/mimir/ctables/AnalyzeUncertainty.scala
+++ b/src/main/scala/mimir/ctables/AnalyzeUncertainty.scala
@@ -277,9 +277,10 @@ class AnalyzeUncertainty(db: Database) extends LazyLogging {
 				)
 			)
 
-			case DataWarning(name, value, message, key) => Map(name -> 
+			case DataWarning(name, value, message, key, idx) => Map(name -> 
 				new DataWarningReason(
 					db.models.get(name),
+					idx,
 					db.interpreter.eval(InlineVGTerms(value, db), tuple),
 					db.interpreter.eval(InlineVGTerms(value, db), tuple) match {
 						case NullPrimitive() => s"Error reading warning ($name(${key.mkString(",")}))"

--- a/src/main/scala/mimir/ctables/ExpressionDeterminism.scala
+++ b/src/main/scala/mimir/ctables/ExpressionDeterminism.scala
@@ -197,7 +197,7 @@ object ExpressionDeterminism {
           u match { 
             case VGTerm(name, idx, args, hints) => 
               Sampler(models(name), idx, args, hints, seed)
-            case DataWarning(_, v, _, _) => 
+            case DataWarning(_, v, _, _, _) => 
               v.recur(compileSample(_, seed, models))
           }
         case _ => expr

--- a/src/main/scala/mimir/ctables/InlineVGTerms.scala
+++ b/src/main/scala/mimir/ctables/InlineVGTerms.scala
@@ -36,7 +36,7 @@ object InlineVGTerms {
 				}
 			}
 
-			case DataWarning(_, v, _, _) => v.recur(inline(_, db))
+			case DataWarning(_, v, _, _, _) => v.recur(inline(_, db))
 
 			case _ => e.recur(inline(_, db))
 		}

--- a/src/main/scala/mimir/ctables/Reason.scala
+++ b/src/main/scala/mimir/ctables/Reason.scala
@@ -85,6 +85,7 @@ class ModelReason(
 
 class DataWarningReason(
   val model: Model,
+  val idx: Int,
   val value: PrimitiveValue,
   val message: String,
   val key: Seq[PrimitiveValue]
@@ -93,7 +94,6 @@ class DataWarningReason(
 {
   override def toString = s"$message {{ $model[${key.mkString(", ")}] }}"
 
-  def idx: Int = 0
   def args: Seq[PrimitiveValue] = key
   def hints: Seq[PrimitiveValue] = Seq()
 

--- a/src/main/scala/mimir/ctables/ReasonSet.scala
+++ b/src/main/scala/mimir/ctables/ReasonSet.scala
@@ -112,14 +112,14 @@ object ReasonSet
           (args, hints) => new ModelReason(model, idx, args, hints)
         )
       }
-      case DataWarning(name, valueExpr, messageExpr, keyExprs) => {
+      case DataWarning(name, valueExpr, messageExpr, keyExprs, idx) => {
         logger.debug(s"Make ReasonSet for Warning $name from\n$input")
         val model = db.models.get(name)
         return new ReasonSet(
           model,
-          0,
+          idx,
           Some(input, keyExprs, Seq(valueExpr, messageExpr)),
-          (keys, valueAndMessage) => new DataWarningReason(model, valueAndMessage(0), valueAndMessage(1).asString, keys)
+          (keys, valueAndMessage) => new DataWarningReason(model, idx, valueAndMessage(0), valueAndMessage(1).asString, keys)
         )
       }
 

--- a/src/main/scala/mimir/ctables/ReasonSet.scala
+++ b/src/main/scala/mimir/ctables/ReasonSet.scala
@@ -29,7 +29,8 @@ class ReasonSet(val model: Model, val idx: Int, val argLookup: Option[(Operator,
           query
             .map( argExprs.zipWithIndex.map { arg => ("ARG_"+arg._2 -> arg._1) }:_* )
             .distinct
-            .count( alias = "COUNT" )
+            .count( alias = "COUNT" ),
+          UnannotatedBestGuess
         ) { _.next.tuple(0).asLong }
       case None => 
         1
@@ -60,7 +61,9 @@ class ReasonSet(val model: Model, val idx: Int, val argLookup: Option[(Operator,
         val projectedQuery =
           Project(argCols ++ hintCols, limitedQuery)
 
-        db.query(projectedQuery) { _.toIndexedSeq.map { _.tuple.splitAt(argExprs.size) } }
+        db.query(projectedQuery, UnannotatedBestGuess) { 
+          _.toIndexedSeq.map { _.tuple.splitAt(argExprs.size) } 
+        }
       }
     }
   }

--- a/src/main/scala/mimir/ctables/ReasonSet.scala
+++ b/src/main/scala/mimir/ctables/ReasonSet.scala
@@ -113,7 +113,7 @@ object ReasonSet
         )
       }
       case DataWarning(name, valueExpr, messageExpr, keyExprs, idx) => {
-        logger.debug(s"Make ReasonSet for Warning $name from\n$input")
+        logger.debug(s"Make ReasonSet for Warning $name:$idx from\n$input")
         val model = db.models.get(name)
         return new ReasonSet(
           model,

--- a/src/main/scala/mimir/exec/mode/UnannotatedBestGuess.scala
+++ b/src/main/scala/mimir/exec/mode/UnannotatedBestGuess.scala
@@ -5,6 +5,7 @@ import mimir.Database
 import mimir.algebra._
 import mimir.exec._
 import mimir.exec.result._
+import mimir.provenance._
 
 object UnannotatedBestGuess
   extends CompileMode[ResultIterator]
@@ -15,11 +16,42 @@ object UnannotatedBestGuess
   /**
    * Rewrite the specified operator
    */
-  def rewrite(db: Database, oper: Operator): (Operator, Seq[ID], MetadataT) =
+  def rewrite(db: Database, operRaw: Operator): (Operator, Seq[ID], MetadataT) =
   {
+    var oper = operRaw
+
+    // Force the typechecker to run
+    db.typechecker.schemaOf(oper)
+      
+    // The names that the provenance compilation step assigns will
+    // be different depending on the structure of the query.  As a 
+    // result it is **critical** that this be the first step in 
+    // compilation.  
+    val provenance = Provenance.compile(oper)
+
+    oper                       = provenance._1
+    val provenanceCols:Seq[ID] = provenance._2
+
+    logger.debug(s"WITH-PROVENANCE (${provenanceCols.mkString(", ")}): $oper")
+
+    oper = db.views.resolve(oper)
+
+    logger.debug(s"INLINED: $oper")
+
+    // Replace VG-Terms with their "Best Guess values"
+    oper = BestGuess.bestGuessQuery(db, oper)
+
+    logger.debug(s"GUESSED: $oper")
+
+    // Clean things up a little... make the query prettier, tighter, and 
+    // faster
+    oper = db.compiler.optimize(oper)
+
+    logger.debug(s"OPTIMIZED: $oper")
+
     (
-      BestGuess.bestGuessQuery(db, oper),
-      oper.columnNames,
+      oper,
+      operRaw.columnNames,
       Seq()
     )
   }

--- a/src/main/scala/mimir/metadata/JDBCMetadataBackend.scala
+++ b/src/main/scala/mimir/metadata/JDBCMetadataBackend.scala
@@ -97,8 +97,9 @@ class JDBCMetadataBackend(val protocol: String, val filename: String)
 
   val ID_COLUMN = "MIMIR_ID"
 
-  def registerMap(category: ID, schema: Metadata.MapSchema): MetadataMap =
+  def registerMap(category: ID, migrations: Seq[MapMigration]): MetadataMap =
   {
+    val schema = Metadata.foldMapMigrations(migrations)
     // Assert that the backend schema lines up with the target
     // This should trigger a migration in the future, but at least 
     // inject a sanity check for now.
@@ -110,6 +111,29 @@ class JDBCMetadataBackend(val protocol: String, val filename: String)
         // SQLite-specific PRAGMA operation.
         SQLiteCompat.getTableSchema(conn, category) match {
           case Some(existing) => {
+
+            val existingMapCols = mutable.Set(existing.map(_._1):_*)
+            lazy val stmt = conn.createStatement()
+            var stmtNeedsClose = false
+            // Checking each migration individually is a bit cumbersome.
+            // it might be appropriate to create a "Schema versions" table
+            // to streamline the process
+            for(step <- migrations) {
+              step match {
+                case InitMap(schema) => 
+                case AddColumnToMap(column, t, default) => 
+                  existingMapCols.add(column)
+                  if( !(existingMapCols contains column) ){
+                    val addColumn = 
+                      s"ALTER TABLE ${category.quoted} ADD COLUMN ${column.quoted} ${Type.rootType(t)} DEFAULT ${default};"
+                    stmt.executeUpdate(addColumn)
+                    stmtNeedsClose = true
+                  }
+
+              }
+            }
+            if(stmtNeedsClose){ stmt.close() }
+
             try {
               assert(existing.length == schema.length+1)
               for(((_, e), (_, f)) <- existing.zip((ID(ID_COLUMN), TString()) +: schema)) {

--- a/src/main/scala/mimir/metadata/Metadata.scala
+++ b/src/main/scala/mimir/metadata/Metadata.scala
@@ -1,0 +1,18 @@
+package mimir.metadata
+
+import mimir.algebra.{ID, Type, PrimitiveValue}
+
+object Metadata
+{
+  type MapSchema = Seq[(ID, Type)]
+  type MapResource = (ID, Seq[PrimitiveValue])
+
+  def foldMapMigrations(migrations: Seq[MapMigration]): MapSchema = 
+  {
+    migrations.foldLeft(Seq[(ID, Type)]()) {
+      case (_, InitMap(schema)) => schema
+      case (prev, AddColumnToMap(column, t, _)) => prev :+ (column, t)
+    }
+  }
+}
+

--- a/src/main/scala/mimir/metadata/MetadataBackend.scala
+++ b/src/main/scala/mimir/metadata/MetadataBackend.scala
@@ -4,19 +4,16 @@ import java.sql._
 import mimir.Database
 import mimir.algebra._
 
-object Metadata
-{
-  type MapSchema = Seq[(ID, Type)]
-  type MapResource = (ID, Seq[PrimitiveValue])
-}
-
 abstract class MetadataBackend {
 
 
   def open(): Unit
   def close(): Unit
 
-  def registerMap(category: ID, schema: Metadata.MapSchema): MetadataMap
+  def registerMap(
+    category: ID, 
+    migrations: Seq[MapMigration]
+  ): MetadataMap
   def registerManyMany(category: ID): MetadataManyMany
 
   def keysForMap(category: ID): Seq[ID]

--- a/src/main/scala/mimir/metadata/Migrations.scala
+++ b/src/main/scala/mimir/metadata/Migrations.scala
@@ -1,0 +1,8 @@
+package mimir.metadata
+
+import mimir.algebra.{ID, Type, PrimitiveValue}
+
+sealed trait MapMigration
+
+case class InitMap(schema: Metadata.MapSchema) extends MapMigration
+case class AddColumnToMap(column: ID, t: Type, default: Option[PrimitiveValue]) extends MapMigration

--- a/src/main/scala/mimir/models/DetectHeaderModel.scala
+++ b/src/main/scala/mimir/models/DetectHeaderModel.scala
@@ -27,7 +27,7 @@ object DetectHeader {
 }
 
 @SerialVersionUID(1002L)
-class DetectHeaderModel(override val name: ID, val targetName: ID, val columns:Seq[ID], val trainingData:Seq[Seq[PrimitiveValue]])
+class DetectHeaderModel(override val name: ID, val descriptiveName: String, val columns:Seq[ID], val trainingData:Seq[Seq[PrimitiveValue]])
 extends Model(name)
 with Serializable
 with SourcedFeedback
@@ -134,11 +134,11 @@ with SourcedFeedback
   def reason(idx: Int, args: Seq[PrimitiveValue],hints: Seq[PrimitiveValue]): String = {
     getFeedback(idx, args) match {
       case Some(colName) => 
-        s"${getReasonWho(idx, args)} told me that $targetName.$colName is a valid column name for column number ${args(0)}"
+        s"${getReasonWho(idx, args)} told me that $descriptiveName.$colName is a valid column name for column number ${args(0)}"
       case None if headerDetected => 
-        s"I analyzed the first several rows of $targetName and there appear to be column headers in the first row.  For column with index: ${args(0)}, the detected header is ${initialHeaders(args(0).asInt)}"
+        s"I analyzed the first several rows of $descriptiveName and there appear to be column headers in the first row.  For column with index: ${args(0)}, the detected header is ${initialHeaders(args(0).asInt)}"
       case None =>
-        s"I analyzed the first several rows of $targetName and there do NOT appear to be column headers in the first row.  For the column with index: ${args(0)}, I used the default value of ${initialHeaders(args(0).asInt)}"
+        s"I analyzed the first several rows of $descriptiveName and there do NOT appear to be column headers in the first row.  For the column with index: ${args(0)}, I used the default value of ${initialHeaders(args(0).asInt)}"
     }
   }
   def feedback(idx: Int, args: Seq[PrimitiveValue], v: PrimitiveValue): Unit = {

--- a/src/main/scala/mimir/models/GeocodingModel.scala
+++ b/src/main/scala/mimir/models/GeocodingModel.scala
@@ -150,10 +150,10 @@ class GeocodingModel(override val name: ID, addrCols:Seq[Expression], geocoder:I
   }
   
   private def makeGeocodeRequest(args: Seq[PrimitiveValue]) : Option[String] = {
-    val houseNumber = args(1).asString
-    val streetName = args(2).asString
-    val city = args(3).asString
-    val state = args(4).asString
+    val houseNumber = args(1) match { case NullPrimitive() => "" ; case x => x.asString }
+    val streetName = args(2) match { case NullPrimitive() => "" ; case x => x.asString }
+    val city = args(3) match { case NullPrimitive() => "" ; case x => x.asString }
+    val state = args(4) match { case NullPrimitive() => "" ; case x => x.asString }
     val url = geocoder match {
       case ID("GOOGLE") => (s"https://maps.googleapis.com/maps/api/geocode/json?address=${s"$houseNumber+${streetName.replaceAll(" ", "+")},+${city.replaceAll(" ", "+")},+$state".replaceAll("\\+\\+", "+")}&key=$apiKey")
       case ID("OSM") | _ => (s"http://52.0.26.255/?format=json&street=$houseNumber%20$streetName&city=$city&state=$state")

--- a/src/main/scala/mimir/models/ModelManager.scala
+++ b/src/main/scala/mimir/models/ModelManager.scala
@@ -5,7 +5,7 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
 import mimir.Database
 import mimir.algebra._
 import mimir.util._
-import mimir.metadata.{MetadataMap, MetadataManyMany}
+import mimir.metadata._
 /**
  * The ModelManager handles model persistence.  
  *
@@ -37,10 +37,10 @@ class ModelManager(db:Database)
    */
   def init(): Unit =
   {
-    modelTable = db.metadata.registerMap(ID("MIMIR_MODELS"), Seq(
+    modelTable = db.metadata.registerMap(ID("MIMIR_MODELS"), Seq(InitMap(Seq(
       ID("ENCODED") -> TString(),
       ID("DECODER") -> TString()
-    ))
+    ))))
     ownerTable = db.metadata.registerManyMany(ID("MIMIR_MODEL_OWNERS"))
   }
 

--- a/src/main/scala/mimir/models/TypeInferenceModel.scala
+++ b/src/main/scala/mimir/models/TypeInferenceModel.scala
@@ -96,7 +96,7 @@ case class VoteList()
 
 
 @SerialVersionUID(1002L)
-class TypeInferenceModel(name: ID, val columns: IndexedSeq[ID], defaultFrac: Double, sparkSql:SQLContext, query:Option[DataFrame] )
+class TypeInferenceModel(name: ID, val descriptiveName: String, val columns: IndexedSeq[ID], defaultFrac: Double, sparkSql:SQLContext, query:Option[DataFrame] )
   extends Model(name)
   with SourcedFeedback
   with FiniteDiscreteDomain
@@ -182,11 +182,11 @@ class TypeInferenceModel(name: ID, val columns: IndexedSeq[ID], defaultFrac: Dou
             case _ => 
               s"around $guessPct% of the data fit"
           }
-        s"I guessed that $name.${columns(column)} was of type $typeStr because $reason"
+        s"I guessed that $descriptiveName.${columns(column)} was of type $typeStr because $reason"
       }
       case Some(t) =>
         val typeStr = Cast(TType(), t).toString.toUpperCase
-        s"${getReasonWho(column,args)} told me that $name.${columns(column)} was of type $typeStr"
+        s"${getReasonWho(column,args)} told me that $descriptiveName.${columns(column)} was of type $typeStr"
     }
   }
 
@@ -201,7 +201,8 @@ class TypeInferenceModel(name: ID, val columns: IndexedSeq[ID], defaultFrac: Dou
     if(v.isInstanceOf[TypePrimitive]){
       setFeedback(idx, args, v)
     } else {
-      throw new ModelException(s"Invalid choice for $name: $v")
+      val column = args(0).asInt
+      throw new ModelException(s"Invalid choice for a value in $descriptiveName.${columns(column)}: $v")
     }
   }
 

--- a/src/main/scala/mimir/parser/MimirSQL.scala
+++ b/src/main/scala/mimir/parser/MimirSQL.scala
@@ -124,7 +124,7 @@ object MimirSQL
       Sparsity.identifier ~
       "(" ~ ExprParser.expressionList ~ ")"
     ).map { case (name, query, lensType, args) =>
-      CreateAdaptiveSchema(name, query, lensType, args)
+      CreateAdaptiveSchema(name, query, lensType, args, name.toString)
     }
   )
   def createLens[_:P] = P(

--- a/src/main/scala/mimir/parser/MimirStatement.scala
+++ b/src/main/scala/mimir/parser/MimirStatement.scala
@@ -31,7 +31,8 @@ case class CreateAdaptiveSchema(
   name: Name,
   body: SelectBody,
   schemaType: Name,
-  args: Seq[Expression]
+  args: Seq[Expression],
+  humanReadableName: String
 ) extends MimirStatement
 
 case class CreateLens(

--- a/src/main/scala/mimir/serialization/Json.scala
+++ b/src/main/scala/mimir/serialization/Json.scala
@@ -340,13 +340,14 @@ object Json
           "hints" -> ofExpressionList(hints)
         ))
 
-      case DataWarning(name, v, message, key) =>
+      case DataWarning(name, v, message, key, idx) =>
         JsObject(Map[String, JsValue](
           "type" -> JsString("data_warning"),
           "name" -> JsString(name.id),
           "value" -> ofExpression(v),
           "message" -> ofExpression(message),
-          "key" -> ofExpressionList(key)
+          "key" -> ofExpressionList(key),
+          "idx" -> JsNumber(idx)
         ))
 
       case CastExpression(expr, t) =>
@@ -424,7 +425,10 @@ object Json
           ID(fields("name").asInstanceOf[JsString].value),
           toExpression(fields("value")),
           toExpression(fields("message")),
-          toExpressionList(fields("key"))
+          toExpressionList(fields("key")),
+          fields.get("idx")
+                .map { _.asInstanceOf[JsNumber].value.toLong.toInt }
+                .getOrElse(0)
         )
 
       // fall back to treating it as a primitive type

--- a/src/main/scala/mimir/sql/SqlToRA.scala
+++ b/src/main/scala/mimir/sql/SqlToRA.scala
@@ -328,7 +328,7 @@ class SqlToRA(db: Database)
                 case Column(name, None) => 
                   ( tableForColumn.get(name) match {
                       case Some(t) => t
-                      case None => throw new SQLException("Invalid group-by column $name")
+                      case None => throw new SQLException(s"Invalid group-by column $name")
                     },
                     name
                   )

--- a/src/main/scala/mimir/views/ViewManager.scala
+++ b/src/main/scala/mimir/views/ViewManager.scala
@@ -11,7 +11,7 @@ import mimir.exec._
 import mimir.exec.mode._
 import mimir.serialization._
 import com.typesafe.scalalogging.slf4j.LazyLogging
-import mimir.metadata.MetadataMap
+import mimir.metadata._
 
 
 class ViewManager(db:Database) extends LazyLogging {
@@ -24,11 +24,11 @@ class ViewManager(db:Database) extends LazyLogging {
    */
   def init(): Unit = 
   {
-    viewTable = db.metadata.registerMap(ID("MIMIR_VIEWS"), Seq(
+    viewTable = db.metadata.registerMap(ID("MIMIR_VIEWS"), Seq(InitMap(Seq(
         ID("QUERY") -> TString(),
         ID("METADATA") -> TInt()
       )
-    )
+    )))
   }
 
   /**


### PR DESCRIPTION
ReasonSet source queries have already had a determinism annotation pass --- the query basically returns the set of inputs where a determinism annotation is true. The expression-level determinism annotation pass in particular creates these gnarly disjunctions on some inputs.  When expanding a ReasonSet, queries were previously being run in (the default) BestGuess mode, which meant that the gnarly disjunctions were being fed through a second round of determinism annotation (i.e., is the determinism annotation non-deterministic?), which made them even gnarlier, or worse would sit there consuming memory and CPU for a disturbingly long time.

Basic solution: ReasonSet now runs any and all queries that it needs to run in UnannotatedBestGuess mode (which skips the determinism annotation pass).

This triggered a bug in UnannotatedBestGuess, which wasn't properly doing RowId annotations, or a few other important steps in the compilation process.  Those are fixed now too.

Overall, seems to be at least an OOM performance improvement on some queries.