### PR TITLE
Vizier rowids

### DIFF
--- a/src/main/scala/mimir/Mimir.scala
+++ b/src/main/scala/mimir/Mimir.scala
@@ -488,7 +488,10 @@ class MimirConfig(arguments: Seq[String]) extends ScallopConf(arguments)
     opt[String]("db", descr = "Connect to the database with the specified name",
     default = Some(dataDirectory() + "/mimir.db"))
   }
-
+  def sparkJars : ScallopOption[String] = { 
+    opt[String]("sparkJars", descr = "Folder with additional jars for spark to load",
+    default = Some(dataDirectory() + "/sparkJars"))
+  }
 }
 
 class SlashCommandDefinition(

--- a/src/main/scala/mimir/adaptive/CheckHeader.scala
+++ b/src/main/scala/mimir/adaptive/CheckHeader.scala
@@ -80,7 +80,14 @@ object CheckHeader
       // If we have a header... 
       if(model.headerDetected) { 
         // Strip off row #1 
-        oper = oper.filter { RowIdVar().neq(RowIdPrimitive("1")) } 
+        val firstRowID = db.query(oper.limit(1))(res => { 
+          val resList = res.toList
+          if(resList.isEmpty)
+            RowIdPrimitive("0")
+          else
+            resList.head.provenance
+        })
+        oper = oper.filter { RowIdVar().neq(firstRowID) } 
         
         // And then rename columns accordingly
         oper = oper.renameByID(

--- a/src/main/scala/mimir/api/MimirAPI.scala
+++ b/src/main/scala/mimir/api/MimirAPI.scala
@@ -142,32 +142,38 @@ class MimirVizierServlet() extends HttpServlet with LazyLogging {
             } catch {
               case e: EOFException => 
                 os.write(Json.stringify(Json.toJson(
-                    ErrorResponse(e.getClass.getCanonicalName(),e.getMessage()))).getBytes)
+                    ErrorResponse(e.getClass.getCanonicalName(),e.getMessage(), 
+                        e.getStackTrace.map(_.toString).mkString("\n")))).getBytes)
       
               case e: FileNotFoundException =>
                 os.write(Json.stringify(Json.toJson(
-                    ErrorResponse(e.getClass.getCanonicalName(),e.getMessage()))).getBytes)
+                    ErrorResponse(e.getClass.getCanonicalName(),e.getMessage(), 
+                        e.getStackTrace.map(_.toString).mkString("\n")))).getBytes)
       
               case e: SQLException =>
                 os.write(Json.stringify(Json.toJson(
-                    ErrorResponse(e.getClass.getCanonicalName(),e.getMessage()))).getBytes)
+                    ErrorResponse(e.getClass.getCanonicalName(),e.getMessage(), 
+                        e.getStackTrace.map(_.toString).mkString("\n")))).getBytes)
                 logger.debug(e.getMessage + "\n" + e.getStackTrace.map(_.toString).mkString("\n"))
       
               case e: RAException =>
                 os.write(Json.stringify(Json.toJson(
-                    ErrorResponse(e.getClass.getCanonicalName(),e.getMessage()))).getBytes)
+                    ErrorResponse(e.getClass.getCanonicalName(),e.getMessage(), 
+                        e.getStackTrace.map(_.toString).mkString("\n")))).getBytes)
                 logger.debug(e.getMessage + "\n" + e.getStackTrace.map(_.toString).mkString("\n"))
       
               case e: Throwable => {
                 os.write(Json.stringify(Json.toJson(
-                    ErrorResponse(e.getClass.getCanonicalName(),"An unknown error occurred..."))).getBytes)
+                    ErrorResponse(e.getClass.getCanonicalName(),"An unknown error occurred...", 
+                        e.getStackTrace.map(_.toString).mkString("\n")))).getBytes)
                 logger.error("MimirAPI POST ERROR: ", e)
               }
             }  
           }
           case _ => {
             os.write(Json.stringify(Json.toJson(
-                    ErrorResponse("MimirAPI POST Not Handled","Unknown Request:"+ req.getPathInfo))).getBytes)
+                    ErrorResponse("MimirAPI POST Not Handled","Unknown Request:"+ req.getPathInfo, 
+                        Thread.currentThread().getStackTrace.map(_.toString).mkString("\n") ))).getBytes)
             logger.error(s"MimirAPI POST Not Handled: ${req.getPathInfo}")
           }
         } 

--- a/src/main/scala/mimir/api/Response.scala
+++ b/src/main/scala/mimir/api/Response.scala
@@ -12,6 +12,17 @@ object Response {
   
 }
 
+case class ErrorResponse (
+            /* throwable class name */
+                  errorType: String,
+            /* throwable message */
+                  errorMessage: String
+) extends Response
+
+object ErrorResponse {
+  implicit val format: Format[ErrorResponse] = Json.format
+}
+
 case class ScalaEvalResponse (
             /* stdout from evaluation of scala code */
                   stdout: String,

--- a/src/main/scala/mimir/api/Response.scala
+++ b/src/main/scala/mimir/api/Response.scala
@@ -16,7 +16,9 @@ case class ErrorResponse (
             /* throwable class name */
                   errorType: String,
             /* throwable message */
-                  errorMessage: String
+                  errorMessage: String,
+            /* throwable stack trace */
+                  stackTrace: String
 ) extends Response
 
 object ErrorResponse {

--- a/src/main/scala/mimir/data/LoadedTables.scala
+++ b/src/main/scala/mimir/data/LoadedTables.scala
@@ -9,7 +9,7 @@ import org.apache.spark.sql.DataFrame
 import mimir.Database
 import mimir.algebra._
 import mimir.metadata._
-import mimir.exec.spark.{MimirSpark,RAToSpark,RowIndexPlan}
+import mimir.exec.spark.{MimirSpark,RAToSpark}
 
 // https://spark.apache.org/docs/latest/sql-data-sources-load-save-functions.html#run-sql-on-files-directly
 

--- a/src/main/scala/mimir/util/FileUtils.scala
+++ b/src/main/scala/mimir/util/FileUtils.scala
@@ -1,0 +1,28 @@
+package mimir.util
+
+import java.io.File
+import java.lang.reflect.Method
+import java.net.URL
+
+
+object FileUtils {
+  def getListOfFiles(dir: String):List[File] = {
+    val d = new File(dir)
+    if (d.exists && d.isDirectory) {
+        d.listFiles.filter(_.isFile).toList
+    } else {
+        List[File]()
+    }
+  }
+  def addJarToClasspath(jar: File): Unit = {
+// Get the ClassLoader class
+    val cl: ClassLoader = ClassLoader.getSystemClassLoader
+    val clazz: Class[_] = cl.getClass
+// Get the protected addURL method from the parent URLClassLoader class
+    val method: Method =
+      clazz.getSuperclass.getDeclaredMethod("addURL", Seq(classOf[URL]):_*)
+// Run projected addURL method to add JAR to classpath
+    method.setAccessible(true)
+    method.invoke(cl, Seq(jar.toURI().toURL()):_*)
+  }
+}

--- a/src/test/scala/mimir/algebra/spark/OperatorTranslationSpec.scala
+++ b/src/test/scala/mimir/algebra/spark/OperatorTranslationSpec.scala
@@ -37,16 +37,16 @@ object OperatorTranslationSpec
         db.table("R")
           .addColumns( "ROWID" -> RowIdVar() )
           .project("ROWID")
-        )(_.toList.map(_.tuple))
+        )(_.toList.map(_.tuple.toList))
       
       result must be equalTo List(
-       List(RowIdPrimitive("1")), 
-       List(RowIdPrimitive("2")), 
-       List(RowIdPrimitive("3")), 
-       List(RowIdPrimitive("4")), 
-       List(RowIdPrimitive("5")), 
-       List(RowIdPrimitive("6")),
-       List(RowIdPrimitive("7"))
+        List(RowIdPrimitive("1661579272")),
+        List(RowIdPrimitive("2133525038")),
+        List(RowIdPrimitive("2066842439")),
+        List(RowIdPrimitive("586364262")),
+        List(RowIdPrimitive("1386748855")),
+        List(RowIdPrimitive("109250532")),
+        List(RowIdPrimitive("420079580"))
       )
     }
     

--- a/src/test/scala/mimir/algebra/spark/SparkDataSourcesSpec.scala
+++ b/src/test/scala/mimir/algebra/spark/SparkDataSourcesSpec.scala
@@ -312,6 +312,58 @@ object SparkDataSourcesSpec
     }
     
     
+    /*"For jdbc data sources" should {
+        "Be able to query from a mysql source" >> {
+        db.loader.loadTable(
+           sourceFile = "jdbc:mysql://mysql-rfam-public.ebi.ac.uk:4497/Rfam",
+           targetTable = Some(ID("M")), 
+           inferTypes = Some(true), 
+           detectHeaders = Some(true), 
+           format = ID("jdbc"),
+           sparkOptions = Map("url" -> "jdbc:mysql://mysql-rfam-public.ebi.ac.uk:4497/Rfam", 
+            "driver" -> "com.mysql.jdbc.Driver", 
+            "dbtable" -> "family", 
+            "user" -> "rfamro", 
+            "password" -> ""))
+            
+        val result = query("""
+          SELECT * FROM M
+        """)(_.toList.map(_.tuple.toList)).toList
+        
+        result.length must be equalTo 3016
+        
+        update("""
+  				CREATE LENS MV_M
+  				  AS SELECT * FROM M
+  				  WITH MISSING_VALUE('TYPE')
+   			""")
+   			val querymv = db.table("MV_M")
+        val resultmv = db.query(querymv)(_.toList.map(_.tuple.toList)).toList
+        
+        resultmv.length must be equalTo 3016
+      }
+      
+      "Be able to query from a postgres source" >> {
+        LoadJDBC.handleLoadTableRaw(db, "P", 
+          Map("url" -> "jdbc:postgresql://128.205.71.102:5432/mimirdb", 
+            "driver" -> "org.postgresql.Driver", 
+            "dbtable" -> "mimir_spark", 
+            "user" -> "mimir", 
+            "password" -> "mimir01"))
+            
+        val result = query("""
+          SELECT * FROM P
+        """)(_.toList.map(_.tuple.toList)).toList
+        
+        result must be equalTo List(
+            List(i(1), NullPrimitive(), i(100)), 
+            List(i(2), i(4), i(104)), 
+            List(i(3), i(4), i(118)), 
+            List(i(4), i(5), NullPrimitive()), 
+         List(i(5), i(4), i(50)))
+      }
+    }*/
+    
     
   }
 }

--- a/src/test/scala/mimir/algebra/spark/SparkMimirCSVDataSourceSpec.scala
+++ b/src/test/scala/mimir/algebra/spark/SparkMimirCSVDataSourceSpec.scala
@@ -104,22 +104,22 @@ object SparkMimirCSVDataSourceSpec
           val results = resultSets.flatMap(_.all(db)).map { _.toString }
           
           results must contain(
-            "The value [ NULL ] is uncertain because there is an error(s) in the data source on row 4 of corrupt. The raw value of the row in the data source is [ ------- ] {{ MIMIR_DSE_WARNING_corrupt_DSE['4', '_c1', NULL, '-------'] }}"
-          )
-          results must contain(
-            "The value [ NULL ] is uncertain because there is an error(s) in the data source on row 4 of corrupt. The raw value of the row in the data source is [ ------- ] {{ MIMIR_DSE_WARNING_corrupt_DSE['4', '_c2', NULL, '-------'] }}"
+            "The value [ NULL ] is uncertain because there is an error(s) in the data source on row -735214268 of corrupt. The raw value of the row in the data source is [ ------- ] {{ MIMIR_DSE_WARNING_corrupt_DSE['-735214268', '_c1', NULL, '-------'] }}"
             )
           results must contain(
-              "The value [ klj8 ] is uncertain because there is an error(s) in the data source on row 6 of corrupt. The raw value of the row in the data source is [ 2,klj8,lmlkjh8,jij9,1 ] {{ MIMIR_DSE_WARNING_corrupt_DSE['6', '_c1', 'klj8', '2,klj8,lmlkjh8,jij9,1'] }}"
+            "The value [ NULL ] is uncertain because there is an error(s) in the data source on row -735214268 of corrupt. The raw value of the row in the data source is [ ------- ] {{ MIMIR_DSE_WARNING_corrupt_DSE['-735214268', '_c2', NULL, '-------'] }}"
             )
           results must contain(
-            "The value [ ------- ] is uncertain because there is an error(s) in the data source on row 4 of corrupt. The raw value of the row in the data source is [ ------- ] {{ MIMIR_DSE_WARNING_corrupt_DSE['4', '_c0', '-------', '-------'] }}"
+            "The value [ klj8 ] is uncertain because there is an error(s) in the data source on row 1268020403 of corrupt. The raw value of the row in the data source is [ 2,klj8,lmlkjh8,jij9,1 ] {{ MIMIR_DSE_WARNING_corrupt_DSE['1268020403', '_c1', 'klj8', '2,klj8,lmlkjh8,jij9,1'] }}"
             )
           results must contain(
-              "The value [ lmlkjh8 ] is uncertain because there is an error(s) in the data source on row 6 of corrupt. The raw value of the row in the data source is [ 2,klj8,lmlkjh8,jij9,1 ] {{ MIMIR_DSE_WARNING_corrupt_DSE['6', '_c2', 'lmlkjh8', '2,klj8,lmlkjh8,jij9,1'] }}"
+            "The value [ ------- ] is uncertain because there is an error(s) in the data source on row -735214268 of corrupt. The raw value of the row in the data source is [ ------- ] {{ MIMIR_DSE_WARNING_corrupt_DSE['-735214268', '_c0', '-------', '-------'] }}"
             )
           results must contain(
-              "The value [ 2 ] is uncertain because there is an error(s) in the data source on row 6 of corrupt. The raw value of the row in the data source is [ 2,klj8,lmlkjh8,jij9,1 ] {{ MIMIR_DSE_WARNING_corrupt_DSE['6', '_c0', '2', '2,klj8,lmlkjh8,jij9,1'] }}"
+            "The value [ lmlkjh8 ] is uncertain because there is an error(s) in the data source on row 1268020403 of corrupt. The raw value of the row in the data source is [ 2,klj8,lmlkjh8,jij9,1 ] {{ MIMIR_DSE_WARNING_corrupt_DSE['1268020403', '_c2', 'lmlkjh8', '2,klj8,lmlkjh8,jij9,1'] }}"
+            )
+          results must contain(
+              "The value [ 2 ] is uncertain because there is an error(s) in the data source on row 1268020403 of corrupt. The raw value of the row in the data source is [ 2,klj8,lmlkjh8,jij9,1 ] {{ MIMIR_DSE_WARNING_corrupt_DSE['1268020403', '_c0', '2', '2,klj8,lmlkjh8,jij9,1'] }}"
             )
         }
     }

--- a/src/test/scala/mimir/backend/SparkBackendSpec.scala
+++ b/src/test/scala/mimir/backend/SparkBackendSpec.scala
@@ -45,8 +45,8 @@ object SparkBackendSpec
 				//"mimir.backend.SparkBackend"
 			){
         val rids = query("Select C.* FROM C;")(_.toList).map(row => (row.provenance.asLong, row(1).toString))
-        rids.head must be equalTo (2, "'All Other Causes'")
-        rids.last must be equalTo (1381, "'All Other Causes'")
+        rids.head must be equalTo (-1929017717, "'All Other Causes'")
+        rids.last must be equalTo (-196590230, "'All Other Causes'")
       }
     }
     
@@ -74,8 +74,8 @@ object SparkBackendSpec
       idxs.last must be equalTo (70715, "null")
       
       val rids = query("Select * FROM D;")(_.toList).map(row => (row.provenance.asLong, row(1).toString)).drop(1)
-      rids.head must be equalTo (2, "748365939771641856")
-      rids.last must be equalTo (70715, "NULL")
+      rids.head must be equalTo (774558468, "748365939771641856")
+      rids.last must be equalTo (551929072, "NULL")
     }
     
     "Be able to zipWithIndex and RowIndexPlan on single-partition datasets" >> {
@@ -102,8 +102,8 @@ object SparkBackendSpec
       idxs.last must be equalTo (5,"5")
       
       val rids = query("select * from P;")(_.toList).map(row => (row.provenance.asLong, row(0).toString))
-      rids.head must be equalTo (2, "1")
-      rids.last must be equalTo (5,"5")
+      rids.head must be equalTo (-706855295, "1")
+      rids.last must be equalTo (-1708392797,"5")
     }
     
     "Be able to use spark sql functions" >> {

--- a/src/test/scala/mimir/ctables/CTExplainerSpec.scala
+++ b/src/test/scala/mimir/ctables/CTExplainerSpec.scala
@@ -48,8 +48,8 @@ object CTExplainerSpec
         set => (set.model.name.id -> set.allArgs(db).map(_._1.toList).toList)
       }.toMap 
       explanations must contain(eachOf(
-        ("MV:SPARKML:B" -> List(List[PrimitiveValue](RowIdPrimitive("3")))),
-        ("MV:SPARKML:C" -> List(List[PrimitiveValue](RowIdPrimitive("4")))),
+        ("MV:SPARKML:B" -> List(List[PrimitiveValue](RowIdPrimitive("2066842439")))),
+        ("MV:SPARKML:C" -> List(List[PrimitiveValue](RowIdPrimitive("586364262")))),
         ("MIMIR_TI_ATTR_R_TI" -> List(0, 1, 2).map { i => List(IntPrimitive(i)) })
       ))
     }
@@ -58,7 +58,7 @@ object CTExplainerSpec
       val reasons = 
         explainCell("""
           SELECT * FROM MV
-        """, "3", "B"
+        """, "2066842439", "B"
         ).reasons.map(_.reason).mkString("\n")
       reasons must contain("I used a classifier to fix MV.B")
     }
@@ -68,7 +68,7 @@ object CTExplainerSpec
         explainRow("""
           SELECT * FROM MV
           WHERE C > 1
-        """, "4"
+        """, "586364262"
         ).reasons.map(_.reason).mkString("\n")
       reasons must contain("I used a classifier to fix MV.C")
 

--- a/src/test/scala/mimir/demo/SimpleDemoScript.scala
+++ b/src/test/scala/mimir/demo/SimpleDemoScript.scala
@@ -192,19 +192,19 @@ object SimpleDemoScript
 		"Obtain Cell Explanations for Simple Queries" >> {
 		  val expl1 = explainCell("""
 					SELECT * FROM RATINGS1FINAL
-				""", "3", "RATING")
+				""", "-1083566332", "RATING")
 			expl1.toString must contain("I used a classifier to fix RATINGS1FINAL.RATING")		
 		}
 		"Obtain Cell Explanations for Queries with WHERE clauses" >> {
 			val expl1 = explainCell("""
 					SELECT * FROM RATINGS1FINAL WHERE RATING > 0
-				""", "3", "RATING")
+				""", "-1083566332", "RATING")
 			expl1.toString must contain("I used a classifier to fix RATINGS1FINAL.RATING")		
 		}
 		"Guard Data-Dependent Explanations for Simple Queries" >> {
 			val expl2 = explainCell("""
 					SELECT * FROM RATINGS1FINAL
-				""", "2", "RATING")
+				""", "1839481200", "RATING")
 			expl2.toString must not contain("I used a classifier to fix RATINGS1FINAL.RATING")		
 		}
 
@@ -292,12 +292,12 @@ object SimpleDemoScript
 				WHERE r.pid = p.id;
 			"""){ 
 				_.toSeq.map { _.provenance.asString } must contain(
-					"4|1|6",
-					"3|1|5",
-					"3|0|4",
-					"2|1|3",
-					"4|0|2",
-					"2|0|1"
+					"1839481200|0|-773368559",
+					"-1716389153|0|781141538",
+					"-1083566332|0|-2092512653",
+					"1979409512|1|526127760",
+					"-500087735|1|824872164",
+					"710149138|1|-1629199915" 
 				)
 			}
 			

--- a/src/test/scala/mimir/models/SeriesMissingValueModelSpec.scala
+++ b/src/test/scala/mimir/models/SeriesMissingValueModelSpec.scala
@@ -10,22 +10,29 @@ object SeriesMissingValueModelSpec extends SQLTestSpecification("SeriesTest")
   sequential
 
   var models = Map[ID,(Model,Int,Seq[Expression])]()
-
+  val rowidMap = 
+    Map("-737200991"->"384450702",
+        "1538020126"->"-1330496373",
+        "196110172"->"1034334144",
+        "1067514362"->"59129355")
+        
   def predict(col:ID, row:String): PrimitiveValue = {
     val (model, idx, hints) = models(col)
-    model.bestGuess(idx, List(RowIdPrimitive(row)), List())
+    model.bestGuess(idx, List(RowIdPrimitive(rowidMap(row))), List())
   }
   def explain(col:ID, row:String): String = {
     val (model, idx, hints) = models(col)
-    model.reason(idx, List(RowIdPrimitive(row)), List())
+    model.reason(idx, List(RowIdPrimitive(rowidMap(row))), List())
   }
 
   def trueValue(col:ID, row:String): PrimitiveValue = {
-	  val queryOper = select(s"SELECT $col FROM ORG_DETECTSERIESTEST3 WHERE ROWID=$row")
+	  val queryOper = select(s"SELECT $col FROM ORG_DETECTSERIESTEST3 WHERE ROWID=${rowidMap(row)}")
   	db.query(queryOper){ result =>
   		result.next.tuple(0)
   	}
   }
+  
+  
 
   "The SeriesMissingValue Model" should {
 
@@ -63,7 +70,6 @@ object SeriesMissingValueModelSpec extends SQLTestSpecification("SeriesTest")
     				//println(s"${rowid.asString}->$a,$b")
     				( (rowid -> a), (rowid -> b) )
   			  }.unzip
-			
   			predicted.toMap must be equalTo(correct.toMap)
       }
 		   }

--- a/src/test/scala/mimir/models/SeriesMissingValueModelSpec.scala
+++ b/src/test/scala/mimir/models/SeriesMissingValueModelSpec.scala
@@ -10,23 +10,34 @@ object SeriesMissingValueModelSpec extends SQLTestSpecification("SeriesTest")
   sequential
 
   var models = Map[ID,(Model,Int,Seq[Expression])]()
+  //now that we are using hash + position for rowid
+  //we need to map rowids from DETECTSERIESTEST3
+  //to ORG_DETECTSERIESTEST3 instead of assuming 
+  //positional equivalent rows based on rowid
   val rowidMap = 
-    Map("-737200991"->"384450702",
-        "1538020126"->"-1330496373",
-        "196110172"->"1034334144",
-        "1067514362"->"59129355")
+    Map("-737200991"->"'384450702'",
+        "1538020126"->"'-1330496373'",
+        "196110172"->"'1034334144'",
+        "1067514362"->"'59129355'")
+  //one could also use the following map and use 
+  //the ROWID column of ORG_DETECTSERIESTEST3
+  //in the where clause in trueValue below
+  /*Map("-737200991"->"4",
+        "1538020126"->"14",
+        "196110172"->"8",
+        "1067514362"->"24") */     
         
   def predict(col:ID, row:String): PrimitiveValue = {
     val (model, idx, hints) = models(col)
-    model.bestGuess(idx, List(RowIdPrimitive(rowidMap(row))), List())
+    model.bestGuess(idx, List(RowIdPrimitive(row)), List())
   }
   def explain(col:ID, row:String): String = {
     val (model, idx, hints) = models(col)
-    model.reason(idx, List(RowIdPrimitive(rowidMap(row))), List())
+    model.reason(idx, List(RowIdPrimitive(row)), List())
   }
 
   def trueValue(col:ID, row:String): PrimitiveValue = {
-	  val queryOper = select(s"SELECT $col FROM ORG_DETECTSERIESTEST3 WHERE ROWID=${rowidMap(row)}")
+	  val queryOper = select(s"SELECT $col FROM ORG_DETECTSERIESTEST3 WHERE ROWID()=${rowidMap(row)}")
   	db.query(queryOper){ result =>
   		result.next.tuple(0)
   	}
@@ -78,7 +89,7 @@ object SeriesMissingValueModelSpec extends SQLTestSpecification("SeriesTest")
     "Produce reasonable explanations" >> {
 
       // explain("AGE", "1") must contain("I'm not able to guess based on weighted mean SERIESREPAIR:AGE.AGE, so defaulting using the upper and lower bound values")
-      explain(ID("AGE"), "4") must contain("I interpolated MyTestCaseDataset.AGE, ordered by MyTestCaseDataset.DOB to get 23 for row '4'")
+      explain(ID("AGE"), "-737200991") must contain("I interpolated MyTestCaseDataset.AGE, ordered by MyTestCaseDataset.DOB to get 23 for row '-737200991'")
     }
   }
 }	

--- a/src/test/scala/mimir/statistics/DatasetShapeSpec.scala
+++ b/src/test/scala/mimir/statistics/DatasetShapeSpec.scala
@@ -59,14 +59,16 @@ object DatasetShapeSpec
         ) {
           db.uncertainty.explainEverything(db.table("Z_BAD_S"))
         }
+      
       resultSets.map(_.all(db).map(_.toJSON)).flatten must contain(eachOf(
           """{"rowidarg":-1,"source":"MIMIR_SHAPE_Z","confirmed":false,"varid":0,"english":"Missing expected column 'B'","repair":{"selector":"warning"},"args":[0,"'Missing expected column 'B''"]}""",
           """{"rowidarg":-1,"source":"MIMIR_SHAPE_Z","confirmed":false,"varid":0,"english":"A had no nulls before, but now has 2","repair":{"selector":"warning"},"args":[3,"'A had no nulls before, but now has 2'"]}""",
           """{"rowidarg":-1,"source":"MIMIR_SHAPE_Z","confirmed":false,"varid":0,"english":"Unexpected column 'B_0'","repair":{"selector":"warning"},"args":[0,"'Unexpected column 'B_0''"]}""",
-          """{"rowidarg":0,"source":"MIMIR_DSE_WARNING_Z_BAD_DSE","confirmed":false,"varid":0,"english":"The value [ NULL ] is uncertain because there is an error(s) in the data source on row 5 of Z_BAD. The raw value of the row in the data source is [ ,,, ]","repair":{"selector":"warning"},"args":["'5'","'_c0'","NULL","',,,'"]}""",
-          """{"rowidarg":0,"source":"MIMIR_DSE_WARNING_Z_BAD_DSE","confirmed":false,"varid":0,"english":"The value [ NULL ] is uncertain because there is an error(s) in the data source on row 5 of Z_BAD. The raw value of the row in the data source is [ ,,, ]","repair":{"selector":"warning"},"args":["'5'","'_c1'","NULL","',,,'"]}""",
-          """{"rowidarg":0,"source":"MIMIR_DSE_WARNING_Z_BAD_DSE","confirmed":false,"varid":0,"english":"The value [ NULL ] is uncertain because there is an error(s) in the data source on row 6 of Z_BAD. The raw value of the row in the data source is [ ---- ]","repair":{"selector":"warning"},"args":["'6'","'_c1'","NULL","'----'"]}""",
-          """{"rowidarg":0,"source":"MIMIR_DSE_WARNING_Z_BAD_DSE","confirmed":false,"varid":0,"english":"The value [ ---- ] is uncertain because there is an error(s) in the data source on row 6 of Z_BAD. The raw value of the row in the data source is [ ---- ]","repair":{"selector":"warning"},"args":["'6'","'_c0'","'----'","'----'"]}"""))
+          """{"rowidarg":0,"source":"MIMIR_DSE_WARNING_Z_BAD_DSE","confirmed":false,"varid":0,"english":"The value [ NULL ] is uncertain because there is an error(s) in the data source on row 911701464 of Z_BAD. The raw value of the row in the data source is [ ,,, ]","repair":{"selector":"warning"},"args":["'911701464'","'_c0'","NULL","',,,'"]}""",
+          """{"rowidarg":0,"source":"MIMIR_DSE_WARNING_Z_BAD_DSE","confirmed":false,"varid":0,"english":"The value [ ---- ] is uncertain because there is an error(s) in the data source on row -2127400930 of Z_BAD. The raw value of the row in the data source is [ ---- ]","repair":{"selector":"warning"},"args":["'-2127400930'","'_c0'","'----'","'----'"]}""",
+          """{"rowidarg":0,"source":"MIMIR_DSE_WARNING_Z_BAD_DSE","confirmed":false,"varid":0,"english":"The value [ NULL ] is uncertain because there is an error(s) in the data source on row 911701464 of Z_BAD. The raw value of the row in the data source is [ ,,, ]","repair":{"selector":"warning"},"args":["'911701464'","'_c1'","NULL","',,,'"]}""",
+          """{"rowidarg":0,"source":"MIMIR_DSE_WARNING_Z_BAD_DSE","confirmed":false,"varid":0,"english":"The value [ NULL ] is uncertain because there is an error(s) in the data source on row -2127400930 of Z_BAD. The raw value of the row in the data source is [ ---- ]","repair":{"selector":"warning"},"args":["'-2127400930'","'_c1'","NULL","'----'"]}"""
+          ))
       
       val result = query("""
         SELECT * FROM Z_BAD_S


### PR DESCRIPTION
There are two reasonably significant changes in this pr:
  - Error messages are now explicitly returned through the mimir web api as an ErrorResponse
      - there are corresponding changes in the web-api that handle ErrorResponse and the web-ui now shown nicer error messages
  - The way ROWIDs are generated in mimir has changed from using a positional-only approach (1-row count of natural order) to a positional + hash approach (take a hash of the row and add it to the position of the row)
      - This will allow vizier spreadsheet operations to fail in a less bad way when new/changed data is reloaded into a workflow with visual-operation cells.